### PR TITLE
feat(modal): introduce focus-wrap

### DIFF
--- a/.storybook/components/focus-trap/focus-trap.scss
+++ b/.storybook/components/focus-trap/focus-trap.scss
@@ -1,5 +1,5 @@
 @import 'carbon-components/scss/globals/scss/css--helpers';
 
-:host(#{$prefix}-focus-trap) {
+:host(#{$prefix}-ce-focus-trap) {
   @extend .#{$prefix}--visually-hidden;
 }

--- a/.storybook/components/focus-trap/focus-trap.ts
+++ b/.storybook/components/focus-trap/focus-trap.ts
@@ -1,23 +1,31 @@
 import settings from 'carbon-components/es/globals/js/settings';
-import { html, customElement, LitElement } from 'lit-element';
+import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './focus-trap.scss';
 
 const { prefix } = settings;
 
-@customElement(`${prefix}-focus-trap` as any)
+@customElement(`${prefix}-ce-focus-trap` as any)
 class BXFocusTrap extends LitElement {
   /**
-   * A property that tells our a11y engine that this element is put off-screen and thus hidden.
+   * The skip link href.
    */
-  PT_NODE_HIDDEN = true;
+  @property()
+  href;
 
   createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
   }
 
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'navigation');
+    }
+    super.connectedCallback();
+  }
+
   render() {
     return html`
-      <input type="text" />
+      <a href="${this.href}"><slot></slot></a>
     `;
   }
 

--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -9,10 +9,11 @@ addDecorator(
     <style>
       ${containerStyles}
     </style>
-    <div data-floating-menu-container role="main" class="bx--body bx-ce-devenv--container">
+    <bx-ce-focus-trap href="#main-content" aria-label="Skip to main content">Skip to main content</bx-ce-focus-trap>
+    <div name="main-content" data-floating-menu-container role="main" class="bx--body bx-ce-devenv--container">
       ${story()}
     </div>
-    <bx-focus-trap />
+    <bx-ce-focus-trap href="#main-content" aria-label="End of content">End of content</bx-ce-focus-trap>
   `
 );
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "lint-staged": "^8.1.0",
     "lit-element": "^2.1.0",
     "lit-html": "~1.0.0",
+    "lodash.findlast": "^4.6.0",
     "mini-css-extract-plugin": "^0.5.0",
     "minimist": "^1.2.0",
     "mocha": "^2.4.0",
@@ -115,7 +116,8 @@
     "carbon-components": "^10.0.0",
     "classnames": "^2.2.0",
     "lit-element": "^2.1.0",
-    "lit-html": "~1.0.0"
+    "lit-html": "~1.0.0",
+    "lodash.findlast": "^4.6.0"
   },
   "commitlint": {
     "extends": [

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -138,6 +138,10 @@ class BXDropdown extends LitElement {
     super.attributeChangedCallback(name, old, current);
   }
 
+  createRenderRoot() {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+
   render() {
     const innerClasses = classnames(`${prefix}--dropdown`, {
       [`${prefix}--dropdown--disabled`]: this.disabled,

--- a/src/components/modal/modal-close-button.ts
+++ b/src/components/modal/modal-close-button.ts
@@ -25,6 +25,9 @@ class BXModalCloseButton extends LitElement {
   }
 
   connectedCallback() {
+    if (!this.hasAttribute('tabindex')) {
+      this.setAttribute('tabindex', '0');
+    }
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'button');
     }

--- a/src/components/overflow-menu/overflow-menu.ts
+++ b/src/components/overflow-menu/overflow-menu.ts
@@ -78,6 +78,10 @@ class BXOverflowMenu extends HostListenerMixin(LitElement) implements BXFloating
     super.attributeChangedCallback(name, old, current);
   }
 
+  createRenderRoot() {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+
   render() {
     return icon(OverflowMenuVertical16, {
       class: `${prefix}--overflow-menu__icon`,

--- a/src/components/structured-list/structured-list.ts
+++ b/src/components/structured-list/structured-list.ts
@@ -22,6 +22,10 @@ class BXStructuredList extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
   hasSelection = false;
 
+  createRenderRoot() {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+
   render() {
     const { border, hasSelection } = this;
     const classes = classnames(`${prefix}--structured-list`, {

--- a/src/globals/settings.ts
+++ b/src/globals/settings.ts
@@ -1,0 +1,25 @@
+import settings from 'carbon-components/es/globals/js/settings';
+
+const { prefix } = settings;
+
+/**
+ * A selector selecting tabbable nodes.
+ * Borrowed from `carbon-angular`. tabbable === focusable.
+ */
+const selectorTabbable = `
+  a[href], area[href], input:not([disabled]):not([tabindex='-1']),
+  button:not([disabled]):not([tabindex='-1']),select:not([disabled]):not([tabindex='-1']),
+  textarea:not([disabled]):not([tabindex='-1']),
+  iframe, object, embed, *[tabindex]:not([tabindex='-1']), *[contenteditable=true],
+  ${prefix}-btn,
+  ${prefix}-dropdown,
+  ${prefix}-modal,
+  ${prefix}-modal-close-button,
+  ${prefix}-overflow-menu,
+  ${prefix}-structured-list,
+  ${prefix}-tooltip
+`;
+
+// Because we're going to have a bunch of exports
+// eslint-disable-next-line import/prefer-default-export
+export { selectorTabbable };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8371,6 +8371,11 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
+lodash.findlast@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.findlast/-/lodash.findlast-4.6.0.tgz#ea8bb78cf2e7e7804fc8aeb7d1953e07fe31fbc8"
+  integrity sha1-6ou3jPLn54BPyK630ZU+B/4x+8g=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"


### PR DESCRIPTION
This change does the following:

- Attempts to focus on the element in the following priority order, when modal gets open:
  - An element that application specifies via `data-modal-primary-focus` attribute
  - A primary button
  - The first focusable element in modal or modal itself
- Attempts to focus on the first focusable element in modal (or modal itself), when modal body loses focus, and the latest focused element follows the modal body in DOM order
- Attempts to focus on the last focusable element in modal (or modal itself), when modal body loses focus, and the latest focused element precedes the modal body in DOM order

This change also:

- Adds the selector for tabbable elements (borrowed from @cal-smith's #2), adding our custom elements that should be focusable
- Enhances the example focus-trap custom element to support skip-to-content feature