### PR TITLE
chore(build): remove TS toolchain from build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,9 @@
   "plugins": [
     "./babel-plugin-supercall",
     "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-proposal-decorators", { "decoratorsBeforeExport": true }],
     ["@babel/plugin-proposal-object-rest-spread", { "useBuiltIns": true }],
-    "@babel/plugin-transform-runtime"
+    "@babel/plugin-transform-runtime",
+    "@babel/plugin-transform-typescript"
   ]
 }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = ({ config, mode }) => {
     },
     {
       test: /\.ts$/,
-      use: ['babel-loader', 'ts-loader'],
+      use: ['babel-loader'],
     },
     {
       test: /\.scss$/,

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
     "@angular/platform-browser-dynamic": "^8.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/plugin-transform-typescript": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@carbon/icon-helpers": "^10.2.0",
@@ -133,7 +135,6 @@
     "style-loader": "^0.23.0",
     "terser-webpack-plugin": "^1.2.0",
     "through2": "^3.0.0",
-    "ts-loader": "^6.0.0",
     "typescript": "^3.4.0",
     "webpack": "^4.28.0",
     "zone.js": "^0.8.0"

--- a/src/globals/decorators/host-listener.ts
+++ b/src/globals/decorators/host-listener.ts
@@ -1,4 +1,45 @@
 /**
+ * Puts an event listener to an internal table for `@HostListener()`.
+ * @param type
+ *   The event type. Can be prefixed with `document:` or `window:`.
+ *   The event listener is attached to host element's owner document or its default view in such case.
+ * @param options The event listener options.
+ * @param Clazz The target class.
+ * @param name The method name in the given target class that works as the event listener.
+ */
+const setHostListener = (type: string, options: boolean | AddEventListenerOptions, Clazz, name: string) => {
+  const hostListeners = Clazz._hostListeners;
+  if (!hostListeners) {
+    throw new Error('The method `@HostListener()` is defined on has to be of a class that has `HostListerMixin`.');
+  }
+  if (!hostListeners[name]) {
+    hostListeners[name] = {};
+  }
+  hostListeners[name][type] = { options };
+};
+
+/**
+ * @param type
+ *   The event type. Can be prefixed with `document:` or `window:`.
+ *   The event listener is attached to host element's owner document or its default view in such case.
+ * @param options The event listener options.
+ * @param descriptor The original class element descriptor of the event listener method.
+ * @returns The updated class element descriptor with `@HostListener()` decorator.
+ */
+const HostListenerStandard = (type: string, options: boolean | AddEventListenerOptions, descriptor) => {
+  const { kind, key, placement } = descriptor;
+  if (!((kind === 'method' && placement === 'prototype') || (kind === 'field' && placement === 'own'))) {
+    throw new Error('`@HostListener()` must be defined on instance methods, but you may have defined it on static, field, etc.');
+  }
+  return {
+    ...descriptor,
+    finisher(Clazz) {
+      setHostListener(type, options, Clazz, key);
+    },
+  };
+};
+
+/**
  * A decorator to add event listener to the host element, or its `document`/`window`, of a custom element.
  * The `target` must extend `HostListenerMixin`.
  * @param type
@@ -6,15 +47,9 @@
  *   The event listener is attached to host element's owner document or its default view in such case.
  * @param options The event listener options.
  */
-const HostListener = (type: string, options?: boolean | AddEventListenerOptions) => (target, listenerName: string) => {
-  const hostListeners = target.constructor._hostListeners;
-  if (!hostListeners) {
-    throw new Error('The method `@HostListener` is defined on has to be of a class that has `HostListerMixin`.');
-  }
-  if (!hostListeners[listenerName]) {
-    hostListeners[listenerName] = {};
-  }
-  hostListeners[listenerName][type] = { options };
-};
+const HostListener = (type: string, options?: boolean | AddEventListenerOptions) => (targetOrDescriptor, name: string) =>
+  typeof name !== 'undefined'
+    ? setHostListener(type, options!, targetOrDescriptor.constructor, name)
+    : HostListenerStandard(type, options!, targetOrDescriptor);
 
 export default HostListener;

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -60,16 +60,6 @@ module.exports = function setupKarma(config) {
                   configFile: path.resolve(__dirname, '..', '.babelrc'),
                 },
               },
-              {
-                loader: 'ts-loader',
-                options: {
-                  ignoreDiagnostics: [6133],
-                  compilerOptions: {
-                    sourceMap: false,
-                    inlineSourceMap: true,
-                  },
-                },
-              },
             ],
           },
           !collectCoverage

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,6 +531,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-decorators" "^7.2.0"
 
+"@babel/plugin-proposal-decorators@^7.0.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz#de9b2a1a8ab0196f378e2a82f10b6e2a36f21cc0"
+  integrity sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-decorators" "^7.2.0"
+
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
@@ -1166,7 +1175,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-typescript@^7.3.2":
+"@babel/plugin-transform-typescript@^7.0.0", "@babel/plugin-transform-typescript@^7.3.2":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz#6d862766f09b2da1cb1f7d505fe2aedab6b7d4b8"
   integrity sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==
@@ -11405,9 +11414,9 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.6.tgz#f39cfedd26213982733ae6b819d3da0e736598d5"
-  integrity sha512-Btng9qVvFsW6FkXYQQK5nEI5i8xdXFDmlKxC7Q8S2Bu5HGWnbQf7ts2kOoxJIrZn5hmw61RZIayAg2zBuJDtyQ==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
+  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -14242,17 +14251,6 @@ trim@0.0.1:
   integrity sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==
   dependencies:
     glob "^7.1.2"
-
-ts-loader@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.0.0.tgz#d489f49410725a12e696ad0b67c33937a7c49147"
-  integrity sha512-lszy+D41R0Te2+loZxADWS+E1+Z55A+i3dFfFie1AZHL++65JRKVDBPQgeWgRrlv5tbxdU3zOtXp8b7AFR6KEg==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
 
 ts-loader@^6.0.1:
   version "6.0.4"


### PR DESCRIPTION
`@HostListener` decorator used to support only with TS coolchain, which is based on legacy decorator spec. This change makes `@HostListener` decorator support one with latest Babel toolchain, which is based on newer decorator spec.

This change allows us to use one transpiler (Babel) to generator the transpiled code, instead of using two transpilers.