### PR TITLE
chore(components): introduce @HostListener

### DIFF
--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -1,23 +1,22 @@
 import settings from 'carbon-components/es/globals/js/settings';
-import on from 'carbon-components/es/globals/js/misc/on';
 import classnames from 'classnames';
 import { html, property, customElement, LitElement } from 'lit-element';
+import HostListener from '../../globals/decorators/HostListener';
+import HostListenerMixin from '../../globals/mixins/HostListener';
 import styles from './modal.scss';
 import BXModalCloseButton from './modal-close-button';
 
 const { prefix } = settings;
 
 @customElement(`${prefix}-modal` as any)
-class BXModal extends LitElement {
-  /**
-   * The handle for the `click` event handler on this element.
-   */
-  private _hClick: Handle | null = null;
-
+class BXModal extends HostListenerMixin(LitElement) {
   /**
    * Handles `click` event on this element.
    * @param event The event.
+   * @private
    */
+  @HostListener('click')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleClick = (event: MouseEvent) => {
     if (event.composedPath().indexOf(this.shadowRoot!) < 0) {
       this._handleUserInitiatedClose(event.target);
@@ -80,18 +79,6 @@ class BXModal extends LitElement {
     return html`
       <div class=${containerClasses} role="dialog" tabidnex="-1" @click=${this._handleClickContainer}><slot></slot></div>
     `;
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    this._hClick = on(this, 'click', this._handleClick);
-  }
-
-  disconnectedCallback() {
-    if (this._hClick) {
-      this._hClick = this._hClick.release();
-    }
-    super.disconnectedCallback();
   }
 
   /**

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -1,6 +1,7 @@
 import settings from 'carbon-components/es/globals/js/settings';
-import on from 'carbon-components/es/globals/js/misc/on';
 import { html, property, customElement, LitElement } from 'lit-element';
+import HostListener from '../../globals/decorators/HostListener';
+import HostListenerMixin from '../../globals/mixins/HostListener';
 import BXFloatingMenu from '../floating-menu/floating-menu';
 import BXFloatingMenuTrigger from '../floating-menu/floating-menu-trigger';
 import styles from './tooltip.scss';
@@ -12,12 +13,7 @@ const find = (a: NodeListOf<Node>, predicate: (search: Node) => boolean) => Arra
  * Trigger button of tooltip.
  */
 @customElement(`${prefix}-tooltip` as any)
-class BXTooltip extends LitElement implements BXFloatingMenuTrigger {
-  /**
-   * The handle for `click` event listener on this element.
-   */
-  private _hClick: Handle | null = null;
-
+class BXTooltip extends HostListenerMixin(LitElement) implements BXFloatingMenuTrigger {
   /**
    * The menu body.
    */
@@ -26,6 +22,8 @@ class BXTooltip extends LitElement implements BXFloatingMenuTrigger {
   /**
    * Handles `click` event on this element.
    */
+  @HostListener('click')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleClick = () => {
     this.open = !this.open;
   };
@@ -64,17 +62,7 @@ class BXTooltip extends LitElement implements BXFloatingMenuTrigger {
     if (!this.shadowRoot) {
       this.attachShadow({ mode: 'open' });
     }
-    if (!this._hClick) {
-      this._hClick = on(this, 'click', this._handleClick);
-    }
     super.connectedCallback();
-  }
-
-  disconnectedCallback() {
-    if (this._hClick) {
-      this._hClick = this._hClick.release();
-    }
-    super.disconnectedCallback();
   }
 
   attributeChangedCallback(name, old, current) {

--- a/src/globals/decorators/HostListener.ts
+++ b/src/globals/decorators/HostListener.ts
@@ -1,0 +1,20 @@
+/**
+ * A decorator to add event listener to the host element, or its `document`/`window`, of a custom element.
+ * The `target` must extend `HostListenerMixin`.
+ * @param type
+ *   The event type. Can be prefixed with `document:` or `window:`.
+ *   The event listener is attached to host element's owner document or its default view in such case.
+ * @param options The event listener options.
+ */
+const HostListener = (type: string, options?: boolean | AddEventListenerOptions) => (target, listenerName: string) => {
+  const hostListeners = target.constructor._hostListeners;
+  if (!hostListeners) {
+    throw new Error('The method `@HostListener` is defined on has to be of a class that has `HostListerMixin`.');
+  }
+  if (!hostListeners[listenerName]) {
+    hostListeners[listenerName] = {};
+  }
+  hostListeners[listenerName][type] = { options };
+};
+
+export default HostListener;

--- a/src/globals/mixins/HostListener.ts
+++ b/src/globals/mixins/HostListener.ts
@@ -1,0 +1,70 @@
+import on from 'carbon-components/es/globals/js/misc/on';
+
+/**
+ * The format for the event name used by `@HostListener` decorator.
+ */
+const EVENT_NAME_FORMAT = /^((document|window):)?(\w+)$/;
+
+/**
+ * @param Base The base class.
+ * @returns A mix-in that sets up and cleans up event listeners defined by `@HostListener` decorator.
+ */
+const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+  /**
+   * A mix-in class that sets up and cleans up event listeners defined by `@HostListener` decorator.
+   */
+  class HostListenerMixinImpl extends Base {
+    /**
+     * The list of handles managed by this mix-in.
+     * @private
+     */
+    _handles: Set<Handle> = new Set(); // Not using TypeScript `private` due to: microsoft/TypeScript#17744
+
+    connectedCallback() {
+      // @ts-ignore: Until `connectedCallback` is added to `HTMLElement` definition
+      super.connectedCallback();
+      const hostListeners = (this.constructor as typeof HostListenerMixinImpl)._hostListeners;
+      Object.keys(hostListeners).forEach(listenerName => {
+        Object.keys(hostListeners[listenerName]).forEach(type => {
+          const { options = false } = hostListeners[listenerName][type];
+          const tokens = EVENT_NAME_FORMAT.exec(type);
+          if (!tokens) {
+            throw new Error(`Could not parse the event name: ${listenerName}`);
+          }
+          const [, , targetName, unprefixedType] = tokens;
+          const target =
+            {
+              document: this.ownerDocument,
+              window: this.ownerDocument!.defaultView,
+            }[targetName] || this;
+          this._handles.add(on(target, unprefixedType as keyof HTMLElementEventMap, this[listenerName], options));
+        });
+      });
+    }
+
+    disconnectedCallback() {
+      this._handles.forEach(handle => {
+        handle.release();
+        this._handles.delete(handle);
+      });
+      // @ts-ignore: Until `disconnectedCallback` is added to `HTMLElement` definition
+      super.disconnectedCallback();
+    }
+
+    /**
+     * The map, keyed by method name, of event listeners that should be attached to host element or host document.
+     * @private
+     */
+    static _hostListeners: {
+      [listenerName: string]: {
+        [type: string]: {
+          options?: boolean | AddEventListenerOptions;
+        };
+      };
+    } = {}; // Not using TypeScript `private` due to: microsoft/TypeScript#17744
+  }
+
+  return HostListenerMixinImpl;
+};
+
+export default HostListenerMixin;

--- a/src/typings/constructor.d.ts
+++ b/src/typings/constructor.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Constructor type. Used for defining mix-ins.
+ */
+type Constructor<T> = new (...args: any[]) => T;


### PR DESCRIPTION
`@HostListener(type, options?)` decorator attaches an event listener of the host element of a custom element.

The custom element class using `@HostListener()` has to extend `HostListenerMixin` that does the actual event listener work. Otherwise, `@HostListener()` throws an error.