### PR TITLE
chore(build): ship sass code

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -64,7 +64,7 @@ module.exports = {
       );
     },
 
-    async sass() {
+    async css() {
       const banner = await readFileAsync(path.resolve(__dirname, '../tools/license.js'), 'utf8');
       await promisifyStream(() =>
         gulp
@@ -182,5 +182,9 @@ module.exports = {
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest(config.jsDestDir));
     },
+  },
+
+  sass() {
+    return gulp.src(`${config.srcDir}/**/*.scss`).pipe(gulp.dest(config.sassDestDir));
   },
 };

--- a/gulp-tasks/clean.js
+++ b/gulp-tasks/clean.js
@@ -14,5 +14,5 @@ const del = require('del');
 const config = require('./config');
 
 module.exports = function clean() {
-  return del(config.jsDestDir);
+  return Promise.all([del(config.jsDestDir), del(config.sassDestDir)]);
 };

--- a/gulp-tasks/config.js
+++ b/gulp-tasks/config.js
@@ -35,6 +35,7 @@ module.exports = {
   srcDir: 'src',
   iconsDir: path.dirname(require.resolve('@carbon/icons/lib')),
   jsDestDir: 'es',
+  sassDestDir: 'scss',
   viewsDir: 'views',
   testsDir: 'tests',
   jsDocDir: 'docs/js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ const lint = require('./gulp-tasks/lint');
 const test = require('./gulp-tasks/test');
 
 gulp.task('build:modules:icons', build.modules.icons);
-gulp.task('build:modules:sass', build.modules.sass);
+gulp.task('build:modules:css', build.modules.css);
 gulp.task('build:modules:react', build.modules.react);
 gulp.task('build:modules:scripts', build.modules.scripts);
 gulp.task('build:modules:types', build.modules.types);
@@ -25,13 +25,14 @@ gulp.task(
   'build:modules',
   gulp.parallel(
     gulp.task('build:modules:icons'),
-    gulp.task('build:modules:sass'),
+    gulp.task('build:modules:css'),
     gulp.task('build:modules:react'),
     gulp.task('build:modules:scripts'),
     gulp.task('build:modules:types')
   )
 );
-gulp.task('build', gulp.task('build:modules'));
+gulp.task('build:sass', build.sass);
+gulp.task('build', gulp.task('build:modules'), gulp.task('build:sass'));
 
 gulp.task('clean', clean);
 


### PR DESCRIPTION
Shipping our Sass code allows users to create custom `.css.js` files, e.g. an optimized version that contains styles of all components application uses and making `styles` of each components point to such single `.css.js`. In this way duplicate styles can be eliminated by `import-once`.