### PR TITLE
chore(dropdown): make ID-ref simpler

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -134,14 +134,6 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
   helperText = '';
 
   /**
-   * The unique ID for this dropdown.
-   */
-  @property()
-  id = `__carbon-dropdown__${Math.random()
-    .toString(36)
-    .substr(2)}`;
-
-  /**
    * The label text. Corresponds to the attribute with the same name.
    */
   @property({ attribute: 'label-text' })
@@ -211,10 +203,10 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
       [`${prefix}-ce--dropdown-list--open`]: this.open,
     });
     return html`
-      <label for=${`${this.id}-inner`} class=${`${prefix}--label`}>${this.labelText}</label>
+      <label for="inner" class=${`${prefix}--label`}>${this.labelText}</label>
       <div class=${`${prefix}--form__helper-text`}>${this.helperText}</div>
       <ul
-        id=${`${this.id}-inner`}
+        id="inner"
         class=${innerClasses}
         role="combobox"
         tabindex="0"

--- a/tests/spec/dropdown_spec.ts
+++ b/tests/spec/dropdown_spec.ts
@@ -23,7 +23,7 @@ describe('bx-dropdown', function() {
     });
 
     it('should add "open" stateful modifier class', async function() {
-      const inner = elem.shadowRoot!.getElementById(`${elem.id}-inner`);
+      const inner = elem.shadowRoot!.getElementById('inner');
       inner!.click();
       await Promise.resolve();
       expect(inner!.classList.contains('bx--dropdown--open')).toBe(true);


### PR DESCRIPTION
Given the ID-ref is in shadow DOM, we don't need to generate unique ID for that.