### PR TITLE
fix(input): support programmatic change in value

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -129,7 +129,7 @@ export default class BXInput extends LitElement {
   /**
    * The value of the input.
    */
-  @property({ reflect: true })
+  @property()
   value = '';
 
   render() {
@@ -175,7 +175,7 @@ export default class BXInput extends LitElement {
           ?readonly="${this.readonly}"
           ?required="${this.required}"
           type="${this.type}"
-          value="${this.value}"
+          .value="${this.value}"
           @input="${handleInput}"
         />
       </div>


### PR DESCRIPTION
This change is to ensure `<bx-input>` supports programmatic change in `value`. This change is needed as after-creation attribute change in `<input>`'s `value` won't be reflected to the UI.

This change also removes `reflect: true` from `value` property to get in sync with native `<input>` as well as `<bx-checkbox>`.
