### PR TITLE
fix(browser-support): misc IE fixes

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = ({ config, mode }) => {
     },
     {
       test: /@carbon[\\/]icons/i,
-      use: [require.resolve('../svg-result-carbon-icon-loader')],
+      use: [...babelLoaderRule.use, require.resolve('../svg-result-carbon-icon-loader')],
     },
     {
       test: /-story\.[jt]sx?$/,

--- a/src/polyfills/element-closest.js
+++ b/src/polyfills/element-closest.js
@@ -2,7 +2,7 @@ if (typeof Element.prototype.closest !== 'function') {
   Element.prototype.closest = function closestElement(selector) {
     const doc = this.ownerDocument;
     for (let traverse = this; traverse && traverse !== doc; traverse = traverse.parentNode) {
-      if (traverse.matches(selector)) {
+      if (traverse.nodeType === Node.ELEMENT_NODE && traverse.matches(selector)) {
         return traverse;
       }
     }


### PR DESCRIPTION
This change fixes the following issues:

* JavaScript error when `Element.prototype.closest()` is called in shady DOM
* Non-transpiled `lit-html` code generated from `@carbon/icons`