### PR TITLE
chore(devenv): allow type annotation in story code

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -63,8 +63,8 @@ module.exports = ({ config, mode }) => {
         {
           loader: require.resolve('@storybook/addon-storysource/loader'),
           options: {
+            parser: 'typescript',
             prettierConfig: {
-              parser: 'babylon',
               printWidth: 80,
               tabWidth: 2,
               bracketSpacing: true,


### PR DESCRIPTION
This change is for allowing type annotations in our `story.ts` code.