### PR TITLE
chore(components): clean-up private/protected

### DIFF
--- a/src/coding-conventions.md
+++ b/src/coding-conventions.md
@@ -19,9 +19,11 @@
     - [Translation](#translation)
     - [Collation](#collation)
   - [Null checks](#null-checks)
+  - [Updating view upon change in `private`/`protected` properties](#updating-view-upon-change-in-privateprotected-properties)
   - [CSS considerations with IE11](#css-considerations-with-ie11)
   - [Custom element registration](#custom-element-registration)
   - [Propagating misc attributes from shadow host to an element in shadow DOM](#propagating-misc-attributes-from-shadow-host-to-an-element-in-shadow-dom)
+  - [Private properties](#private-properties)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -208,3 +210,7 @@ It may not be desirable in two scenarios:
 Some components, e.g. `<bx-btn>`, simply represent the content in shadow DOM, e.g. `<button>` in it. It's sometimes desiable for applications to have control of attributes in `<button>`, for example, adding `data-` attributes there.
 
 In such case, we let consumer create a derived class. For example, its `.attributeChangedCallback()` can propagate `<bx-btn>`'s attribute to `<button>` in it.
+
+## Private properties
+
+This codebase tends to make all component class/instance propereties `private` unless they serve API purpose. This codebase makes some of them `protected` to support inherited components.

--- a/src/coding-conventions.md
+++ b/src/coding-conventions.md
@@ -213,4 +213,4 @@ In such case, we let consumer create a derived class. For example, its `.attribu
 
 ## Private properties
 
-This codebase tends to make all component class/instance propereties `private` unless they serve API purpose. This codebase makes some of them `protected` to support inherited components.
+This codebase tends to make all component class/instance properties `private` unless they serve API purpose. This codebase makes some of them `protected` to support inherited components.

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -12,19 +12,19 @@ const { prefix } = settings;
 @customElement(`${prefix}-checkbox`)
 class BXCheckbox extends LitElement {
   @query('input')
-  _checkboxNode!: HTMLInputElement;
+  private _checkboxNode!: HTMLInputElement;
 
   /**
    * Unique ID used for ID refs.
    */
-  protected _uniqueId = Math.random()
+  private _uniqueId = Math.random()
     .toString(36)
     .slice(2);
 
   /**
    * The element ID for the check box.
    */
-  protected get _checkboxId() {
+  private get _checkboxId() {
     const { id: elementId, _uniqueId: uniqueId } = this;
     return `__bx-ce-selectable-tile_${elementId || uniqueId}`;
   }

--- a/src/components/pagination/page-sizes-select.ts
+++ b/src/components/pagination/page-sizes-select.ts
@@ -11,19 +11,19 @@ const { prefix } = settings;
 @customElement(`${prefix}-page-sizes-select`)
 class BXPageSizesSelect extends LitElement {
   @query('select')
-  protected _selectNode!: HTMLSelectElement;
+  private _selectNode!: HTMLSelectElement;
 
   /**
    * Unique ID used for ID refs.
    */
-  protected _uniqueId = Math.random()
+  private _uniqueId = Math.random()
     .toString(36)
     .slice(2);
 
   /**
    * The element ID for the select box.
    */
-  protected get _selectId() {
+  private get _selectId() {
     const { id: elementId, _uniqueId: uniqueId } = this;
     return `__bx-ce-page-sizes-select_${elementId || uniqueId}`;
   }
@@ -31,7 +31,7 @@ class BXPageSizesSelect extends LitElement {
   /**
    * Handles `change` event on the `<select>` to select page size.
    */
-  protected _handleChange({ target }: Event) {
+  private _handleChange({ target }: Event) {
     const value = Number((target as HTMLSelectElement).value);
     this.dispatchEvent(
       new CustomEvent((this.constructor as typeof BXPageSizesSelect).eventAfterChange, {
@@ -49,7 +49,7 @@ class BXPageSizesSelect extends LitElement {
    * Handles `slotchange` event for the `<slot>` for `<options>`.
    * @param event The event.
    */
-  protected _handleSlotChange({ target }: Event) {
+  private _handleSlotChange({ target }: Event) {
     const { _selectNode: selectNode } = this;
     while (selectNode.firstChild) {
       selectNode.removeChild(selectNode.firstChild);

--- a/src/components/pagination/pagination.ts
+++ b/src/components/pagination/pagination.ts
@@ -20,17 +20,17 @@ class BXPagination extends LitElement {
   /**
    * The handle for the listener of `${prefix}-pages-select-changed` event.
    */
-  protected _hChangePage: Handle | null = null;
+  private _hChangePage: Handle | null = null;
 
   /**
    * The handle for the listener of `${prefix}-page-sizes-select-changed` event.
    */
-  protected _hChangePageSize: Handle | null = null;
+  private _hChangePageSize: Handle | null = null;
 
   /**
    * @returns Page status text.
    */
-  protected _renderStatusText() {
+  private _renderStatusText() {
     const { start, pageSize, total, formatStatusWithDeterminateTotal, formatStatusWithIndeterminateTotal } = this;
     const end = start + pageSize - 1;
     const format = typeof total === 'undefined' ? formatStatusWithIndeterminateTotal : formatStatusWithDeterminateTotal;
@@ -42,7 +42,7 @@ class BXPagination extends LitElement {
    * Handles user-initiated change in the row number the current page starts with.
    * @param start The new current row number, index that starts with zero.
    */
-  protected _handleUserInitiatedChangeStart(start: number) {
+  private _handleUserInitiatedChangeStart(start: number) {
     this.start = start;
     this.dispatchEvent(
       new CustomEvent((this.constructor as typeof BXPagination).eventAfterChangeCurrent, {
@@ -58,7 +58,7 @@ class BXPagination extends LitElement {
   /**
    * Handles `click` event on the previous button.
    */
-  protected _handleClickPrevButton() {
+  private _handleClickPrevButton() {
     const { start: oldStart, pageSize } = this;
     this._handleUserInitiatedChangeStart(Math.max(oldStart - pageSize, 0));
   }
@@ -66,7 +66,7 @@ class BXPagination extends LitElement {
   /**
    * Handles `click` event on the next button.
    */
-  protected _handleClickNextButton() {
+  private _handleClickNextButton() {
     const { start: oldStart, pageSize, total } = this;
     this._handleUserInitiatedChangeStart(Math.min(oldStart + pageSize, typeof total === 'undefined' ? Infinity : total - 1));
   }
@@ -75,7 +75,7 @@ class BXPagination extends LitElement {
    * Handles user-initiated change in current page.
    * @param event The event.
    */
-  protected _handleChangePage({ detail }: CustomEvent) {
+  private _handleChangePage({ detail }: CustomEvent) {
     const { value } = detail;
     const { pageSize } = this;
     this._handleUserInitiatedChangeStart(value * pageSize);
@@ -85,7 +85,7 @@ class BXPagination extends LitElement {
    * Handles user-initiated change in number of rows per page.
    * @param event The event.
    */
-  protected _handleChangePageSize({ detail }: CustomEvent) {
+  private _handleChangePageSize({ detail }: CustomEvent) {
     this.pageSize = detail.value;
   }
 

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -35,14 +35,14 @@ class BXSearch extends LitElement {
   /**
    * Unique ID used for ID refs.
    */
-  protected _uniqueId = Math.random()
+  private _uniqueId = Math.random()
     .toString(36)
     .slice(2);
 
   /**
    * The element ID for the search box.
    */
-  protected get _inputId() {
+  private get _inputId() {
     const { id: elementId, _uniqueId: uniqueId } = this;
     return `__bx-ce-search_${elementId || uniqueId}`;
   }


### PR DESCRIPTION
This change fixes an issue where an instance property of checkbox missed its `private` declaration. This change also aligns new code to existing code where non-API-purpose properties are `private` unless we expect in-house usage of inheritance.