### PR TITLE
fix(textarea): reflect value attribute on init

### DIFF
--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -21,6 +21,14 @@ const { prefix } = settings;
 @customElement(`${prefix}-textarea`)
 export default class BXTextarea extends LitElement {
   /**
+   * Handles `oninput` event on the `<input>`.
+   * @param event The event.
+   */
+  private _handleInput({ target }: Event) {
+    this.value = (target as HTMLTextAreaElement).value;
+  }
+
+  /**
    * May be any of the standard HTML autocomplete options
    */
   @property()
@@ -114,18 +122,7 @@ export default class BXTextarea extends LitElement {
    * The value of the text area.
    */
   @property()
-  set value(v: string) {
-    if (this._textarea) {
-      this._textarea.value = v;
-    }
-  }
-
-  get value(): string {
-    if (this._textarea) {
-      return this._textarea.value;
-    }
-    return '';
-  }
+  value = '';
 
   /**
    * Get a reference to the underlying textarea so we can directly apply values.
@@ -176,6 +173,8 @@ export default class BXTextarea extends LitElement {
           ?readonly="${this.readonly}"
           ?required="${this.required}"
           rows="${this.rows}"
+          .value="${this.value}"
+          @input="${this._handleInput}"
         ></textarea>
       </div>
       <div class="${prefix}--form-requirement">

--- a/tests/snapshots/bx-textarea.md
+++ b/tests/snapshots/bx-textarea.md
@@ -1,0 +1,44 @@
+# `bx-textarea`
+
+## `Rendering`
+
+#### `Should render with various attributes`
+
+```
+<label
+  class="bx--label bx--label--disabled"
+  for="input"
+>
+  <slot name="label-text">
+    label-text-foo
+  </slot>
+</label>
+<div class="bx--form__helper-text bx--form__helper-text--disabled">
+  <slot name="helper-text">
+    helper-text-foo
+  </slot>
+</div>
+<div class="bx--text-area__wrapper">
+  <textarea
+    autocomplete=""
+    autofocus=""
+    class="bx--text-area bx--text-area--v2"
+    cols="50"
+    disabled=""
+    id="input"
+    name="name-foo"
+    pattern="pattern-foo"
+    placeholder="placeholder-foo"
+    readonly=""
+    required=""
+    rows="4"
+  >
+  </textarea>
+</div>
+<div class="bx--form-requirement">
+  <slot name="validity-message">
+    validity-message-foo
+  </slot>
+</div>
+
+```

--- a/tests/spec/textarea_spec.ts
+++ b/tests/spec/textarea_spec.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, render, TemplateResult } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import BXTextarea from '../../src/components/textarea/textarea';
+
+const template = ({
+  hasContent = true,
+  autocomplete,
+  autofocus,
+  disabled,
+  helperText,
+  labelText,
+  name,
+  pattern,
+  placeholder,
+  readonly,
+  required,
+  validityMessage,
+  value,
+}: {
+  hasContent?: boolean;
+  autocomplete?: string;
+  autofocus?: boolean;
+  disabled?: boolean;
+  helperText?: string;
+  labelText?: string;
+  name?: string;
+  pattern?: string;
+  placeholder?: string;
+  readonly?: boolean;
+  required?: boolean;
+  validityMessage?: string;
+  value?: string;
+} = {}) =>
+  !hasContent
+    ? (undefined! as TemplateResult)
+    : html`
+        <bx-textarea
+          autocomplete="${ifDefined(autocomplete)}"
+          ?autofocus="${autofocus}"
+          ?disabled="${disabled}"
+          helper-text="${ifDefined(helperText)}"
+          label-text="${ifDefined(labelText)}"
+          name="${ifDefined(name)}"
+          pattern="${ifDefined(pattern)}"
+          placeholder="${ifDefined(placeholder)}"
+          ?readonly="${readonly}"
+          ?required="${required}"
+          validity-message="${ifDefined(validityMessage)}"
+          value="${ifDefined(value)}"
+        ></bx-textarea>
+      `;
+
+describe('bx-textarea', function() {
+  describe('Rendering', function() {
+    it('Should render with various attributes', async function() {
+      render(
+        template({
+          autocomplete: 'on',
+          autofocus: true,
+          disabled: true,
+          helperText: 'helper-text-foo',
+          labelText: 'label-text-foo',
+          name: 'name-foo',
+          pattern: 'pattern-foo',
+          placeholder: 'placeholder-foo',
+          readonly: true,
+          required: true,
+          validityMessage: 'validity-message-foo',
+          value: 'value-foo',
+        }),
+        document.body
+      );
+      await Promise.resolve();
+      expect(document.body.querySelector('bx-textarea')).toMatchSnapshot({ mode: 'shadow' });
+    });
+
+    it('Should reflect value in DOM', async function() {
+      render(
+        template({
+          value: 'value-foo',
+        }),
+        document.body
+      );
+      await Promise.resolve();
+      expect((document.body.querySelector('bx-textarea') as BXTextarea).value).toBe('value-foo');
+    });
+  });
+
+  describe('Reacting to user gesture', function() {
+    it('Should update value upon user input', async function() {
+      render(
+        template({
+          value: '',
+        }),
+        document.body
+      );
+      await Promise.resolve();
+      const textareaNode = document.body.querySelector('bx-textarea')!.shadowRoot!.querySelector('textarea');
+      expect(textareaNode!.value).toBe('');
+      textareaNode!.value = 'value-foo';
+      textareaNode!.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
+      expect(textareaNode!.value).toBe('value-foo');
+    });
+  });
+
+  afterEach(function() {
+    render(template({ hasContent: false }), document.body);
+  });
+});


### PR DESCRIPTION
This change ensures that `value` attribute of `<bx-textarea>` is reflected to the `<textarea>` in shadow DOM at initialization, where `lit-element` attempts to reflect `value` attribute to `value` property before it renders `<textarea>`.
