### PR TITLE
chore(components): switch to fixed IDs

### DIFF
--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -25,21 +25,6 @@ class BXCheckbox extends FocusMixin(LitElement) {
   private _checkboxNode!: HTMLInputElement;
 
   /**
-   * Unique ID used for ID refs.
-   */
-  private _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
-   * The element ID for the check box.
-   */
-  private get _checkboxId() {
-    const { id: elementId, _uniqueId: uniqueId } = this;
-    return `__bx-ce-selectable-tile_${elementId || uniqueId}`;
-  }
-
-  /**
    * Handles `click` event on the `<input>` in the shadow DOM.
    */
   private _handleChange() {
@@ -95,23 +80,13 @@ class BXCheckbox extends FocusMixin(LitElement) {
   }
 
   render() {
-    const {
-      checked,
-      disabled,
-      hideLabel,
-      indeterminate,
-      labelText,
-      name,
-      value,
-      _checkboxId: checkboxId,
-      _handleChange: handleChange,
-    } = this;
+    const { checked, disabled, hideLabel, indeterminate, labelText, name, value, _handleChange: handleChange } = this;
     const labelClasses = classnames(`${prefix}--checkbox-label`, {
       [`${prefix}--visually-hidden`]: hideLabel,
     });
     return html`
       <input
-        id="${checkboxId}"
+        id="checkbox"
         type="checkbox"
         class="${`${prefix}--checkbox`}"
         aria-checked="${indeterminate ? 'mixed' : String(Boolean(checked))}"
@@ -122,7 +97,7 @@ class BXCheckbox extends FocusMixin(LitElement) {
         value="${ifDefined(value == null ? undefined : value)}"
         @change="${handleChange}"
       />
-      <label for="${checkboxId}" class="${labelClasses}">${labelText}</label>
+      <label for="checkbox" class="${labelClasses}">${labelText}</label>
     `;
   }
 

--- a/src/components/combo-box/combo-box.ts
+++ b/src/components/combo-box/combo-box.ts
@@ -123,25 +123,17 @@ class BXComboBox extends BXDropdown {
   }
 
   protected _renderTriggerContent(): TemplateResult {
-    const {
-      disabled,
-      inputLabel,
-      triggerContent,
-      _filterInputValue: filterInputValue,
-      _menuBodyId: menuBodyId,
-      _triggerLabelId: triggerLabelId,
-      _handleInput: handleInput,
-    } = this;
+    const { disabled, inputLabel, triggerContent, _filterInputValue: filterInputValue, _handleInput: handleInput } = this;
     return html`
       <input
-        id="${triggerLabelId}"
+        id="trigger-label"
         class="${prefix}--text-input"
         ?disabled=${disabled}
         placeholder="${triggerContent}"
         .value=${filterInputValue}
         role="combobox"
         aria-label="${inputLabel}"
-        aria-controls="${menuBodyId}"
+        aria-controls="menu-body"
         aria-autocomplete="list"
         @input=${handleInput}
       />

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -95,29 +95,6 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
   protected _shouldTriggerBeFocusable = true;
 
   /**
-   * The element ID of the one that has the content of the trigger button.
-   */
-  protected get _triggerLabelId() {
-    const { id, _uniqueId: uniqueId } = this;
-    return `__bx-ce-dropdown_trigger-label_${id || uniqueId}`;
-  }
-
-  /**
-   * The element ID for the menu body.
-   */
-  protected get _menuBodyId() {
-    const { id, _uniqueId: uniqueId } = this;
-    return `__bx-ce-dropdown_menu_${id || uniqueId}`;
-  }
-
-  /**
-   * Unique ID used for ID refs.
-   */
-  protected _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
    * @param itemToSelect A dropdown item. Absense of this argument means clearing selection.
    * @returns `true` if the selection of this dropdown should change if the given item is selected upon user interaction.
    */
@@ -320,9 +297,9 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
    * @returns The main content of the trigger button.
    */
   protected _renderTriggerContent(): TemplateResult {
-    const { triggerContent, _selectedItemContent: selectedItemContent, _triggerLabelId: triggerLabelId } = this;
+    const { triggerContent, _selectedItemContent: selectedItemContent } = this;
     return html`
-      <span id="${triggerLabelId}" class="${prefix}--list-box__label">${selectedItemContent || triggerContent}</span>
+      <span id="trigger-label" class="${prefix}--list-box__label">${selectedItemContent || triggerContent}</span>
     `;
   }
 
@@ -476,8 +453,6 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
       validityMessage,
       _assistiveStatusText: assistiveStatusText,
       _shouldTriggerBeFocusable: shouldTriggerBeFocusable,
-      _menuBodyId: menuBodyId,
-      _triggerLabelId: triggerLabelId,
       _handleClickInner: handleClickInner,
       _handleKeydownInner: handleKeydownInner,
     } = this;
@@ -525,7 +500,7 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
     const menuBody = !open
       ? undefined
       : html`
-          <div id="${menuBodyId}" class="${prefix}--list-box__menu" role="listbox" tabindex="-1">
+          <div id="menu-body" class="${prefix}--list-box__menu" role="listbox" tabindex="-1">
             <slot></slot>
           </div>
         `;
@@ -543,11 +518,11 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
           role="${ifDefined(!shouldTriggerBeFocusable ? undefined : 'button')}"
           class="${prefix}--list-box__field"
           tabindex="${ifDefined(!shouldTriggerBeFocusable ? undefined : '0')}"
-          aria-labelledby="${triggerLabelId}"
+          aria-labelledby="trigger-label"
           aria-expanded="${String(open)}"
           aria-haspopup="listbox"
-          aria-owns="${menuBodyId}"
-          aria-controls="${menuBodyId}"
+          aria-owns="menu-body"
+          aria-controls="menu-body"
         >
           ${this._renderPrecedingTriggerContent()}${this._renderTriggerContent()}${this._renderFollowingTriggerContent()}
           <div class="${iconContainerClasses}">

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -124,17 +124,6 @@ export default class BXInput extends LitElement {
   @property({ reflect: true })
   value = '';
 
-  /**
-   * Unique ID used for ID refs.
-   */
-  protected _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  protected get _inputId() {
-    return this.id || this._uniqueId;
-  }
-
   render() {
     const invalidIcon = WarningFilled16({ class: `${prefix}--text-input__invalid-icon` });
 
@@ -151,7 +140,7 @@ export default class BXInput extends LitElement {
     });
 
     return html`
-      <label class="${labelClasses}" for="${this._inputId}">
+      <label class="${labelClasses}" for="input">
         <slot name="label-text">
           ${this.labelText}
         </slot>
@@ -169,7 +158,7 @@ export default class BXInput extends LitElement {
           class="${inputClasses}"
           ?data-invalid="${this.invalid}"
           ?disabled="${this.disabled}"
-          id="${this._inputId}"
+          id="input"
           name="${this.name}"
           pattern="${this.pattern}"
           placeholder="${this.placeholder}"

--- a/src/components/multi-select/multi-select-item.ts
+++ b/src/components/multi-select/multi-select-item.ts
@@ -21,25 +21,18 @@ const { prefix } = settings;
 @customElement(`${prefix}-multi-select-item`)
 class BXMultiSelectItem extends BXDropdownItem {
   /**
-   * Unique ID used for form elements.
-   */
-  protected _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
    * The `name` attribute for the `<input>` for selection. Corresponds to `selection-name` attribute.
    */
   @property({ attribute: 'selection-name' })
   selectionName = '';
 
   render() {
-    const { id: elementId, disabled, selected, selectionName, value } = this;
+    const { disabled, selected, selectionName, value } = this;
     return html`
       <div class="${prefix}--list-box__menu-item__option">
         <div class="${prefix}--form-item ${prefix}--checkbox-wrapper">
           <input
-            id="__bx-multi-select-item_checkbox_${elementId || this._uniqueId}"
+            id="input"
             type="checkbox"
             class="${prefix}--checkbox"
             tabindex="-1"
@@ -49,7 +42,7 @@ class BXMultiSelectItem extends BXDropdownItem {
             name="${ifDefined(selectionName || undefined)}"
             value="${value}"
           />
-          <label for="__bx-multi-select-item_checkbox_${elementId || this._uniqueId}" class="${prefix}--checkbox-label">
+          <label for="input" class="${prefix}--checkbox-label">
             <span class="${prefix}--checkbox-label-text"><slot></slot></span>
           </label>
         </div>

--- a/src/components/pagination/page-sizes-select.ts
+++ b/src/components/pagination/page-sizes-select.ts
@@ -23,21 +23,6 @@ class BXPageSizesSelect extends LitElement {
   private _selectNode!: HTMLSelectElement;
 
   /**
-   * Unique ID used for ID refs.
-   */
-  private _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
-   * The element ID for the select box.
-   */
-  private get _selectId() {
-    const { id: elementId, _uniqueId: uniqueId } = this;
-    return `__bx-ce-page-sizes-select_${elementId || uniqueId}`;
-  }
-
-  /**
    * Handles `change` event on the `<select>` to select page size.
    */
   private _handleChange({ target }: Event) {
@@ -81,11 +66,11 @@ class BXPageSizesSelect extends LitElement {
   value!: number;
 
   render() {
-    const { labelText, value, _selectId: selectId, _handleChange: handleChange, _handleSlotChange: handleSlotChange } = this;
+    const { labelText, value, _handleChange: handleChange, _handleSlotChange: handleSlotChange } = this;
     return html`
-      <label for="${selectId}_size" class="${prefix}--pagination__text">${labelText}<slot name="label-text"></slot></label>
+      <label for="select" class="${prefix}--pagination__text">${labelText}<slot name="label-text"></slot></label>
       <div class="${prefix}--select__item-count">
-        <select id="${selectId}_size" class="${prefix}--select-input" .value="${value}" @change=${handleChange}></select>
+        <select id="select" class="${prefix}--select-input" .value="${value}" @change=${handleChange}></select>
         ${ChevronDown16({ class: `${prefix}--select__arrow` })}
       </div>
       <div hidden><slot @slotchange="${handleSlotChange}"></slot></div>

--- a/src/components/pagination/pages-select.ts
+++ b/src/components/pagination/pages-select.ts
@@ -20,21 +20,6 @@ const { prefix } = settings;
 @customElement(`${prefix}-pages-select`)
 class BXPagesSelect extends LitElement {
   /**
-   * Unique ID used for ID refs.
-   */
-  protected _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
-   * The element ID for the select box.
-   */
-  protected get _selectId() {
-    const { id: elementId, _uniqueId: uniqueId } = this;
-    return `__bx-ce-pages-select_${elementId || uniqueId}`;
-  }
-
-  /**
    * Handles `change` event on the `<select>` to select page size.
    */
   protected _handleChange({ target }: Event) {
@@ -77,13 +62,13 @@ class BXPagesSelect extends LitElement {
   value!: number;
 
   render() {
-    const { formatLabelText, formatSupplementalText, total, value, _selectId: selectId, _handleChange: handleChange } = this;
+    const { formatLabelText, formatSupplementalText, total, value, _handleChange: handleChange } = this;
     return html`
       <div class="${prefix}--select__page-number">
-        <label for="${selectId}_page-number" class="${prefix}--label ${prefix}--visually-hidden">
+        <label for="select" class="${prefix}--label ${prefix}--visually-hidden">
           ${formatLabelText(this)}
         </label>
-        <select id="${selectId}_page-number" class="${prefix}--select-input" .value="${value}" @change="${handleChange}">
+        <select id="select" class="${prefix}--select-input" .value="${value}" @change="${handleChange}">
           ${Array.from(new Array(total)).map(
             (_item, index) => html`
               <option value=${index}>${index + 1}</option>

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -43,21 +43,6 @@ class BXSearch extends FocusMixin(LitElement) {
   private _inputNode!: HTMLInputElement;
 
   /**
-   * Unique ID used for ID refs.
-   */
-  private _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
-   * The element ID for the search box.
-   */
-  private get _inputId() {
-    const { id: elementId, _uniqueId: uniqueId } = this;
-    return `__bx-ce-search_${elementId || uniqueId}`;
-  }
-
-  /**
    * Handles `input` event on the `<input>` in the shadow DOM.
    */
   private _handleInput(event: Event) {
@@ -158,7 +143,6 @@ class BXSearch extends FocusMixin(LitElement) {
       size,
       type,
       value = '',
-      _inputId: inputId,
       _inputNode: inputNode,
       _handleInput: handleInput,
       _handleClearInputButtonClick: handleClearInputButtonClick,
@@ -171,11 +155,11 @@ class BXSearch extends FocusMixin(LitElement) {
         class: `${prefix}--search-magnifier`,
         role: 'img',
       })}
-      <label for="${inputId}" class="${prefix}--label">
+      <label for="input" class="${prefix}--label">
         ${labelText}
       </label>
       <input
-        id="${inputId}"
+        id="input"
         type="${ifDefined(type == null ? undefined : type)}"
         class="${prefix}--search-input"
         ?disabled="${disabled}"

--- a/src/components/tile/expandable-tile.ts
+++ b/src/components/tile/expandable-tile.ts
@@ -21,21 +21,6 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-expandable-tile`)
 class BXExpandableTile extends HostListenerMixin(LitElement) {
-  /**
-   * Unique ID used for ID refs.
-   */
-  private _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
-   * The element ID for the check box.
-   */
-  private get _iconId() {
-    const { id: elementId, _uniqueId: uniqueId } = this;
-    return `__bx-ce-selectable-tile_${elementId || uniqueId}`;
-  }
-
   @HostListener('click')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleClick = () => {
@@ -80,12 +65,12 @@ class BXExpandableTile extends HostListenerMixin(LitElement) {
   expanded = false;
 
   render() {
-    const { collapsedAssistiveText, expandedAssistiveText, expanded, _iconId: iconId } = this;
+    const { collapsedAssistiveText, expandedAssistiveText, expanded } = this;
     const assistiveText = expanded ? expandedAssistiveText : collapsedAssistiveText;
     return html`
-      <button class="${prefix}--tile__chevron" aria-labelledby="${iconId}">
+      <button class="${prefix}--tile__chevron" aria-labelledby="icon">
         ${ChevronDown16({
-          id: iconId,
+          id: 'icon',
           alt: assistiveText,
           description: assistiveText,
           'aria-label': assistiveText,

--- a/src/components/tile/selectable-tile.ts
+++ b/src/components/tile/selectable-tile.ts
@@ -30,21 +30,6 @@ class BXSelectableTile extends FocusMixin(LitElement) {
   protected _inputType = 'checkbox';
 
   /**
-   * Unique ID used for form elements.
-   */
-  protected _uniqueId = Math.random()
-    .toString(36)
-    .slice(2);
-
-  /**
-   * The element ID for the check box.
-   */
-  protected get _inputId() {
-    const { id: elementId, _uniqueId: uniqueId } = this;
-    return `__bx-ce-selectable-tile_${elementId || uniqueId}`;
-  }
-
-  /**
    * Handles `change` event on the `<input>` in the shadow DOM.
    */
   protected _handleChange() {
@@ -80,11 +65,11 @@ class BXSelectableTile extends FocusMixin(LitElement) {
   }
 
   render() {
-    const { checkmarkLabel, name, selected, value, _inputId: inputId, _inputType: inputType, _handleChange: handleChange } = this;
+    const { checkmarkLabel, name, selected, value, _inputType: inputType, _handleChange: handleChange } = this;
     return html`
       <input
         type="${inputType}"
-        id="${inputId}"
+        id="input"
         class="${prefix}--tile-input"
         tabindex="-1"
         name="${ifDefined(name == null ? undefined : name)}"
@@ -92,7 +77,7 @@ class BXSelectableTile extends FocusMixin(LitElement) {
         .checked=${selected}
         @change=${handleChange}
       />
-      <label for="${inputId}" class="${prefix}--tile ${prefix}--tile--selectable" tabindex="0">
+      <label for="input" class="${prefix}--tile ${prefix}--tile--selectable" tabindex="0">
         <div class="${prefix}--tile__checkmark">
           ${CheckmarkFilled16({
             children: !checkmarkLabel ? undefined : svg`<title>${checkmarkLabel}</title>`,

--- a/tests/snapshots/bx-checkbox.md
+++ b/tests/snapshots/bx-checkbox.md
@@ -8,12 +8,12 @@
 <input
   aria-checked="false"
   class="bx--checkbox"
-  id="__bx-ce-selectable-tile_id-foo"
+  id="checkbox"
   type="checkbox"
 >
 <label
   class="bx--checkbox-label"
-  for="__bx-ce-selectable-tile_id-foo"
+  for="checkbox"
 >
 </label>
 
@@ -26,14 +26,14 @@
   aria-checked="mixed"
   class="bx--checkbox"
   disabled=""
-  id="__bx-ce-selectable-tile_id-foo"
+  id="checkbox"
   name="name-foo"
   type="checkbox"
   value="value-foo"
 >
 <label
   class="bx--checkbox-label bx--visually-hidden"
-  for="__bx-ce-selectable-tile_id-foo"
+  for="checkbox"
 >
   label-text-foo
 </label>


### PR DESCRIPTION
Given shadow DOM creates an isolated space for element IDs, we don't need unique ID generation logic for IDs used in shadow DOM.