### PR TITLE
chore(components): make API exposure consistent

### DIFF
--- a/src/coding-conventions.md
+++ b/src/coding-conventions.md
@@ -4,6 +4,7 @@
 - [Coding conventions](#coding-conventions)
   - [Linters/formatters](#lintersformatters)
   - [TSDoc comments](#tsdoc-comments)
+  - [No kitchen-sink "base" class and using mix-in](#no-kitchen-sink-base-class-and-using-mix-in)
   - [Lifecycle management](#lifecycle-management)
   - [Component styles for different component states/variants](#component-styles-for-different-component-statesvariants)
   - [Customizing components](#customizing-components)
@@ -11,11 +12,18 @@
     - [Component variants with different options](#component-variants-with-different-options)
       - [Areas to make them configurable as component options](#areas-to-make-them-configurable-as-component-options)
       - [Areas where component optinos are _not_ applied](#areas-where-component-optinos-are-_not_-applied)
+    - [Creating inherited components](#creating-inherited-components)
   - [Polymorphism with static properties](#polymorphism-with-static-properties)
   - [Custom events](#custom-events)
+  - [Globalization](#globalization)
+    - [Translation](#translation)
+    - [Collation](#collation)
+  - [Null checks](#null-checks)
+  - [CSS considerations with IE11](#css-considerations-with-ie11)
   - [Custom element registration](#custom-element-registration)
   - [Propagating misc attributes from shadow host to an element in shadow DOM](#propagating-misc-attributes-from-shadow-host-to-an-element-in-shadow-dom)
-    <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Coding conventions
 
@@ -113,6 +121,14 @@ A component variant with different options can be created by creating a derived 
 #### Areas where component optinos are _not_ applied
 
 - CSS classes used in template (Should be done by overriding `.render()` method)
+
+### Creating inherited components
+
+This codebase intends to support the components being inherited, to some extent. e.g. Compoennts with different options described above. To support that, it's easier for all properties/methods exposed as `protected`, but it exposes a risk of the component internals being poked around. The current guideline for using `protected` is the following:
+
+- Ones where override happens within this component library (e.g. `<bx-multi-select>` inheriting `<bx-dropdown>`)
+- Element ID's auto-generation logic
+- (Possibly some more, e.g. ones whose API are stable enough)
 
 ## Polymorphism with static properties
 

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -32,7 +32,7 @@ class BXCheckbox extends LitElement {
   /**
    * Handles `click` event on the `<input>` in the shadow DOM.
    */
-  protected _handleChange() {
+  private _handleChange() {
     const { checked, indeterminate } = this._checkboxNode;
     this.checked = checked;
     this.indeterminate = indeterminate;

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -39,7 +39,7 @@ class BXCEDemoDataTable extends LitElement {
   /**
    * Unique ID used for form elements.
    */
-  private _uniqueId = Math.random()
+  protected _uniqueId = Math.random()
     .toString(36)
     .slice(2);
 

--- a/src/components/data-table/table-row.ts
+++ b/src/components/data-table/table-row.ts
@@ -14,7 +14,7 @@ class BXTableRow extends LitElement {
    * Handles `click` event on the check box.
    * @param event The event.
    */
-  protected _handleClickSelectionCheckbox(event: Event) {
+  private _handleClickSelectionCheckbox(event: Event) {
     const selected = (event.target as HTMLInputElement).checked;
     const init = {
       bubbles: true,

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -20,7 +20,6 @@ class BXModal extends HostListenerMixin(LitElement) {
   /**
    * Handles `click` event on this element.
    * @param event The event.
-   * @private
    */
   @HostListener('click')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
@@ -33,7 +32,6 @@ class BXModal extends HostListenerMixin(LitElement) {
   /**
    * Handles `blur` event on this element.
    * @param event The event.
-   * @private
    */
   @HostListener('blur')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to

--- a/src/components/tile/selectable-tile.ts
+++ b/src/components/tile/selectable-tile.ts
@@ -33,7 +33,7 @@ class BXSelectableTile extends LitElement {
   /**
    * Handles `change` event on the `<input>` in the shadow DOM.
    */
-  protected _handleChange() {
+  private _handleChange() {
     this.selected = this._checkboxNode.checked;
   }
 

--- a/src/components/ui-shell/header-menu-button.ts
+++ b/src/components/ui-shell/header-menu-button.ts
@@ -14,7 +14,7 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-header-menu-button` as any)
 class BXHeaderMenuButton extends LitElement {
-  protected _handleClick() {
+  private _handleClick() {
     const active = !this.active;
     this.active = !active;
     forEach(this.querySelectorAll((this.constructor as typeof BXHeaderMenuButton).selectorNav), nav => {

--- a/src/components/ui-shell/header-menu.ts
+++ b/src/components/ui-shell/header-menu.ts
@@ -17,19 +17,19 @@ class BXHeaderMenu extends HostListenerMixin(LitElement) {
    * The trigger button.
    */
   @query('a')
-  protected _trigger!: HTMLElement;
+  private _trigger!: HTMLElement;
 
   /**
    * Handles `click` event handler on this element.
    */
-  protected _handleClick() {
+  private _handleClick() {
     this._handleUserInitiatedToggle();
   }
 
   /**
    * Handler for the `keydown` event on the trigger button.
    */
-  protected _handleKeydownTrigger({ key }: KeyboardEvent) {
+  private _handleKeydownTrigger({ key }: KeyboardEvent) {
     if (key === 'Esc' || key === 'Escape') {
       this._handleUserInitiatedToggle(false);
     }
@@ -39,7 +39,7 @@ class BXHeaderMenu extends HostListenerMixin(LitElement) {
    * Handles user-initiated toggling the open state.
    * @param [force] If specified, forces the open state to the given one.
    */
-  protected _handleUserInitiatedToggle(force: boolean = !this.expanded) {
+  private _handleUserInitiatedToggle(force: boolean = !this.expanded) {
     this.expanded = force;
     if (!force) {
       this._trigger.focus();
@@ -50,7 +50,8 @@ class BXHeaderMenu extends HostListenerMixin(LitElement) {
    * Handles `blur` event handler on this element.
    */
   @HostListener('blur')
-  protected _handleBlur({ relatedTarget }: FocusEvent) {
+  // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
+  private _handleBlur({ relatedTarget }: FocusEvent) {
     if (!this.contains(relatedTarget as Node)) {
       this.expanded = false;
     }

--- a/src/components/ui-shell/side-nav-link.ts
+++ b/src/components/ui-shell/side-nav-link.ts
@@ -13,7 +13,7 @@ class BXSideNavLink extends LitElement {
   /**
    * Handles `slotchange` event on the `<slot>` for the title icon.
    */
-  protected _handleSlotChangeTitleIcon({ target }) {
+  private _handleSlotChangeTitleIcon({ target }) {
     this.shadowRoot!.getElementById('title-icon-container')!.toggleAttribute('hidden', target.assignedNodes().length === 0);
   }
 

--- a/src/components/ui-shell/side-nav-menu.ts
+++ b/src/components/ui-shell/side-nav-menu.ts
@@ -11,6 +11,10 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-side-nav-menu`)
 class BXSideNavMenu extends LitElement {
+  /**
+   * @param item A menu item.
+   * @returns `true` if the given menu item is active.
+   */
   private isMenuItemActive(item: Node) {
     return (
       typeof (item as Element).matches === 'function' &&
@@ -21,19 +25,19 @@ class BXSideNavMenu extends LitElement {
   /**
    * `true` if this menu has an icon.
    */
-  protected _hasIcon = false;
+  private _hasIcon = false;
 
   /**
    * Handles `click` event on the expando button.
    */
-  protected _handleClickExpando() {
+  private _handleClickExpando() {
     this.expanded = !this.expanded;
   }
 
   /**
    * Handles `slotchange` event on the non-named `<slot>`.
    */
-  protected _handleSlotChange({ target }) {
+  private _handleSlotChange({ target }) {
     const { _hasIcon: hasIcon } = this;
     forEach(target.assignedNodes(), item => {
       item.toggleAttribute((this.constructor as typeof BXSideNavMenu).attribItemHasIcon, hasIcon);
@@ -44,7 +48,7 @@ class BXSideNavMenu extends LitElement {
   /**
    * Handles `slotchange` event on the `<slot>` for the title icon.
    */
-  protected _handleSlotChangeTitleIcon({ target }) {
+  private _handleSlotChangeTitleIcon({ target }) {
     const constructor = this.constructor as typeof BXSideNavMenu;
     const hasIcon = target.assignedNodes().length > 0;
     this._hasIcon = hasIcon;


### PR DESCRIPTION
This change makes the usage of `private`/`protected` a bit more coherent across the codebase. This change also adds a guideline in that area.