### PR TITLE
chore(devenv): fix Storysource for Angular/React

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = ({ config, mode }) => {
       use: [...babelLoaderRule.use, require.resolve('../svg-result-carbon-icon-loader')],
     },
     {
-      test: /-story\.[jt]sx?$/,
+      test: /-story(-(angular|react))?\.[jt]sx?$/,
       use: [
         {
           loader: require.resolve('@storybook/addon-storysource/loader'),


### PR DESCRIPTION
This change fixes broken Storybook `addon-storysource` add-on in Angular/React environment.

Refs #60.