### PR TITLE
fix(button): null-check properties

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -10,6 +10,7 @@
 import settings from 'carbon-components/es/globals/js/settings';
 import classnames from 'classnames';
 import { html, property, customElement, LitElement } from 'lit-element';
+import ifNonNull from '../../globals/directives/if-non-null';
 import FocusMixin from '../../globals/mixins/focus';
 import styles from './button.scss';
 
@@ -147,19 +148,19 @@ class BXButton extends FocusMixin(LitElement) {
             id="button"
             role="button"
             class="${classes}"
-            .download="${download}"
-            .href="${href}"
-            .hreflang="${hreflang}"
-            .ping="${ping}"
-            .rel="${rel}"
-            .target="${target}"
-            .type="${type}"
+            download="${ifNonNull(download)}"
+            href="${ifNonNull(href)}"
+            hreflang="${ifNonNull(hreflang)}"
+            ping="${ifNonNull(ping)}"
+            rel="${ifNonNull(rel)}"
+            target="${ifNonNull(target)}"
+            type="${ifNonNull(type)}"
             @click="${this._handleClickLink}"
             ><slot></slot
           ></a>
         `
       : html`
-          <button id="button" class="${classes}" ?autofocus="${autofocus}" ?disabled="${disabled}" .type="${type}">
+          <button id="button" class="${classes}" ?autofocus="${autofocus}" ?disabled="${disabled}" type="${ifNonNull(type)}">
             <slot></slot>
           </button>
         `;

--- a/tests/snapshots/bx-btn.md
+++ b/tests/snapshots/bx-btn.md
@@ -2,6 +2,19 @@
 
 ## `Misc attributes`
 
+#### `should render with minimum attributes for <button>`
+
+```
+<button
+  class="bx--btn bx--btn--primary"
+  id="button"
+>
+  <slot>
+  </slot>
+</button>
+
+```
+
 #### `should render with various attributes for <button>`
 
 ```
@@ -15,6 +28,21 @@
   <slot>
   </slot>
 </button>
+
+```
+
+#### `should render with minimum attributes for <a>`
+
+```
+<a
+  class="bx--btn bx--btn--primary"
+  href="about:blank"
+  id="button"
+  role="button"
+>
+  <slot>
+  </slot>
+</a>
 
 ```
 

--- a/tests/spec/button_spec.ts
+++ b/tests/spec/button_spec.ts
@@ -117,6 +117,12 @@ describe('bx-btn', function() {
   });
 
   describe('Misc attributes', function() {
+    it('should render with minimum attributes for <button>', async function() {
+      render(template(), document.body);
+      await Promise.resolve();
+      expect(document.body.querySelector('bx-btn')).toMatchSnapshot({ mode: 'shadow' });
+    });
+
     it('should render with various attributes for <button>', async function() {
       render(
         template({
@@ -128,6 +134,12 @@ describe('bx-btn', function() {
         }),
         document.body
       );
+      await Promise.resolve();
+      expect(document.body.querySelector('bx-btn')).toMatchSnapshot({ mode: 'shadow' });
+    });
+
+    it('should render with minimum attributes for <a>', async function() {
+      render(template({ href: 'about:blank' }), document.body);
       await Promise.resolve();
       expect(document.body.querySelector('bx-btn')).toMatchSnapshot({ mode: 'shadow' });
     });


### PR DESCRIPTION
This change ensures `null`-checking string properties before setting them as attributes, ensuring that `null`/`undefined` won't be set as attribute value.