### PR TITLE
feat(structured-list): add bx-structured-list

### DIFF
--- a/src/components/structured-list/structured-list-body.ts
+++ b/src/components/structured-list/structured-list-body.ts
@@ -1,0 +1,21 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, customElement, LitElement } from 'lit-element';
+import styles from './structured-list.scss';
+
+const { prefix } = settings;
+
+/**
+ * Structured list body.
+ */
+@customElement(`${prefix}-structured-list-body` as any)
+class BXStructuredListBody extends LitElement {
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXStructuredListBody;

--- a/src/components/structured-list/structured-list-head.ts
+++ b/src/components/structured-list/structured-list-head.ts
@@ -1,0 +1,21 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, customElement, LitElement } from 'lit-element';
+import styles from './structured-list.scss';
+
+const { prefix } = settings;
+
+/**
+ * Structured list header.
+ */
+@customElement(`${prefix}-structured-list-head` as any)
+class BXStructuredListHeader extends LitElement {
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXStructuredListHeader;

--- a/src/components/structured-list/structured-list-header-row.ts
+++ b/src/components/structured-list/structured-list-header-row.ts
@@ -1,0 +1,35 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, property, customElement, LitElement } from 'lit-element';
+import styles from './structured-list.scss';
+
+const { prefix } = settings;
+
+/**
+ * Structured list header row.
+ */
+@customElement(`${prefix}-structured-list-header-row` as any)
+class BXStructuredListHeaderRow extends LitElement {
+  /**
+   * `true` if parent structured list supports selection. Corresponds to `has-selection` attribute.
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
+  hasSelection = false;
+
+  render() {
+    // We could look up in DOM for `bx-structured-list[hasSelection]`,
+    // but uses `hasSelection` prop to utilize attribute change callback
+    if (this.hasSelection) {
+      return html`
+        <slot></slot>
+        <div class="${prefix}--structured-list-th"></div>
+      `;
+    }
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXStructuredListHeaderRow;

--- a/src/components/structured-list/structured-list-row.ts
+++ b/src/components/structured-list/structured-list-row.ts
@@ -1,0 +1,208 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import { html, property, customElement, LitElement } from 'lit-element';
+import HostListener from '../../globals/decorators/HostListener';
+import HostListenerMixin from '../../globals/mixins/HostListener';
+import RadioGroupManager, { NAVIGATION_DIRECTION, ManagedRadioButtonDelegate } from '../../globals/internal/radio-group-manager';
+import styles from './structured-list.scss';
+
+const { prefix } = settings;
+
+/**
+ * Map of navigation direction by key.
+ */
+const navigationDirectionForKey = {
+  ArrowUp: NAVIGATION_DIRECTION.BACKWARD,
+  ArrowDown: NAVIGATION_DIRECTION.FORWARD,
+};
+
+/**
+ * The interface for `RadioGroupManager` for structured list row.
+ */
+class StructuredListRowRadioButtonDelegate implements ManagedRadioButtonDelegate {
+  /**
+   * The structured list row to target.
+   */
+  private _row: BXStructuredListRow;
+
+  constructor(row: BXStructuredListRow) {
+    this._row = row;
+  }
+
+  get checked() {
+    return this._row.selected;
+  }
+
+  set checked(checked) {
+    this._row.selected = checked;
+    this._row.tabIndex = checked ? 0 : -1;
+  }
+
+  get tabIndex() {
+    return this._row.tabIndex;
+  }
+
+  set tabIndex(tabIndex) {
+    this._row.tabIndex = tabIndex;
+  }
+
+  get name() {
+    return this._row.selectionName;
+  }
+
+  compareDocumentPosition(other: StructuredListRowRadioButtonDelegate) {
+    return this._row.compareDocumentPosition(other._row);
+  }
+
+  focus() {
+    this._row.focus();
+  }
+}
+
+/**
+ * Structured list row.
+ */
+@customElement(`${prefix}-structured-list-row` as any)
+class BXStructuredListRow extends HostListenerMixin(LitElement) {
+  /**
+   * The radio group manager associated with the radio button.
+   */
+  private _manager: RadioGroupManager | null = null;
+
+  /**
+   * The interface for `RadioGroupManager` for structured list row.
+   */
+  private _radioButtonDelegate = new StructuredListRowRadioButtonDelegate(this);
+
+  /**
+   * Handles `click` event on this element.
+   */
+  @HostListener('click')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleClick = () => {
+    const input = this.shadowRoot!.getElementById('input') as HTMLInputElement;
+    if (input) {
+      this.selected = true;
+      if (this._manager) {
+        this._manager.select(this._radioButtonDelegate);
+      }
+    }
+  };
+
+  /**
+   * Handles `keydown` event on this element.
+   */
+  @HostListener('keydown')
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleKeydown = (event: KeyboardEvent) => {
+    const input = this.shadowRoot!.getElementById('input') as HTMLInputElement;
+    const manager = this._manager;
+    if (input && manager) {
+      const navigationDirection = navigationDirectionForKey[event.key];
+      if (navigationDirection) {
+        manager.select(manager.navigate(this._radioButtonDelegate, navigationDirection));
+      }
+      if (event.key === ' ' || event.key === 'Enter') {
+        manager.select(this._radioButtonDelegate);
+      }
+    }
+  };
+
+  /**
+   * `true` if this structured list row should be selectable and selected. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  selected = false;
+
+  /**
+   * The `name` attribute for the `<input>` for selection. Corresponds to `selection-name` attribute.
+   * If present, this structured list row will be a selectable one.
+   */
+  @property({ attribute: 'selection-name' })
+  selectionName = '';
+
+  /**
+   * The `value` attribute for the `<input>` for selection. Corresponds to `selection-value` attribute.
+   * If present, this structured list row will be a selectable one.
+   */
+  @property({ attribute: 'selection-value' })
+  selectionValue = '';
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (!this._manager) {
+      this._manager = RadioGroupManager.get(this.getRootNode({ composed: true }) as Document);
+      const { selectionName } = this;
+      if (selectionName) {
+        this._manager!.add(this._radioButtonDelegate);
+      }
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._manager) {
+      this._manager.delete(this._radioButtonDelegate);
+    }
+    super.disconnectedCallback();
+  }
+
+  updated(changedProperties) {
+    const { _manager: manager, selectionName } = this;
+    if (changedProperties.has('selectionName')) {
+      if (manager) {
+        if (selectionName) {
+          manager.add(this._radioButtonDelegate);
+        } else {
+          manager.delete(this._radioButtonDelegate);
+        }
+      }
+      this.setAttribute(
+        'tabindex',
+        !selectionName || !manager || !manager.shouldBeFocusable(this._radioButtonDelegate) ? '-1' : '0'
+      );
+    }
+  }
+
+  render() {
+    const { selected, selectionName, selectionValue } = this;
+    if (selectionName) {
+      // "Selected" style with `.bx--structured-list-td` does not work somehow - Need investigation
+      return html`
+        <slot></slot>
+        <input
+          id="input"
+          type="radio"
+          class="${prefix}--structured-list-input"
+          ?checked=${selected}
+          name=${selectionName}
+          value=${ifDefined(selectionValue)}
+        />
+        <div class="${prefix}--structured-list-td ${prefix}--structured-list-cell">
+          <svg
+            focusable="false"
+            preserveAspectRatio="xMidYMid meet"
+            aria-label="select an option"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            role="img"
+            class="${prefix}--structured-list-svg"
+            style="will-change: transform;"
+          >
+            <title>select an option</title>
+            <path d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"></path>
+            <path d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z" opacity="0"></path>
+          </svg>
+        </div>
+      `;
+    }
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXStructuredListRow;

--- a/src/components/structured-list/structured-list-story.ts
+++ b/src/components/structured-list/structured-list-story.ts
@@ -1,0 +1,60 @@
+import { html } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import { storiesOf } from '@storybook/polymer';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import './structured-list';
+import './structured-list-head';
+import './structured-list-header-row';
+import './structured-list-body';
+import './structured-list-row';
+
+const createProps = () => ({
+  hasSelection: boolean('Supports selection feature (has-selection)', false),
+});
+
+storiesOf('Structured list', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    const { hasSelection } = createProps();
+    const selectionName = !hasSelection ? undefined : 'structured-list-selection';
+    const selectionValues = !hasSelection
+      ? []
+      : ['structured-list-selection-0', 'structured-list-selection-1', 'structured-list-selection-2'];
+    return html`
+      <bx-structured-list ?has-selection=${hasSelection}>
+        <bx-structured-list-head>
+          <bx-structured-list-header-row ?has-selection=${hasSelection}>
+            <bx-structured-list-header>ColumnA</bx-structured-list-header>
+            <bx-structured-list-header>ColumnB</bx-structured-list-header>
+            <bx-structured-list-header>ColumnC</bx-structured-list-header>
+          </bx-structured-list-header-row>
+        </bx-structured-list-head>
+        <bx-structured-list-body>
+          <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[0])}>
+            <bx-structured-list-cell>Row 1</bx-structured-list-cell>
+            <bx-structured-list-cell>Row 1</bx-structured-list-cell>
+            <bx-structured-list-cell
+              >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
+              augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
+            >
+          </bx-structured-list-row>
+          <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[1])}>
+            <bx-structured-list-cell>Row 2</bx-structured-list-cell>
+            <bx-structured-list-cell>Row 2</bx-structured-list-cell>
+            <bx-structured-list-cell
+              >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
+              augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
+            >
+          </bx-structured-list-row>
+          <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[2])}>
+            <bx-structured-list-cell>Row 3</bx-structured-list-cell>
+            <bx-structured-list-cell>Row 3</bx-structured-list-cell>
+            <bx-structured-list-cell
+              >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
+              augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
+            >
+          </bx-structured-list-row>
+        </bx-structured-list-body>
+      </bx-structured-list>
+    `;
+  });

--- a/src/components/structured-list/structured-list.scss
+++ b/src/components/structured-list/structured-list.scss
@@ -1,0 +1,45 @@
+$css--plex: true !default;
+
+@import 'carbon-components/scss/components/structured-list/structured-list';
+
+:host(#{$prefix}-structured-list) ::slotted(#{$prefix}-structured-list-head) {
+  @extend .#{$prefix}--structured-list-thead;
+}
+
+:host(#{$prefix}-structured-list-head) ::slotted(#{$prefix}-structured-list-header-row) {
+  @extend .#{$prefix}--structured-list-row;
+  @extend .#{$prefix}--structured-list-row.#{$prefix}--structured-list-row--header-row;
+}
+
+:host(#{$prefix}-structured-list-header-row) ::slotted(#{$prefix}-structured-list-header) {
+  @extend .#{$prefix}--structured-list-th;
+}
+
+:host(#{$prefix}-structured-list) ::slotted(#{$prefix}-structured-list-header[nowrap]) {
+  @extend .#{$prefix}--structured-list-content--nowrap;
+}
+
+:host(#{$prefix}-structured-list) ::slotted(#{$prefix}-structured-list-body) {
+  @extend .#{$prefix}--structured-list-tbody;
+}
+
+:host(#{$prefix}-structured-list-body) ::slotted(#{$prefix}-structured-list-row) {
+  @extend .#{$prefix}--structured-list-row;
+}
+
+:host(#{$prefix}-structured-list-row:hover) .#{$prefix}--structured-list-svg {
+  fill: $ibm-color__gray-40;
+}
+
+:host(#{$prefix}-structured-list-row) ::slotted(#{$prefix}-structured-list-cell) {
+  @extend .#{$prefix}--structured-list-td;
+}
+
+:host(#{$prefix}-structured-list-row) ::slotted(#{$prefix}-structured-list-cell[nowrap]) {
+  @extend .#{$prefix}--structured-list-content--nowrap;
+}
+
+// "Selected" style with `.bx--structured-list-td` does not work somehow - Need investigation
+.#{$prefix}--structured-list-input:checked + .#{$prefix}--structured-list-cell .#{$prefix}--structured-list-svg {
+  fill: $text-01;
+}

--- a/src/components/structured-list/structured-list.ts
+++ b/src/components/structured-list/structured-list.ts
@@ -1,0 +1,39 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import classnames from 'classnames';
+import { html, property, customElement, LitElement } from 'lit-element';
+import styles from './structured-list.scss';
+
+const { prefix } = settings;
+
+/**
+ * Structured list wrapper.
+ */
+@customElement(`${prefix}-structured-list` as any)
+class BXStructuredList extends LitElement {
+  /**
+   * `true` if border should be used. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  border = false;
+
+  /**
+   * `true` if selection should be supported. Corresponds to `has-selection` attribute.
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
+  hasSelection = false;
+
+  render() {
+    const { border, hasSelection } = this;
+    const classes = classnames(`${prefix}--structured-list`, {
+      [`${prefix}--structured-list--border`]: border,
+      [`${prefix}--structured-list--selection`]: hasSelection,
+    });
+    return html`
+      <section id="section" class=${classes}><slot></slot></section>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXStructuredList;

--- a/src/globals/internal/radio-group-manager.ts
+++ b/src/globals/internal/radio-group-manager.ts
@@ -1,0 +1,175 @@
+/**
+ * The navigation direction.
+ */
+export enum NAVIGATION_DIRECTION {
+  /**
+   * Navigating backward.
+   */
+  BACKWARD = -1,
+
+  /**
+   * Navigating forward.
+   */
+  FORWARD = 1,
+}
+
+export interface ManagedRadioButtonDelegate {
+  /**
+   * `true` if this radio button is selected.
+   */
+  checked: boolean;
+
+  /**
+   * The tab index.
+   */
+  tabIndex: number;
+
+  /**
+   * The name of the radio group.
+   */
+  name: string;
+
+  /**
+   * @param other A node to compare this radio button's DOM position in document with.
+   * @returns
+   *   An integer value, the same format as `Node.compareDocumentPosition` does,
+   *   whose bits represent the calling this radio button's relationship to the given node within the document.
+   */
+  compareDocumentPosition(other: ManagedRadioButtonDelegate): number;
+
+  /**
+   * Focuses on the radio button.
+   */
+  focus();
+}
+
+type ManagedRadioButton = HTMLInputElement | ManagedRadioButtonDelegate;
+
+/**
+ * An object that manages radio groups in a document.
+ * There must be only one instance for one document.
+ */
+class RadioGroupManager {
+  /**
+   * Radio groups, keyed by their names.
+   */
+  private _groups: { [name: string]: Set<ManagedRadioButton> } = {};
+
+  private constructor(document: Document) {
+    (this.constructor as typeof RadioGroupManager)._instances.set(document, this);
+  }
+
+  /**
+   * @param radio A radio button.
+   * @returns
+   *   `true` if the given radio button should be focusable, which is either:
+   *   - The radio button is selected
+   *   - No radio button is selected and the radio button is first one in the radio group
+   */
+  shouldBeFocusable(radio: ManagedRadioButton) {
+    if (radio.checked) {
+      return true;
+    }
+    const { name } = radio;
+    const group = this._groups[name];
+    const hasSelectedItemInGroup = group && Array.from(group).some(item => item.checked);
+    if (hasSelectedItemInGroup) {
+      return false;
+    }
+    const isFirstInGroup = !group || group.size === 1 || this.getSortedGroup(radio)[0] === radio;
+    return isFirstInGroup;
+  }
+
+  /**
+   * @param radio A radio button.
+   * @returns The sorted radio group the given radio button is in.
+   */
+  getSortedGroup(radio: ManagedRadioButton) {
+    const group = this._groups[radio.name];
+    return Array.from(group).sort((lhs, rhs) => {
+      const comparisonResult = (lhs as ManagedRadioButtonDelegate).compareDocumentPosition(rhs as ManagedRadioButtonDelegate);
+      // eslint-disable-next-line no-bitwise
+      if (comparisonResult & Node.DOCUMENT_POSITION_FOLLOWING || comparisonResult & Node.DOCUMENT_POSITION_CONTAINED_BY) {
+        return -1;
+      }
+      // eslint-disable-next-line no-bitwise
+      if (comparisonResult & Node.DOCUMENT_POSITION_PRECEDING || comparisonResult & Node.DOCUMENT_POSITION_CONTAINS) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+
+  /**
+   * Manages a radio button.
+   * @param radio The radio button to manage.
+   * @returns This object.
+   */
+  add(radio: ManagedRadioButton) {
+    const { name } = radio;
+    const groups = this._groups;
+    if (!groups[name]) {
+      groups[name] = new Set<ManagedRadioButton>();
+    }
+    groups[name].add(radio);
+    return this;
+  }
+
+  /**
+   * Unmanages a radio button.
+   * @param radio The radio button to unmanage.
+   * @returns `true` if `element` was actually managed.
+   */
+  delete(radio: ManagedRadioButton) {
+    const group = this._groups[radio.name];
+    return !group ? false : group.delete(radio);
+  }
+
+  /**
+   * Selects or focuses on a radio button.
+   * @param radio The radio button to select.
+   */
+  select(radio: ManagedRadioButton) {
+    const group = this._groups[radio.name];
+    group.forEach(item => {
+      const shouldBeSelected = radio === item;
+      item.checked = shouldBeSelected;
+      item.tabIndex = shouldBeSelected ? 0 : -1;
+      if (shouldBeSelected) {
+        item.focus();
+      }
+    });
+  }
+
+  /**
+   * @param radio The currently selected radio button.
+   * @param direction The direction to navigate to.
+   * @returns The radio button that should be selected next.
+   */
+  navigate(radio: ManagedRadioButton, direction: NAVIGATION_DIRECTION) {
+    const sortedGroup = this.getSortedGroup(radio);
+    let newIndex = sortedGroup.indexOf(radio) + direction;
+    if (newIndex < 0) {
+      newIndex = sortedGroup.length - 1;
+    } else if (newIndex >= sortedGroup.length) {
+      newIndex = 0;
+    }
+    return sortedGroup[newIndex];
+  }
+
+  /**
+   * `RadioGroupManager` instances associated with documents.
+   */
+  private static _instances = new WeakMap();
+
+  /**
+   * @param document A document element.
+   * @returns The `RadioGroupManager` instance associated with the given document.
+   */
+  static get(document: Document) {
+    const found = this._instances.get(document);
+    return found || new RadioGroupManager(document);
+  }
+}
+
+export default RadioGroupManager;


### PR DESCRIPTION
Introduces `<bx-structured-list>`, etc. - Carbon structured list. With experimental keyboard navigation support for selection.