### PR TITLE
chore(components): make custom events composed

### DIFF
--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -104,6 +104,7 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
       const init = {
         bubbles: true,
         cancelable: true,
+        composed: true,
         detail: {
           item,
         },

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -94,6 +94,7 @@ class BXModal extends HostListenerMixin(LitElement) {
     const init = {
       bubbles: true,
       cancelable: true,
+      composed: true,
       detail: {
         triggeredBy,
       },


### PR DESCRIPTION
Doing so allows our custom events to bubble up and to go through shadow DOM boundary, useful when our components are used in shadow DOM.