### PR TITLE
chore(build): define Handle interface in src

### DIFF
--- a/src/components/pagination/pagination.ts
+++ b/src/components/pagination/pagination.ts
@@ -5,6 +5,7 @@ import CaretRight24 from '@carbon/icons/lib/caret--right/24';
 import settings from 'carbon-components/es/globals/js/settings';
 import on from 'carbon-components/es/globals/js/misc/on';
 import { forEach } from '../../globals/internal/collection-helpers';
+import Handle from '../../globals/internal/handle';
 import BXPagesSelect from './pages-select';
 import BXPageSizesSelect from './page-sizes-select';
 import styles from './pagination.scss';

--- a/src/globals/internal/handle.ts
+++ b/src/globals/internal/handle.ts
@@ -1,0 +1,10 @@
+/**
+ * An object to keep track of things that can be cleaned up.
+ */
+export default interface Handle {
+  /**
+   * Releases the thing that this object is keeping track of.
+   * For example, if this `Handle` is keeping track of an event listener, this `release()` method removes the event listener.
+   */
+  release(): null;
+}

--- a/src/globals/mixins/host-listener.ts
+++ b/src/globals/mixins/host-listener.ts
@@ -1,4 +1,5 @@
 import on from 'carbon-components/es/globals/js/misc/on';
+import Handle from '../internal/handle';
 
 /**
  * The format for the event name used by `@HostListener` decorator.

--- a/src/globals/wrappers/createReactCustomElementType.ts
+++ b/src/globals/wrappers/createReactCustomElementType.ts
@@ -1,5 +1,6 @@
 import React, { Component, createElement, forwardRef } from 'react';
 import on from 'carbon-components/es/globals/js/misc/on';
+import Handle from '../internal/handle';
 
 /**
  * A descriptor for a React event prop of a custom element.

--- a/src/typings/vendor.d.ts
+++ b/src/typings/vendor.d.ts
@@ -1,13 +1,4 @@
-/**
- * An object to keep track of things that can be cleaned up.
- */
-interface Handle {
-  /**
-   * Releases the thing that this object is keeping track of.
-   * For example, if this `Handle` is keeping track of an event listener, this `release()` method removes the event listener.
-   */
-  release(): null;
-}
+import Handle from '../globals/internal/handle';
 
 declare module 'carbon-components/es/globals/js/settings' {
   const settings: {

--- a/tests/utils/event-manager.ts
+++ b/tests/utils/event-manager.ts
@@ -1,4 +1,5 @@
 import on from 'carbon-components/es/globals/js/misc/on';
+import Handle from '../../src/globals/internal/handle';
 
 interface CustomEventListener {
   (evt: CustomEvent): void;


### PR DESCRIPTION
`Handle` used to be defined in `vendor.d.ts` given it originally comes from `carbon-components` library, but given `carbon-custom-elements` does not ship `vendor.d.ts` as of today it causes a TS compilation error due to missing `Handle` references from the `.d.ts` code in `carbon-custom-elements`.

Shipping `vendor.d.ts` was a possible option, but given `Handle` is the only interface that requires "re-export", defining `Handle` by our own made more sense for now.