### PR TITLE
feat(modal): keyboard nav enhancements

### DIFF
--- a/src/globals/mixins/host-listener.ts
+++ b/src/globals/mixins/host-listener.ts
@@ -3,7 +3,7 @@ import on from 'carbon-components/es/globals/js/misc/on';
 /**
  * The format for the event name used by `@HostListener` decorator.
  */
-const EVENT_NAME_FORMAT = /^((document|window):)?(\w+)$/;
+const EVENT_NAME_FORMAT = /^((document|window|shadowRoot):)?(\w+)$/;
 
 /**
  * @param Base The base class.
@@ -36,6 +36,7 @@ const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
             {
               document: this.ownerDocument,
               window: this.ownerDocument!.defaultView,
+              shadowRoot: this.shadowRoot,
             }[targetName] || this;
 
           // Determines the event type for delegated `focus`/`blur` event


### PR DESCRIPTION
This changes adds the following features to `<bx-modal>`:

* Introduces focus-pop behavior
* Traps focus by itself, for its focus-wrap feature

This change also adds a feature to `@HostListener()` decorator to hook event listeners on shadow root, which is useful if we want to get events that are not re-targeted.