### PR TITLE
feat(data-table): introduce data table

### DIFF
--- a/src/components/data-table/README.md
+++ b/src/components/data-table/README.md
@@ -1,0 +1,240 @@
+# Data table
+
+Data table in `carbon-custom-elements` focuses on primitives that constructs table UI, consisting of the following:
+
+| Tag                      | Description     | HTML tag counterpart |
+| ------------------------ | --------------- | -------------------- |
+| `<bx-data-table>`        | The container   | N/A                  |
+| `<bx-table>`             | The table       | `<table>`            |
+| `<bx-table-head>`        | The header      | `<thead>`            |
+| `<bx-table-header-row>`  | The header row  | `<tr>` in `<thead>`  |
+| `<bx-table-header-cell>` | The header cell | `<th>`               |
+| `<bx-table-body>`        | The header body | `<tbody>`            |
+| `<bx-table-row>`         | The header row  | `<tr>` in `<tbody>`  |
+| `<bx-table-cell>`        | The header cell | `<td>`               |
+
+## Basic usage
+
+In the most basic case, you can simply put your table rows/cells in the same way as putting `<tr>`/`<td>` like below, and you'll get Carbon-styled table automatically:
+
+```html
+<bx-data-table>
+  <bx-table>
+    <bx-table-head>
+      <bx-table-header-row>
+        <bx-table-header-cell>Foo</bx-table-header-cell>
+        <bx-table-header-cell>Bar</bx-table-header-cell>
+        <bx-table-header-cell>Baz</bx-table-header-cell>
+      </bx-table-header-row>
+    </bx-table-head>
+    <bx-table-body>
+      <bx-table-row>
+        <bx-table-cell>Foo1</bx-table-cell>
+        <bx-table-cell>Bar1</bx-table-cell>
+        <bx-table-cell>Baz1</bx-table-cell>
+      </bx-table-row>
+      <bx-table-row>
+        <bx-table-cell>Foo2</bx-table-cell>
+        <bx-table-cell>Bar2</bx-table-cell>
+        <bx-table-cell>Baz2</bx-table-cell>
+      </bx-table-row>
+      <bx-table-row>
+        <bx-table-cell>Foo3</bx-table-cell>
+        <bx-table-cell>Bar3</bx-table-cell>
+        <bx-table-cell>Baz3</bx-table-cell>
+      </bx-table-row>
+    </bx-table-body>
+  </bx-table>
+</bx-data-table>
+```
+
+Typically you want to render the table rows/cells from your data. Below is an example of [`lit-html`](https://lit-html.polymer-project.org), but similar stories apply to React, Angular, Vue, Backbone, Knockout and many others:
+
+```javascript
+html`
+  <bx-data-table>
+    <bx-table>
+      <bx-table-head>
+        <bx-table-header-row>
+          <bx-table-header-cell>Foo</bx-table-header-cell>
+          <bx-table-header-cell>Bar</bx-table-header-cell>
+          <bx-table-header-cell>Baz</bx-table-header-cell>
+        </bx-table-header-row>
+      </bx-table-head>
+      <bx-table-body>
+        ${rows.map(
+          row => html`
+            <bx-table-row>
+              <bx-table-cell>${row.foo}</bx-table-cell>
+              <bx-table-cell>${row.bar}</bx-table-cell>
+              <bx-table-cell>${row.baz}</bx-table-cell>
+            </bx-table-row>
+          `
+        )}
+      </bx-table-body>
+    </bx-table>
+  </bx-data-table>
+`;
+```
+
+## Row selection
+
+Adding `selection-name` attribute to `<bx-table-row>`/`<bx-table-header-row>` shows the selection UI in the table row.
+
+When user attempts to change row selection, the following events fire:
+
+| Element                 | Event                           | Description                                                   |
+| ----------------------- | ------------------------------- | ------------------------------------------------------------- |
+| `<bx-table-row>`        | `bx-table-row-change-selection` | Indicates user-initiated change in selection of a single row. |
+| `<bx-table-header-row>` | `bx-table-change-selection-all` | Indicates user-initiated change in selection of all rows.     |
+
+Both of above events have the following properties in the event details:
+
+| Property   | Description              |
+| ---------- | ------------------------ |
+| `selected` | The new selection state. |
+
+Both of above events bubble and are cancelable. Canceling those events mean canceling change in selection.
+
+Application code should listen to those events update its internal state of table rows. To do so, it's convenient to add a `data-` attribte to each table rows so the delegated event handler can see which row the events are from.
+
+Here's an example of [`lit-html`](https://lit-html.polymer-project.org). Note that those events are native DOM events, and thus something like `document.addEventListener('bx-table-row-change-selection', event => { ... })` works, too:
+
+```javascript
+/**
+ * Handles an event to change in selection of rows, fired from `<bx-table-row>`,
+ * to update application's row selection states.
+ * @param {CustomEvent} event The event.
+ */
+const handleChangeSelection = event => {
+  if (!event.defaultPrevented) {
+    rows = this.rows.map(row => {
+      // The row ID you set to `<bx-table-row>` the event is fired on
+      const targetRowId = event.target.dataset.rowId;
+      return targetRowId !== row.id
+        ? row
+        : {
+            ...row,
+            selected: event.detail.selected,
+          };
+    });
+  }
+};
+
+/**
+ * Handles an event to change in selection of all rows, fired from `<bx-table-header-row>`,
+ * to update application's row selection states.
+ * @param {CustomEvent} event The event.
+ */
+const handleChangeSelectionAll = event => {
+  if (!event.defaultPrevented) {
+    rows = this.rows.map(row => ({
+      ...row,
+      selected: event.detail.selected,
+    }));
+  }
+};
+
+...
+
+html`
+  <bx-data-table
+    @bx-table-row-change-selection=${handleChangeSelection}
+    @bx-table-change-selection-all=${handleChangeSelectionAll}
+  >
+    <bx-table>
+      <bx-table-head>
+        <bx-table-header-row ?selected=${rows.every(row => row.selected)} selection-name="my-row-selection-all">
+          <bx-table-header-cell>Foo</bx-table-header-cell>
+          <bx-table-header-cell>Bar</bx-table-header-cell>
+          <bx-table-header-cell>Baz</bx-table-header-cell>
+        </bx-table-header-row>
+      </bx-table-head>
+      <bx-table-body>
+        ${rows.map(
+          row => html`
+            <bx-table-row ?selected=${row.selected} selection-name="${`my-row-selection-${row.id}`}" data-row-id="${row.id}">
+              <bx-table-cell>${row.foo}</bx-table-cell>
+              <bx-table-cell>${row.bar}</bx-table-cell>
+              <bx-table-cell>${row.baz}</bx-table-cell>
+            </bx-table-row>
+          `
+        )}
+      </bx-table-body>
+    </bx-table>
+  </bx-data-table>
+`;
+```
+
+## Sorting
+
+Adding `sort-direction` attribute to `<bx-table-header-cell>` shows the sorting UI in the table header cell.
+
+When user attempts to change sorting, `bx-table-header-cell-sort` event is fired, with the following properties in the event details:
+
+| Property           | Description             |
+| ------------------ | ----------------------- |
+| `oldSortDirection` | The old sort direction. |
+| `sortDirection`    | The new sort direction. |
+
+`bx-table-header-cell-sort` event bubbles and is cancelable. Canceling `bx-table-header-cell-sort` event means canceling change in sort direction.
+
+Application code should listen to those events update its internal state of sorting. To do so, it's convenient to add a `data-` attribte to each table header cells so the delegated event handler can see which table column the events are from.
+
+Here's an example of [`lit-html`](https://lit-html.polymer-project.org). Note that those events are native DOM events, and thus something like `document.addEventListener('bx-table-header-cell-sort', event => { ... })` works, too:
+
+```javascript
+/**
+ * Handles an event to sort rows, fired from `<bx-table-header-cell>`, to update application's sorting state.
+ * @param {CustomEvent} event The event.
+ */
+const handleChangeSort = event => {
+  if (!defaultPrevented) {
+    // Changes the sorting state upon user gesture
+    sortInfo = {
+      columnId: event.target.dataset.columnId,
+      direction: event.detail.direction,
+    };
+  }
+};
+
+...
+
+const collator = new Intl.Collator('en'); // Use the locale user is on
+
+/**
+ * Rows sorted by application's sorting state.
+ */
+const sortedRows = rows.slice().sort((lhs, rhs) => {
+  const lhsValue = lhs[sortInfo.columnId];
+  const rhsValue = rhs[sortInfo.columnId];
+  return (sortInfo.direction === 'ascending' ? 1 : -1) * collator.compare(lhsValue, rhsValue);
+});
+
+html`
+  <bx-data-table
+    @bx-table-header-cell-sort=${handleChangeSort}
+  >
+    <bx-table>
+      <bx-table-head>
+        <bx-table-header-row>
+          <bx-table-header-cell data-column-id="foo">Foo</bx-table-header-cell>
+          <bx-table-header-cell data-column-id="bar">Bar</bx-table-header-cell>
+          <bx-table-header-cell data-column-id="baz">Baz</bx-table-header-cell>
+        </bx-table-header-row>
+      </bx-table-head>
+      <bx-table-body>
+        ${sortedRows.map(
+          row => html`
+            <bx-table-row>
+              <bx-table-cell>${row.foo}</bx-table-cell>
+              <bx-table-cell>${row.bar}</bx-table-cell>
+              <bx-table-cell>${row.baz}</bx-table-cell>
+            </bx-table-row>
+          `
+        )}
+      </bx-table-body>
+    </bx-table>
+  </bx-data-table>
+`;
+```

--- a/src/components/data-table/_table-core.scss
+++ b/src/components/data-table/_table-core.scss
@@ -1,0 +1,121 @@
+//
+// Table
+//
+
+.#{$prefix}--data-table_inner-container ::slotted(#{$prefix}-table) {
+  @extend .#{$prefix}--data-table;
+  display: table;
+}
+
+//
+// Table header and table body
+//
+
+:host(#{$prefix}-table) {
+  ::slotted(#{$prefix}-table-head) {
+    @include type-style('heading-01');
+    background-color: $ui-03;
+    display: table-header-group;
+  }
+
+  ::slotted(#{$prefix}-table-body) {
+    @include type-style('body-short-01');
+    background-color: $ui-01;
+    width: 100%;
+    display: table-row-group;
+  }
+}
+
+//
+// Common style for table cell and table header cell
+//
+
+:host(#{$prefix}-table-header-row) ::slotted(#{$prefix}-table-header-cell),
+:host(#{$prefix}-table-header-row) .#{$prefix}--table-column-checkbox,
+:host(#{$prefix}-table-row) ::slotted(#{$prefix}-table-cell),
+:host(#{$prefix}-table-row) .#{$prefix}--table-column-checkbox {
+  display: table-cell;
+}
+
+//
+// Table header row
+//
+
+:host(#{$prefix}-table-head) ::slotted(#{$prefix}-table-header-row) {
+  height: $layout-04;
+  display: table-row;
+}
+
+//
+// Table header cell
+//
+
+:host(#{$prefix}-table-header-row) {
+  ::slotted(#{$prefix}-table-header-cell) {
+    color: $text-01;
+    background-color: $ui-03;
+    text-align: left;
+    display: table-cell;
+  }
+
+  ::slotted(#{$prefix}-table-header-cell:first-of-type) {
+    padding-left: $spacing-05;
+  }
+
+  ::slotted(#{$prefix}-table-header-cell:last-of-type) {
+    position: relative;
+    width: auto;
+  }
+
+  ::slotted(#{$prefix}-table-header-cell),
+  .#{$prefix}--table-column-checkbox {
+    padding-left: $spacing-04;
+    padding-right: $spacing-04;
+    vertical-align: middle;
+  }
+}
+
+//
+// Table row
+//
+
+:host(#{$prefix}-table-body) ::slotted(#{$prefix}-table-row) {
+  border: none;
+  height: $layout-04;
+  width: 100%;
+  display: table-row;
+}
+
+//
+// Table cell
+//
+
+:host(#{$prefix}-table-row) {
+  ::slotted(#{$prefix}-table-cell),
+  .#{$prefix}--table-column-checkbox {
+    color: $text-02;
+    border-top: 1px solid $ui-01;
+    border-bottom: 1px solid $ui-03;
+    padding: rem(14px) $spacing-04;
+    padding-bottom: rem(13px);
+    vertical-align: top;
+  }
+
+  ::slotted(#{$prefix}-table-cell:first-of-type) {
+    padding-left: $spacing-05;
+  }
+
+  ::slotted(#{$prefix}-table-cell:last-of-type) {
+    padding-right: $spacing-05;
+  }
+}
+
+:host(#{$prefix}-table-row:hover) {
+  ::slotted(#{$prefix}-table-cell),
+  .#{$prefix}--table-column-checkbox {
+    color: $text-01;
+    background-color: $hover-field;
+    border-bottom-color: $hover-field;
+    border-top-color: $hover-field;
+  }
+}

--- a/src/components/data-table/_table-selection.scss
+++ b/src/components/data-table/_table-selection.scss
@@ -1,0 +1,51 @@
+//
+// Selection check box
+//
+
+:host(#{$prefix}-table-header-row) .#{$prefix}--table-column-checkbox {
+  position: relative;
+  background-color: $ui-03;
+  width: rem(44px); // 16px padding left + 8px padding right + 20px checkbox width
+  transition: background-color $duration--fast-01 motion(entrance, productive);
+}
+
+:host(#{$prefix}-table-row) .#{$prefix}--table-column-checkbox {
+  padding-top: rem(11px);
+  padding-bottom: 0;
+
+  .#{$prefix}--checkbox-label {
+    padding-left: $spacing-05;
+  }
+}
+
+:host(#{$prefix}-table-header-row) .#{$prefix}--table-column-checkbox:hover {
+  // Highlight "select all" columns like sorting column
+  background-color: $data-table-column-hover;
+}
+
+:host(#{$prefix}-table-row[size='tall']) .#{$prefix}--table-column-checkbox {
+  padding-top: rem(12px);
+}
+
+//
+// Selected rows
+//
+
+:host(#{$prefix}-table-row[selected]) {
+  ::slotted(#{$prefix}-table-cell),
+  .#{$prefix}--table-column-checkbox {
+    color: $text-01;
+    background-color: $ui-03;
+    border-top: 1px solid $ui-03;
+    border-bottom: 1px solid $active-ui; //bottom border acts as separator from other rows
+  }
+}
+
+:host(#{$prefix}-table-row[selected]:hover) {
+  ::slotted(#{$prefix}-table-cell),
+  .#{$prefix}--table-column-checkbox {
+    background-color: $data-table-column-hover;
+    border-top-color: $data-table-column-hover;
+    border-bottom-color: $data-table-column-hover;
+  }
+}

--- a/src/components/data-table/_table-sizes.scss
+++ b/src/components/data-table/_table-sizes.scss
@@ -1,0 +1,40 @@
+//
+// "Compact" table size variant
+//
+
+:host(#{$prefix}-table-head) ::slotted(#{$prefix}-table-header-row[size='compact']),
+:host(#{$prefix}-table-body) ::slotted(#{$prefix}-table-row[size='compact']) {
+  height: rem(24px);
+}
+
+:host(#{$prefix}-table-row[size='compact']) ::slotted(#{$prefix}-table-cell) {
+  padding-top: rem(2px);
+  padding-bottom: rem(2px);
+}
+
+//
+// "Short" table size variant
+//
+
+:host(#{$prefix}-table-head) ::slotted(#{$prefix}-table-header-row[size='short']),
+:host(#{$prefix}-table-body) ::slotted(#{$prefix}-table-row[size='short']) {
+  height: rem(32px);
+}
+
+:host(#{$prefix}-table-row[size='short']) ::slotted(#{$prefix}-table-cell) {
+  padding-top: rem(7px);
+  padding-bottom: rem(6px);
+}
+
+//
+// "Tall" table size variant
+//
+
+:host(#{$prefix}-table-head) ::slotted(#{$prefix}-table-header-row[size='tall']),
+:host(#{$prefix}-table-body) ::slotted(#{$prefix}-table-row[size='tall']) {
+  height: rem(64px);
+}
+
+:host(#{$prefix}-table-row[size='tall']) ::slotted(#{$prefix}-table-cell) {
+  padding-top: rem(16px);
+}

--- a/src/components/data-table/_table-sort.scss
+++ b/src/components/data-table/_table-sort.scss
@@ -1,0 +1,63 @@
+@import 'carbon-components/scss/components/data-table/data-table-sort';
+
+// Height of header cell for sorting
+//
+// Ensure sort button takes 100% of the cell, by setting the same height as the parent row
+
+:host(#{$prefix}-table-header-row) ::slotted(#{$prefix}-table-header-cell[sort-direction]) {
+  height: rem(48px);
+}
+
+:host(#{$prefix}-table-header-row[size='compact']) ::slotted(#{$prefix}-table-header-cell[sort-direction]) {
+  height: rem(24px);
+}
+
+:host(#{$prefix}-table-header-row[size='short']) ::slotted(#{$prefix}-table-header-cell[sort-direction]) {
+  height: rem(32px);
+}
+
+:host(#{$prefix}-table-header-row[size='tall']) ::slotted(#{$prefix}-table-header-cell[sort-direction]) {
+  height: rem(64px);
+}
+
+:host(#{$prefix}-table-header-cell[sort-direction]) .#{$prefix}--table-sort {
+  height: 100%;
+}
+
+// Padding of header cell for sorting
+//
+// Let sort button rather than the cell define the padding
+
+:host(#{$prefix}-table-header-row) ::slotted(#{$prefix}-table-header-cell[sort-direction]) {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+:host(#{$prefix}-table-header-cell[sort-direction]) .#{$prefix}--table-sort {
+  padding-left: $spacing-04;
+  padding-right: $spacing-04;
+}
+
+:host(#{$prefix}-table-header-cell[sort-direction]:first-of-type) .#{$prefix}--table-sort {
+  padding-left: $spacing-05;
+}
+
+//
+// Sort icon style
+//
+
+// Show sort icon of primary sorting column or one of hovered column
+:host(#{$prefix}-table-header-cell[sort-active]) .bx--table-sort .bx--table-sort__icon,
+:host(#{$prefix}-table-header-cell) .bx--table-sort:hover .bx--table-sort__icon {
+  opacity: 1;
+}
+
+// `carbon-custom-elements` uses conditional rendering for choosing Arrows16 vs. ArrowDown16,
+// and thus `display:none` here is not needed
+:host(#{$prefix}-table-header-cell[sort-direction]) .bx--table-sort .bx--table-sort__icon {
+  display: block;
+}
+
+:host(#{$prefix}-table-header-cell[sort-direction='ascending']) .#{$prefix}--table-sort__icon {
+  transform: rotate(180deg);
+}

--- a/src/components/data-table/core-library-style-questions.md
+++ b/src/components/data-table/core-library-style-questions.md
@@ -1,0 +1,4 @@
+- `<tr>` in addition to `<td>` setting `background-color`: https://github.com/carbon-design-system/carbon/blob/v10.3.0/packages/components/src/components/data-table/_data-table-core.scss#L74-L76
+- Re-definition of text color and border width/style for selected and hovered `<tr>`s:
+  - https://github.com/carbon-design-system/carbon/blob/v10.3.0/packages/components/src/components/data-table/_data-table-core.scss#L78-L83
+  - https://github.com/carbon-design-system/carbon/blob/v10.3.0/packages/components/src/components/data-table/_data-table-core.scss#L304-L314

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -1,0 +1,365 @@
+import { html, property, customElement, LitElement } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import { repeat } from 'lit-html/directives/repeat';
+import { storiesOf } from '@storybook/polymer';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import './data-table';
+import { TABLE_SIZE } from './table';
+import './table-head';
+import './table-header-row';
+import { TABLE_SORT_DIRECTION } from './table-header-cell';
+import './table-body';
+import './table-row';
+import './table-cell';
+import { rows as demoRows, columns as demoColumns, sortInfo as demoSortInfo } from './stories/data';
+import { TDemoTableColumn, TDemoTableRow, TDemoSortInfo } from './stories/types';
+
+/**
+ * A class to manage table states, like selection and sorting.
+ * DEMONSTRATION-PURPOSE ONLY.
+ * Data/state handling in data table tends to involve lots of application-specific logics
+ * and thus abstracting everything in a library won't be a good return on investment
+ * vs. letting users copy code here and implement features that fit their needs.
+ */
+@customElement('bx-ce-demo-data-table' as any)
+// @ts-ignore `BXCEDemoDataTable` is used (only) for type reference
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class BXCEDemoDataTable extends LitElement {
+  /**
+   * The table sorting info reflecting user-initiated changes.
+   */
+  private _sortInfo?: TDemoSortInfo;
+
+  /**
+   * The table rows reflecting user-initiated changes in sorting.
+   */
+  private _rows?: TDemoTableRow[];
+
+  /**
+   * Unique ID used for form elements.
+   */
+  private _uniqueId = Math.random()
+    .toString(36)
+    .slice(2);
+
+  /**
+   * @param lhs A value.
+   * @param rhs Another value.
+   * @returns
+   *   * `0` if the given two values are equal
+   *   * A negative value to sort `lhs` to an index lower than `rhs`
+   *   * A positive value to sort `rhs` to an index lower than `lhs`
+   */
+  private _compare(lhs, rhs) {
+    if (typeof lhs === 'number' && typeof rhs === 'number') {
+      return lhs - rhs;
+    }
+    return this.collator.compare(lhs, rhs);
+  }
+
+  /**
+   * Handles an event to change in selection of rows, fired from `<bx-table-row>`.
+   * @param event The event.
+   */
+  private _handleChangeSelection({ defaultPrevented, detail, target }: CustomEvent) {
+    if (!defaultPrevented) {
+      const { rowId: changedRowId } = (target as HTMLElement).dataset;
+      const { selected } = detail;
+      const { _rows: oldRows } = this;
+      this._rows = this.rows!.map(row => (Number(changedRowId) !== row.id ? row : { ...row, selected }));
+      this.requestUpdate('_rows', oldRows);
+    }
+  }
+
+  /**
+   * Handles an event to change in selection of all rows, fired from `<bx-table-header-row>`.
+   * @param event The event.
+   */
+  private _handleChangeSelectionAll({ defaultPrevented, detail }: CustomEvent) {
+    if (!defaultPrevented) {
+      const { selected } = detail;
+      const { _rows: oldRows } = this;
+      this._rows = this._rows!.map(row => ({ ...row, selected }));
+      this.requestUpdate('_rows', oldRows);
+    }
+  }
+
+  /**
+   * Handles an event to sort rows, fired from `<bx-table-header-cell>`.
+   * @param event The event.
+   */
+  private _handleChangeSort({ defaultPrevented, detail, target }: CustomEvent) {
+    if (!defaultPrevented) {
+      const { columnId } = (target as HTMLElement).dataset;
+      const { sortDirection: direction } = detail;
+      const { _sortInfo: oldSortInfo } = this;
+      if (direction === TABLE_SORT_DIRECTION.NONE && columnId !== 'name') {
+        // Resets the sorting, given non-primary sorting column has got in non-sorting state
+        this._sortInfo = this.sortInfo;
+      } else {
+        // Sets the sorting as user desires
+        this._sortInfo = {
+          columnId: columnId!,
+          direction,
+        };
+      }
+      this.requestUpdate('_sortInfo', oldSortInfo);
+    }
+  }
+
+  /**
+   * The g11n collator to use.
+   */
+  @property({ attribute: false })
+  collator = new Intl.Collator();
+
+  /**
+   * Data table columns.
+   */
+  @property({ attribute: false })
+  columns?: TDemoTableColumn[];
+
+  /**
+   * Data table rows.
+   */
+  @property({ attribute: false })
+  rows?: TDemoTableRow[];
+
+  /**
+   * Table sorting info.
+   */
+  @property({ attribute: false })
+  sortInfo?: TDemoSortInfo;
+
+  /**
+   * `true` if the the table should support selection UI. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
+  hasSelection = false;
+
+  /**
+   * `true` if the the table should use the compact version of the UI. Corresponds to the attribute with the same name.
+   */
+  @property({ reflect: true })
+  size = TABLE_SIZE.REGULAR;
+
+  shouldUpdate(changedProperties) {
+    if (changedProperties.has('sortInfo')) {
+      this._sortInfo = this.sortInfo;
+    }
+    if (changedProperties.has('rows')) {
+      this._rows = this.rows;
+    }
+    return true;
+  }
+
+  render() {
+    const { id: elementId, hasSelection, size, columns, _rows: rows } = this;
+    const selectionAllName = !hasSelection ? undefined : `__bx-ce-demo-data-table_select-all_${elementId || this._uniqueId}`;
+    const selectedAll = rows!.every(({ selected }) => selected!);
+    const { columnId: sortColumnId, direction: sortDirection } = this._sortInfo!;
+    const sortedRows =
+      sortDirection === TABLE_SORT_DIRECTION.NONE
+        ? rows!.slice()
+        : rows!
+            .slice()
+            .sort(
+              (lhs, rhs) =>
+                (this.constructor as typeof BXCEDemoDataTable).collationFactors[sortDirection] *
+                this._compare(lhs[sortColumnId!], rhs[sortColumnId!])
+            );
+    return html`
+      <bx-data-table
+        ?has-selection=${hasSelection}
+        @bx-table-row-change-selection=${this._handleChangeSelection}
+        @bx-table-change-selection-all=${this._handleChangeSelectionAll}
+        @bx-table-header-cell-sort=${this._handleChangeSort}
+      >
+        <bx-table size="${size}">
+          <bx-table-head>
+            <bx-table-header-row
+              ?selected=${selectedAll}
+              selection-name=${ifDefined(selectionAllName)}
+              selection-value=${ifDefined(selectionAllName)}
+            >
+              ${repeat(
+                columns!,
+                ({ id: columnId }) => columnId,
+                ({ id: columnId, sortCycle, title }) => {
+                  const sortDirectionForThisCell =
+                    sortCycle && (columnId === sortColumnId ? sortDirection : TABLE_SORT_DIRECTION.NONE);
+                  return html`
+                    <bx-table-header-cell
+                      sort-cycle="${ifDefined(sortCycle)}"
+                      sort-direction="${ifDefined(sortDirectionForThisCell)}"
+                      data-column-id="${columnId}"
+                    >
+                      ${title}
+                    </bx-table-header-cell>
+                  `;
+                }
+              )}
+            </bx-table-header-row>
+          </bx-table-head>
+          <bx-table-body>
+            ${repeat(
+              sortedRows,
+              ({ id: rowId }) => rowId,
+              row => {
+                const { id: rowId, selected } = row;
+                const selectionName = !hasSelection
+                  ? undefined
+                  : `__bx-ce-demo-data-table_${elementId || this._uniqueId}_${rowId}`;
+                const selectionValue = !hasSelection ? undefined : 'selected';
+                return html`
+                  <bx-table-row
+                    ?selected=${hasSelection && selected}
+                    selection-name="${ifDefined(selectionName)}"
+                    selection-value="${ifDefined(selectionValue)}"
+                    data-row-id="${rowId}"
+                  >
+                    ${repeat(
+                      columns!,
+                      ({ id: columnId }) => columnId,
+                      ({ id: columnId }) => html`
+                        <bx-table-cell>${row[columnId]}</bx-table-cell>
+                      `
+                    )}
+                  </bx-table-row>
+                `;
+              }
+            )}
+          </bx-table-body>
+        </bx-table>
+      </bx-data-table>
+    `;
+  }
+
+  /**
+   * The map of how sorting direction affects sorting order.
+   */
+  static collationFactors = {
+    [TABLE_SORT_DIRECTION.ASCENDING]: 1,
+    [TABLE_SORT_DIRECTION.DESCENDING]: -1,
+  };
+}
+
+const sizes = {
+  [`Compact size (${TABLE_SIZE.COMPACT})`]: TABLE_SIZE.COMPACT,
+  [`Short size (${TABLE_SIZE.SHORT})`]: TABLE_SIZE.SHORT,
+  [`Regular size (${TABLE_SIZE.REGULAR})`]: TABLE_SIZE.REGULAR,
+  [`Tall size (${TABLE_SIZE.TALL})`]: TABLE_SIZE.TALL,
+};
+
+const createProps = ({ sortable }: { sortable?: boolean } = {}) => {
+  const hasSelection = sortable && boolean('Supports selection feature (has-selection)', false);
+  return {
+    hasSelection,
+    size: select('Table size (size)', sizes, TABLE_SIZE.REGULAR),
+    disableChangeSelection:
+      hasSelection &&
+      boolean(
+        'Disable user-initiated change in selection ' +
+          '(Call event.preventDefault() in bx-table-row-change-selection/bx-table-change-selection-all events)',
+        false
+      ),
+    disableChangeSort:
+      sortable &&
+      boolean(
+        'Disable user-initiated change in sorting ' +
+          '(Call event.preventDefault() in bx-table-row-change-selection/bx-table-change-selection-all events)',
+        false
+      ),
+  };
+};
+
+storiesOf('Data table', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    const { size } = createProps();
+    return html`
+      <bx-data-table>
+        <bx-table size="${size}">
+          <bx-table-head>
+            <bx-table-header-row>
+              <bx-table-header-cell>Name</bx-table-header-cell>
+              <bx-table-header-cell>Protocol</bx-table-header-cell>
+              <bx-table-header-cell>Port</bx-table-header-cell>
+              <bx-table-header-cell>Rule</bx-table-header-cell>
+              <bx-table-header-cell>Attached Groups</bx-table-header-cell>
+              <bx-table-header-cell>Status</bx-table-header-cell>
+            </bx-table-header-row>
+          </bx-table-head>
+          <bx-table-body>
+            <bx-table-row>
+              <bx-table-cell>Load Balancer 1</bx-table-cell>
+              <bx-table-cell>HTTP</bx-table-cell>
+              <bx-table-cell>80</bx-table-cell>
+              <bx-table-cell>Round Robin</bx-table-cell>
+              <bx-table-cell>Maureen's VM Groups</bx-table-cell>
+              <bx-table-cell>Active</bx-table-cell>
+            </bx-table-row>
+            <bx-table-row>
+              <bx-table-cell>Load Balancer 2</bx-table-cell>
+              <bx-table-cell>HTTP</bx-table-cell>
+              <bx-table-cell>80</bx-table-cell>
+              <bx-table-cell>Round Robin</bx-table-cell>
+              <bx-table-cell>Maureen's VM Groups</bx-table-cell>
+              <bx-table-cell>Active</bx-table-cell>
+            </bx-table-row>
+            <bx-table-row>
+              <bx-table-cell>Load Balancer 3</bx-table-cell>
+              <bx-table-cell>HTTP</bx-table-cell>
+              <bx-table-cell>80</bx-table-cell>
+              <bx-table-cell>Round Robin</bx-table-cell>
+              <bx-table-cell>Maureen's VM Groups</bx-table-cell>
+              <bx-table-cell>Active</bx-table-cell>
+            </bx-table-row>
+          </bx-table-body>
+        </bx-table>
+      </bx-data-table>
+    `;
+  })
+  .add('Sortable', () => {
+    const { hasSelection, size, disableChangeSelection, disableChangeSort } = createProps({ sortable: true });
+    const beforeChangeSelectionAction = action('bx-table-row-change-selection');
+    const beforeChangeSelectionAllAction = action('bx-table-change-selection-all');
+    const beforeChangeSelectionHandler = {
+      handleEvent(event: CustomEvent) {
+        if (event.type === 'bx-table-change-selection-all') {
+          beforeChangeSelectionAllAction(event);
+        } else {
+          beforeChangeSelectionAction(event);
+        }
+        if (disableChangeSelection) {
+          event.preventDefault();
+        }
+      },
+      capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
+    };
+    const beforeChangeSortAction = action('bx-table-header-cell-sort');
+    const beforeChangeSortHandler = {
+      handleEvent(event: CustomEvent) {
+        beforeChangeSortAction(event);
+        if (disableChangeSort) {
+          event.preventDefault();
+        }
+      },
+      capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
+    };
+    return html`
+      <!-- Refer to <bx-ce-demo-data-table> implementation at the top for details -->
+      <bx-ce-demo-data-table
+        .columns=${demoColumns}
+        .rows=${demoRows}
+        .sortInfo=${demoSortInfo}
+        ?has-selection=${hasSelection}
+        size="${size}"
+        @bx-table-row-change-selection=${beforeChangeSelectionHandler}
+        @bx-table-change-selection-all=${beforeChangeSelectionHandler}
+        @bx-table-header-cell-sort=${beforeChangeSortHandler}
+      >
+      </bx-ce-demo-data-table>
+    `;
+  });

--- a/src/components/data-table/data-table.scss
+++ b/src/components/data-table/data-table.scss
@@ -1,0 +1,15 @@
+$css--plex: true !default;
+
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/type/font-family';
+@import 'carbon-components/scss/components/checkbox/checkbox';
+
+@import 'carbon-components/scss/components/data-table/data-table-action';
+@import 'carbon-components/scss/components/data-table/data-table-core';
+@import 'carbon-components/scss/components/data-table/data-table-expandable';
+@import 'carbon-components/scss/components/data-table/data-table-inline-edit';
+@import 'carbon-components/scss/components/data-table/data-table-skeleton';
+
+@import 'table-core';
+@import 'table-sizes';
+@import 'table-selection';
+@import 'table-sort';

--- a/src/components/data-table/data-table.ts
+++ b/src/components/data-table/data-table.ts
@@ -1,0 +1,21 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, customElement, LitElement } from 'lit-element';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Data table container.
+ */
+@customElement(`${prefix}-data-table` as any)
+class BXDataTable extends LitElement {
+  render() {
+    return html`
+      <section class="${prefix}--data-table_inner-container"><slot></slot></section>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXDataTable;

--- a/src/components/data-table/stories/data.ts
+++ b/src/components/data-table/stories/data.ts
@@ -1,0 +1,67 @@
+import { TABLE_SORT_DIRECTION } from '../table-header-cell';
+import { TDemoTableColumn, TDemoTableRow, TDemoSortInfo } from './types';
+
+export const columns: TDemoTableColumn[] = [
+  {
+    id: 'name',
+    title: 'Name',
+    sortCycle: 'bi-states-from-ascending',
+  },
+  {
+    id: 'protocol',
+    title: 'Protocol',
+  },
+  {
+    id: 'port',
+    title: 'Port',
+    sortCycle: 'tri-states-from-ascending',
+  },
+  {
+    id: 'rule',
+    title: 'Rule',
+  },
+  {
+    id: 'attachedGroups',
+    title: 'Attached Groups',
+  },
+  {
+    id: 'status',
+    title: 'Status',
+  },
+];
+
+export const rows: TDemoTableRow[] = [
+  {
+    id: 1,
+    name: 'Load Balancer 1',
+    protocol: 'HTTP',
+    port: 80,
+    rule: 'Round Robin',
+    attachedGroups: "Maureen's VM Groups",
+    status: 'Active',
+  },
+  {
+    id: 2,
+    name: 'Load Balancer 2',
+    protocol: 'HTTPS',
+    port: 443,
+    rule: 'Round Robin',
+    attachedGroups: "Maureen's VM Groups",
+    status: 'Active',
+  },
+  {
+    id: 3,
+    selected: true,
+    name: 'Load Balancer 3',
+    protocol: 'HTTP',
+    port: 80,
+    rule: 'Round Robin',
+    attachedGroups: "Maureen's VM Groups",
+    status: 'Active',
+  },
+];
+
+export const sortInfo: TDemoSortInfo = {
+  columnId: 'name',
+  direction: TABLE_SORT_DIRECTION.ASCENDING,
+};

--- a/src/components/data-table/stories/types.ts
+++ b/src/components/data-table/stories/types.ts
@@ -1,0 +1,27 @@
+import { TABLE_SORT_DIRECTION } from '../table-header-cell';
+
+/**
+ * Example data structure of data table column.
+ */
+export type TDemoTableColumn = {
+  id: string;
+  title: string;
+  sortCycle?: string;
+};
+
+/**
+ * Example data structure of data table row.
+ */
+export type TDemoTableRow = {
+  id: number;
+  selected?: boolean;
+  [key: string]: any;
+};
+
+/**
+ * Example structure of table sorting info.
+ */
+export type TDemoSortInfo = {
+  columnId: string;
+  direction: TABLE_SORT_DIRECTION;
+};

--- a/src/components/data-table/table-body.ts
+++ b/src/components/data-table/table-body.ts
@@ -1,0 +1,28 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, customElement, LitElement } from 'lit-element';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Data table header.
+ */
+@customElement(`${prefix}-table-body` as any)
+class BXTableBody extends LitElement {
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'rowgroup');
+    }
+    super.connectedCallback();
+  }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXTableBody;

--- a/src/components/data-table/table-cell.ts
+++ b/src/components/data-table/table-cell.ts
@@ -1,0 +1,28 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, customElement, LitElement } from 'lit-element';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Data table cell.
+ */
+@customElement(`${prefix}-table-cell` as any)
+class BXTableCell extends LitElement {
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'cell');
+    }
+    super.connectedCallback();
+  }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXTableCell;

--- a/src/components/data-table/table-head.ts
+++ b/src/components/data-table/table-head.ts
@@ -1,0 +1,28 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, customElement, LitElement } from 'lit-element';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Data table header.
+ */
+@customElement(`${prefix}-table-head` as any)
+class BXTableHead extends LitElement {
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'rowgroup');
+    }
+    super.connectedCallback();
+  }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  static styles = styles;
+}
+
+export default BXTableHead;

--- a/src/components/data-table/table-header-cell.ts
+++ b/src/components/data-table/table-header-cell.ts
@@ -1,0 +1,180 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, property, customElement, LitElement } from 'lit-element';
+import Arrows16 from '@carbon/icons/es/arrows/16';
+import ArrowDown16 from '@carbon/icons/es/arrow--down/16';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Table sort state.
+ */
+export enum TABLE_SORT_DIRECTION {
+  /**
+   * Not sorted.
+   */
+  NONE = 'none',
+
+  /**
+   * Sorted ascendingly.
+   */
+  ASCENDING = 'ascending',
+
+  /**
+   * Sorted descendingly.
+   */
+  DESCENDING = 'descending',
+}
+
+/**
+ * Table sort cycle.
+ */
+export enum TABLE_SORT_CYCLE {
+  BI_STATES_FROM_ASCENDING = 'bi-states-from-ascending',
+  BI_STATES_FROM_DESCENDING = 'bi-states-from-descending',
+  TRI_STATES_FROM_ASCENDING = 'tri-states-from-ascending',
+  TRI_STATES_FROM_DESCENDING = 'tri-states-from-descending',
+}
+
+/**
+ * Mapping of table sort cycles to table sort states.
+ */
+export const TABLE_SORT_CYCLES = {
+  [TABLE_SORT_CYCLE.BI_STATES_FROM_ASCENDING]: [TABLE_SORT_DIRECTION.ASCENDING, TABLE_SORT_DIRECTION.DESCENDING],
+  [TABLE_SORT_CYCLE.BI_STATES_FROM_DESCENDING]: [TABLE_SORT_DIRECTION.DESCENDING, TABLE_SORT_DIRECTION.ASCENDING],
+  [TABLE_SORT_CYCLE.TRI_STATES_FROM_ASCENDING]: [
+    TABLE_SORT_DIRECTION.NONE,
+    TABLE_SORT_DIRECTION.ASCENDING,
+    TABLE_SORT_DIRECTION.DESCENDING,
+  ],
+  [TABLE_SORT_CYCLE.TRI_STATES_FROM_DESCENDING]: [
+    TABLE_SORT_DIRECTION.NONE,
+    TABLE_SORT_DIRECTION.DESCENDING,
+    TABLE_SORT_DIRECTION.ASCENDING,
+  ],
+};
+
+/**
+ * Data table header cell.
+ */
+@customElement(`${prefix}-table-header-cell` as any)
+class BXTableHeaderCell extends LitElement {
+  /**
+   * Handles `click` event on the sort button.
+   * @param event The event.
+   */
+  private _handleClickSortButton() {
+    const nextSortDirection = this._getNextSort();
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      detail: {
+        oldSortDirection: this.sortDirection,
+        sortDirection: nextSortDirection,
+      },
+    };
+    const constructor = this.constructor as typeof BXTableHeaderCell;
+    if (this.dispatchEvent(new CustomEvent(constructor.eventBeforeSort, init))) {
+      this.sortActive = true;
+      this.sortDirection = nextSortDirection;
+    }
+  }
+
+  /**
+   * Handles `slotchange` event.
+   * @param event The event.
+   */
+  private _handleSlotChange() {
+    this.requestUpdate();
+  }
+
+  /**
+   * @returns The next sort direction.
+   */
+  private _getNextSort() {
+    const { sortCycle = TABLE_SORT_CYCLE.TRI_STATES_FROM_ASCENDING, sortDirection } = this;
+    if (!sortDirection) {
+      throw new TypeError(
+        'Table sort direction is not defined. ' +
+          'Likely that `_getNextSort()` is called with non-sorted table column, which should not happen in regular condition.'
+      );
+    }
+    const directions = (this.constructor as typeof BXTableHeaderCell).TABLE_SORT_CYCLES[sortCycle];
+    const index = directions.indexOf(sortDirection as TABLE_SORT_DIRECTION);
+    if (index < 0) {
+      if (sortDirection === TABLE_SORT_DIRECTION.NONE) {
+        // If the current sort direction is `none` in bi-state sort cycle, returns the first one in the cycle
+        return directions[0];
+      }
+      throw new RangeError(`The given sort state (${sortDirection}) is not found in the given table sort cycle: ${sortCycle}`);
+    }
+    return directions[(index + 1) % directions.length];
+  }
+
+  /**
+   * `true` if this table header cell is of a primary sorting column. Corresponds to `sort-active` attribute.
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'sort-active' })
+  sortActive = false;
+
+  /**
+   * The table sort cycle in use. Corresponds to `sort-cycle` attribute.
+   */
+  @property({ reflect: true, attribute: 'sort-cycle' })
+  sortCycle?: TABLE_SORT_CYCLE;
+
+  /**
+   * The table sort direction. Corresponds to `sort-direction` attribute.
+   * If present, this table header cell will have a sorting UI.
+   */
+  @property({ reflect: true, attribute: 'sort-direction' })
+  sortDirection?: TABLE_SORT_DIRECTION;
+
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'columnheader');
+    }
+    super.connectedCallback();
+  }
+
+  render() {
+    const { sortDirection } = this;
+    if (sortDirection) {
+      const sortIcon =
+        sortDirection === TABLE_SORT_DIRECTION.NONE
+          ? Arrows16({
+              class: `${prefix}--table-sort__icon-unsorted`,
+            })
+          : ArrowDown16({
+              class: `${prefix}--table-sort__icon`,
+            });
+      return html`
+        <button class="${prefix}--table-sort" title="${this.textContent}" @click=${this._handleClickSortButton}>
+          <span class="${prefix}--table-header-label"><slot @slotchange=${this._handleSlotChange}></slot></span>
+          ${sortIcon}
+        </button>
+      `;
+    }
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  /**
+   * The name of the custom event fired before a new sort direction is set upon a user gesture.
+   * Cancellation of this event stops the user-initiated change in sort direction.
+   */
+  static get eventBeforeSort() {
+    return `${prefix}-table-header-cell-sort`;
+  }
+
+  static styles = styles;
+
+  /**
+   * Mapping of table sort cycles to table sort states.
+   */
+  static TABLE_SORT_CYCLES = TABLE_SORT_CYCLES;
+}
+
+export default BXTableHeaderCell;

--- a/src/components/data-table/table-header-row.ts
+++ b/src/components/data-table/table-header-row.ts
@@ -1,0 +1,21 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { customElement } from 'lit-element';
+import BXTableRow from './table-row';
+
+const { prefix } = settings;
+
+/**
+ * Data table header row.
+ */
+@customElement(`${prefix}-table-header-row` as any)
+class BXTableHeaderRow extends BXTableRow {
+  /**
+   * The name of the custom event fired before this row is selected/unselected upon a user gesture.
+   * Cancellation of this event stops the user-initiated change in selection.
+   */
+  static get eventBeforeChangeSelection() {
+    return `${prefix}-table-change-selection-all`;
+  }
+}
+
+export default BXTableHeaderRow;

--- a/src/components/data-table/table-row.ts
+++ b/src/components/data-table/table-row.ts
@@ -1,0 +1,136 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, property, customElement, LitElement } from 'lit-element';
+import ChevronRight16 from '@carbon/icons/es/chevron--right/16';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Data table row.
+ */
+@customElement(`${prefix}-table-row` as any)
+class BXTableRow extends LitElement {
+  /**
+   * Handles `click` event on the check box.
+   * @param event The event.
+   */
+  protected _handleClickSelectionCheckbox(event: Event) {
+    const selected = (event.target as HTMLInputElement).checked;
+    const init = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      detail: {
+        selected,
+      },
+    };
+    const constructor = this.constructor as typeof BXTableRow;
+    if (!this.dispatchEvent(new CustomEvent(constructor.eventBeforeChangeSelection, init))) {
+      this.selected = selected;
+      event.preventDefault();
+    }
+  }
+
+  /**
+   * `true` if this table row should be disabled. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  /**
+   * `true` if this table row should work as an expando. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  section = false;
+
+  /**
+   * `true` if this table row should be selected. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  selected = false;
+
+  /**
+   * The `aria-label` attribute for the `<label>` for selection. Corresponds to `selection-label` attribute.
+   */
+  @property({ attribute: 'selection-label' })
+  selectionLabel = '';
+
+  /**
+   * The `name` attribute for the `<input>` for selection. Corresponds to `selection-name` attribute.
+   * If present, this table row will be a selectable one.
+   */
+  @property({ attribute: 'selection-name' })
+  selectionName = '';
+
+  /**
+   * The `value` attribute for the `<input>` for selection. Corresponds to `selection-value` attribute.
+   */
+  @property({ attribute: 'selection-value' })
+  selectionValue = '';
+
+  connectedCallback() {
+    const table = this.closest((this.constructor as typeof BXTableRow).selectorTable);
+    if (table) {
+      // Propagate `size` attribute from `<bx-table>` until `:host-context()` gets supported in all major browsers
+      this.setAttribute('size', table.getAttribute('size')!);
+    }
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'row');
+    }
+    super.connectedCallback();
+  }
+
+  render() {
+    const { disabled, section, selected, selectionLabel, selectionName, selectionValue } = this;
+    const expando = !section
+      ? undefined
+      : html`
+          <div class="${prefix}--table-expand">
+            <button class="${prefix}--table-expand__button">
+              ${ChevronRight16({ class: `${prefix}--table-expand__svg` })}
+            </button>
+          </div>
+        `;
+    // Using `@click` instead of `@change` to support `.preventDefault()`
+    const selection = !selectionName
+      ? undefined
+      : html`
+          <div class="${prefix}--table-column-checkbox">
+            ${html`
+              <input
+                id="selection"
+                class="${prefix}--checkbox"
+                type="checkbox"
+                value="${selectionValue}"
+                name="${selectionName}"
+                ?disabled="${disabled}"
+                .checked=${selected}
+                @click=${this._handleClickSelectionCheckbox}
+              />
+              <label for="selection" class="${prefix}--checkbox-label" aria-label="${selectionLabel}"></label>
+            `}
+          </div>
+        `;
+
+    return html`
+      ${expando}${selection}<slot></slot>
+    `;
+  }
+
+  /**
+   * The name of the custom event fired before this row is selected/unselected upon a user gesture.
+   * Cancellation of this event stops the user-initiated change in selection.
+   */
+  static get eventBeforeChangeSelection() {
+    return `${prefix}-table-row-change-selection`;
+  }
+
+  /**
+   * The CSS selector to find the table.
+   */
+  static selectorTable = `${prefix}-table`;
+
+  static styles = styles;
+}
+
+export default BXTableRow;

--- a/src/components/data-table/table.ts
+++ b/src/components/data-table/table.ts
@@ -1,0 +1,80 @@
+import settings from 'carbon-components/es/globals/js/settings';
+import { html, property, customElement, LitElement } from 'lit-element';
+import styles from './data-table.scss';
+
+const { prefix } = settings;
+
+/**
+ * Table size.
+ */
+export enum TABLE_SIZE {
+  /**
+   * Compact size.
+   */
+  COMPACT = 'compact',
+
+  /**
+   * Short size.
+   */
+  SHORT = 'short',
+
+  /**
+   * Regular size.
+   */
+  REGULAR = 'regular',
+
+  /**
+   * Tall size.
+   */
+  TALL = 'tall',
+}
+
+/**
+ * Data table.
+ */
+@customElement(`${prefix}-table` as any)
+class BXTable extends LitElement {
+  /**
+   * `true` if the the table should use the compact version of the UI. Corresponds to the attribute with the same name.
+   */
+  @property({ reflect: true })
+  size = TABLE_SIZE.REGULAR;
+
+  /**
+   * `true` if this table should support sorting. Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  sort = false;
+
+  connectedCallback() {
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'table');
+    }
+    super.connectedCallback();
+  }
+
+  attributeChangedCallback(name, old, current) {
+    if (name === 'size') {
+      // Propagate `size` attribute to descendants until `:host-context()` gets supported in all major browsers
+      Array.prototype.forEach.call(this.querySelectorAll((this.constructor as typeof BXTable).selectorRowsWithHeader), elem => {
+        elem.setAttribute('size', current);
+      });
+    }
+    super.attributeChangedCallback(name, old, current);
+  }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  /**
+   * The CSS selector to find the rows, including header rows.
+   */
+  static selectorRowsWithHeader = `${prefix}-table-header-row,${prefix}-table-row`;
+
+  static styles = styles;
+}
+
+export default BXTable;

--- a/src/components/structured-list/structured-list-row.ts
+++ b/src/components/structured-list/structured-list-row.ts
@@ -126,7 +126,6 @@ class BXStructuredListRow extends HostListenerMixin(LitElement) {
 
   /**
    * The `value` attribute for the `<input>` for selection. Corresponds to `selection-value` attribute.
-   * If present, this structured list row will be a selectable one.
    */
   @property({ attribute: 'selection-value' })
   selectionValue = '';


### PR DESCRIPTION
This change re-implements `carbon-components` style code temporarily for now, from the following reasons:

* Many of the style rules are not supported by Sass `@extend`
* There are some open questions in `carbon-components` style code, and fiddling with an alternate implementation may help solving those questions

Please see https://github.com/asudoh/carbon-custom-elements/blob/75cb84052984644ab4ad0bd0910982c5e6a8f686/src/components/data-table/README.md for the basic notion of how the data table in `carbon-custom-elements` is implemented. Please don't hesitate to bring up if there are any questions. Thanks!