### PR TITLE
chore(devenv): fix theme switcher being reset

### DIFF
--- a/.storybook/addon-carbon-theme/components/Panel.js
+++ b/.storybook/addon-carbon-theme/components/Panel.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@storybook/components';
 import { CURRENT_THEME } from '../shared';
@@ -7,9 +7,12 @@ import { CURRENT_THEME } from '../shared';
  * Storybook add-on panel for Carbon theme switcher.
  */
 const Panel = ({ api, active }) => {
+  const [currentTheme, setCurrentTheme] = useState('white');
   const handleChange = useCallback(
     event => {
-      api.getChannel().emit(CURRENT_THEME, event.target.value);
+      const { value } = event.target;
+      setCurrentTheme(value);
+      api.getChannel().emit(CURRENT_THEME, value);
     },
     [api]
   );
@@ -17,7 +20,7 @@ const Panel = ({ api, active }) => {
     active && (
       <Form>
         <Form.Field label="Select Carbon theme:">
-          <Form.Select initialValue="white" name="carbon-theme" onChange={handleChange} size="flex">
+          <Form.Select name="carbon-theme" value={currentTheme} onChange={handleChange} size="flex">
             <option key="white" value="white">
               white
             </option>


### PR DESCRIPTION
This change fixes theme switcher selection being reset when user clicks on another Storybook add-on tab and then goes back to Carbon theme add-on tab.