### PR TITLE
feat(host-listener): supports delegated focus/blur

### DIFF
--- a/src/typings/vendor.d.ts
+++ b/src/typings/vendor.d.ts
@@ -21,17 +21,17 @@ declare module 'carbon-components/es/globals/js/settings' {
 
 declare module 'carbon-components/es/globals/js/misc/on' {
   /**
-   * Adds an event listener function to the list of event listeners for the given event type on the given element.
-   * @param element The element to add event listener on.
+   * Adds an event listener function to the list of event listeners for the given event type on the given event target.
+   * @param target The target to add event listener on.
    * @param type A case-sensitive string representing the event type to listen for.
    * @param listener The event listener callback.
    * @param options An options object that specifies characteristics about the event listener.
    * @returns The handle to release the event listener. Its `release()` method removes the event listener.
    */
   function on<K extends keyof HTMLElementEventMap>(
-    element: Element,
+    target: EventTarget,
     type: K,
-    listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
+    listener: (this: EventTarget, ev: HTMLElementEventMap[K]) => any,
     options?: boolean | AddEventListenerOptions
   ): Handle;
   export default on;


### PR DESCRIPTION
This change makes `@HostListener('focus')` capture descendant nodes' (e.g. ones' in shadow DOM) focus events. Similar for `blur` as well.