### PR TITLE
chore(devenv): introduce prefix for devenv

### DIFF
--- a/.storybook/_container.scss
+++ b/.storybook/_container.scss
@@ -1,6 +1,6 @@
 @import 'carbon-components/scss/globals/scss/css--helpers';
 
-.bx-ce-devenv--container {
+.bx-ce-demo-devenv--container {
   padding: 3em;
   display: flex;
   flex-direction: column;

--- a/.storybook/components/focus-trap/focus-trap.scss
+++ b/.storybook/components/focus-trap/focus-trap.scss
@@ -1,5 +1,5 @@
 @import 'carbon-components/scss/globals/scss/css--helpers';
 
-:host(#{$prefix}-ce-focus-trap) {
+:host(#{$prefix}-ce-demo-focus-trap) {
   @extend .#{$prefix}--visually-hidden;
 }

--- a/.storybook/components/focus-trap/focus-trap.ts
+++ b/.storybook/components/focus-trap/focus-trap.ts
@@ -4,7 +4,7 @@ import styles from './focus-trap.scss';
 
 const { prefix } = settings;
 
-@customElement(`${prefix}-ce-focus-trap` as any)
+@customElement(`${prefix}-ce-demo-focus-trap` as any)
 class BXFocusTrap extends LitElement {
   /**
    * The skip link href.

--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -9,11 +9,11 @@ addDecorator(
     <style>
       ${containerStyles}
     </style>
-    <bx-ce-focus-trap href="#main-content" aria-label="Skip to main content">Skip to main content</bx-ce-focus-trap>
-    <div name="main-content" data-floating-menu-container role="main" class="bx--body bx-ce-devenv--container">
+    <bx-ce-demo-focus-trap href="#main-content" aria-label="Skip to main content">Skip to main content</bx-ce-demo-focus-trap>
+    <div name="main-content" data-floating-menu-container role="main" class="bx--body bx-ce-demo-devenv--container">
       ${story()}
     </div>
-    <bx-ce-focus-trap href="#main-content" aria-label="End of content">End of content</bx-ce-focus-trap>
+    <bx-ce-demo-focus-trap href="#main-content" aria-label="End of content">End of content</bx-ce-demo-focus-trap>
   `
 );
 


### PR DESCRIPTION
This change introduces a new prefix for custom element name as well as for BEM, `bx-ce-demo`, used only for our dev env. Doing so allows us to distinguish prefix for dev env from one for BEM prefix used only for `carbon-custom-elements`.