### PR TITLE
feat(angular): introduce form directives

### DIFF
--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -107,17 +107,6 @@ module.exports = {
       );
     },
 
-    angular() {
-      const tsProject = typescript.createProject(path.resolve(__dirname, '../tsconfig.json'));
-      const { js } = gulp
-        // Ensures type references are in the TS project by adding `.d.ts` here
-        .src([`${config.srcDir}/directives-angular/**/*.ts`, `${config.srcDir}/**/*.d.ts`], { base: config.srcDir })
-        .pipe(plumber())
-        .pipe(sourcemaps.init())
-        .pipe(tsProject());
-      return js.pipe(sourcemaps.write('.')).pipe(gulp.dest(config.jsDestDir));
-    },
-
     async react() {
       const banner = await readFileAsync(path.resolve(__dirname, '../tools/license.js'), 'utf8');
       await promisifyStream(() =>
@@ -180,7 +169,12 @@ module.exports = {
     types() {
       const tsProject = typescript.createProject(path.resolve(__dirname, '../tsconfig.json'));
       const { dts } = gulp
-        .src([`${config.srcDir}/**/*.ts`, `!${config.srcDir}/**/*-story*.ts*`, `!${config.srcDir}/**/stories/**/*.ts*`])
+        .src([
+          `${config.srcDir}/**/*.ts`,
+          `!${config.srcDir}/directives-angular/**/*.ts`,
+          `!${config.srcDir}/**/*-story*.ts*`,
+          `!${config.srcDir}/**/stories/**/*.ts*`,
+        ])
         .pipe(plumber())
         .pipe(sourcemaps.init())
         .pipe(tsProject());

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -107,6 +107,17 @@ module.exports = {
       );
     },
 
+    angular() {
+      const tsProject = typescript.createProject(path.resolve(__dirname, '../tsconfig.json'));
+      const { js } = gulp
+        // Ensures type references are in the TS project by adding `.d.ts` here
+        .src([`${config.srcDir}/directives-angular/**/*.ts`, `${config.srcDir}/**/*.d.ts`], { base: config.srcDir })
+        .pipe(plumber())
+        .pipe(sourcemaps.init())
+        .pipe(tsProject());
+      return js.pipe(sourcemaps.write('.')).pipe(gulp.dest(config.jsDestDir));
+    },
+
     async react() {
       const banner = await readFileAsync(path.resolve(__dirname, '../tools/license.js'), 'utf8');
       await promisifyStream(() =>
@@ -135,6 +146,7 @@ module.exports = {
         gulp
           .src([
             `${config.srcDir}/**/*.ts`,
+            `!${config.srcDir}/directives-angular/**/*.ts`,
             `!${config.srcDir}/**/*-story*.ts*`,
             `!${config.srcDir}/**/stories/*.ts`,
             `!${config.srcDir}/**/*.d.ts`,

--- a/gulp-tasks/lint.js
+++ b/gulp-tasks/lint.js
@@ -65,7 +65,7 @@ module.exports = {
 
     dist() {
       return gulp
-        .src([`${config.jsDestDir}/**/*`, '!**/*.map'])
+        .src([`${config.jsDestDir}/**/*`, '!**/*.json', '!**/*.map'])
         .pipe(filter(file => !file.stat.isDirectory()))
         .pipe(gulpCheckLicense());
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ const test = require('./gulp-tasks/test');
 
 gulp.task('build:modules:icons', build.modules.icons);
 gulp.task('build:modules:sass', build.modules.sass);
+gulp.task('build:modules:angular', build.modules.angular);
 gulp.task('build:modules:react', build.modules.react);
 gulp.task('build:modules:scripts', build.modules.scripts);
 gulp.task('build:modules:types', build.modules.types);
@@ -26,6 +27,7 @@ gulp.task(
   gulp.parallel(
     gulp.task('build:modules:icons'),
     gulp.task('build:modules:sass'),
+    gulp.task('build:modules:angular'),
     gulp.task('build:modules:react'),
     gulp.task('build:modules:scripts'),
     gulp.task('build:modules:types')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,6 @@ const test = require('./gulp-tasks/test');
 
 gulp.task('build:modules:icons', build.modules.icons);
 gulp.task('build:modules:sass', build.modules.sass);
-gulp.task('build:modules:angular', build.modules.angular);
 gulp.task('build:modules:react', build.modules.react);
 gulp.task('build:modules:scripts', build.modules.scripts);
 gulp.task('build:modules:types', build.modules.types);
@@ -27,7 +26,6 @@ gulp.task(
   gulp.parallel(
     gulp.task('build:modules:icons'),
     gulp.task('build:modules:sass'),
-    gulp.task('build:modules:angular'),
     gulp.task('build:modules:react'),
     gulp.task('build:modules:scripts'),
     gulp.task('build:modules:types')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "es/**/*"
   ],
   "scripts": {
-    "build": "gulp build",
+    "build": "gulp build && yarn build:ngc",
+    "build:ngc": "yarn build:ngc:esm2015 && yarn build:ngc:esm5",
+    "build:ngc:esm2015": "ngc -p tsconfig-angular-esm2015.json",
+    "build:ngc:esm5": "ngc -p tsconfig-angular-esm5.json",
     "ci-check": "yarn format:diff && yarn lint:src && yarn typecheck && yarn test && yarn build && yarn lint:dist",
     "clean": "gulp clean",
     "format": "prettier --write \"**/*.{css,js,md,scss}\"",
@@ -34,9 +37,10 @@
     "babel-plugin-transform-vue-jsx": "^4.0.0"
   },
   "devDependencies": {
-    "@angular-devkit/core": "^7.0.0",
+    "@angular-devkit/core": "^8.0.0",
     "@angular/common": "^8.0.0",
     "@angular/compiler": "^8.0.0",
+    "@angular/compiler-cli": "^8.0.0",
     "@angular/core": "^8.0.0",
     "@angular/forms": "^8.0.0",
     "@angular/platform-browser": "^8.0.0",
@@ -159,6 +163,7 @@
     "terser-webpack-plugin": "^1.2.0",
     "through2": "^3.0.0",
     "ts-loader": "^6.0.0",
+    "tsickle": "^0.37.0",
     "typescript": "^3.4.0",
     "vue": "^2.6.0",
     "vue-eslint-parser": "^6.0.0",

--- a/src/directives-angular/checkbox.ts
+++ b/src/directives-angular/checkbox.ts
@@ -11,7 +11,7 @@ import { Directive, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, CheckboxControlValueAccessor } from '@angular/forms';
 import settings from 'carbon-components/es/globals/js/settings';
 
-const { prefix } = settings;
+const prefix = settings.prefix; // eslint-disable-line prefer-destructuring
 
 @Directive({
   selector: `
@@ -30,4 +30,4 @@ const { prefix } = settings;
     },
   ],
 })
-export default class BXCheckboxDirective extends CheckboxControlValueAccessor {}
+export class BXCheckboxDirective extends CheckboxControlValueAccessor {} // eslint-disable-line import/prefer-default-export

--- a/src/directives-angular/checkbox.ts
+++ b/src/directives-angular/checkbox.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Directive, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, CheckboxControlValueAccessor } from '@angular/forms';
+import settings from 'carbon-components/es/globals/js/settings';
+
+const { prefix } = settings;
+
+@Directive({
+  selector: `
+    ${prefix}-checkbox[formControlName],${prefix}-checkbox[formControl],${prefix}-checkbox[ngModel],
+    ${prefix}-toggle[formControlName],${prefix}-toggle[formControl],${prefix}-toggle[ngModel],
+  `,
+  host: {
+    '(input)': 'onChange($event.target.checked)',
+    '(blur)': 'onTouched()',
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => BXCheckboxDirective), // eslint-disable-line no-use-before-define
+      multi: true,
+    },
+  ],
+})
+export default class BXCheckboxDirective extends CheckboxControlValueAccessor {}

--- a/src/directives-angular/index.ts
+++ b/src/directives-angular/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { NgModule } from '@angular/core';
+import { BXCheckboxDirective } from './checkbox';
+import { BXInputDirective } from './input';
+import { BXSliderDirective } from './slider';
+
+@NgModule({
+  declarations: [BXCheckboxDirective, BXInputDirective, BXSliderDirective],
+  exports: [BXCheckboxDirective, BXInputDirective, BXSliderDirective],
+})
+export class BXFormAccessorsModule {} // eslint-disable-line import/prefer-default-export

--- a/src/directives-angular/input.ts
+++ b/src/directives-angular/input.ts
@@ -11,7 +11,7 @@ import { Directive, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, DefaultValueAccessor } from '@angular/forms';
 import settings from 'carbon-components/es/globals/js/settings';
 
-const { prefix } = settings;
+const prefix = settings.prefix; // eslint-disable-line prefer-destructuring
 
 @Directive({
   selector: `${prefix}-input[formControlName],${prefix}-input[formControl],${prefix}-input[ngModel]`,
@@ -29,4 +29,4 @@ const { prefix } = settings;
     },
   ],
 })
-export default class BXInputDirective extends DefaultValueAccessor {}
+export class BXInputDirective extends DefaultValueAccessor {} // eslint-disable-line import/prefer-default-export

--- a/src/directives-angular/input.ts
+++ b/src/directives-angular/input.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Directive, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, DefaultValueAccessor } from '@angular/forms';
+import settings from 'carbon-components/es/globals/js/settings';
+
+const { prefix } = settings;
+
+@Directive({
+  selector: `${prefix}-input[formControlName],${prefix}-input[formControl],${prefix}-input[ngModel]`,
+  host: {
+    '(input)': '_handleInput($event.target.value)',
+    '(blur)': 'onTouched()',
+    '(compositionstart)': '_compositionStart()',
+    '(compositionend)': '_compositionEnd($event.target.value)',
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => BXInputDirective), // eslint-disable-line no-use-before-define
+      multi: true,
+    },
+  ],
+})
+export default class BXInputDirective extends DefaultValueAccessor {}

--- a/src/directives-angular/slider.ts
+++ b/src/directives-angular/slider.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Directive, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, NumberValueAccessor } from '@angular/forms';
+import settings from 'carbon-components/es/globals/js/settings';
+import BXSlider from '../components/slider/slider';
+
+const { prefix } = settings;
+
+@Directive({
+  selector: `${prefix}-slider[formControlName],${prefix}-slider[formControl],${prefix}-slider[ngModel]`,
+  host: {
+    [`(${BXSlider.eventAfterChange})`]: 'onChange($event.detail.value)',
+    '(blur)': 'onTouched()',
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => BXSliderDirective), // eslint-disable-line no-use-before-define
+      multi: true,
+    },
+  ],
+})
+export default class BXSliderDirective extends NumberValueAccessor {}

--- a/src/directives-angular/slider.ts
+++ b/src/directives-angular/slider.ts
@@ -10,16 +10,20 @@
 import { Directive, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, NumberValueAccessor } from '@angular/forms';
 import settings from 'carbon-components/es/globals/js/settings';
-import BXSlider from '../components/slider/slider';
 
-const { prefix } = settings;
+const prefix = settings.prefix; // eslint-disable-line prefer-destructuring
+
+const host = {
+  '(blur)': 'onTouched()',
+};
+
+// NOTE: Referring `BXSlider.eventAfterChange` seems to cause ng-packagr to package up `src/components/slider.ts` code,
+// Which is not desirable
+host[`(${prefix}-slider-changed)`] = 'onChange($event.detail.value)';
 
 @Directive({
   selector: `${prefix}-slider[formControlName],${prefix}-slider[formControl],${prefix}-slider[ngModel]`,
-  host: {
-    [`(${BXSlider.eventAfterChange})`]: 'onChange($event.detail.value)',
-    '(blur)': 'onTouched()',
-  },
+  host,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -28,4 +32,4 @@ const { prefix } = settings;
     },
   ],
 })
-export default class BXSliderDirective extends NumberValueAccessor {}
+export class BXSliderDirective extends NumberValueAccessor {} // eslint-disable-line import/prefer-default-export

--- a/src/typings/vendor.d.ts
+++ b/src/typings/vendor.d.ts
@@ -7,8 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Handle from '../globals/internal/handle';
-
 declare module 'carbon-components/es/globals/js/settings' {
   const settings: {
     /**

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function setupKarma(config) {
       },
     },
 
-    files: ['src/polyfills/index.js', 'tests/utils/snapshot.js', 'tests/snapshots/**/*.md'].concat(
+    files: ['src/polyfills/index.ts', 'tests/utils/snapshot.js', 'tests/snapshots/**/*.md'].concat(
       specs.length > 0 ? specs : ['tests/karma-test-shim.js']
     ),
 
@@ -80,6 +80,21 @@ module.exports = function setupKarma(config) {
                 loader: 'babel-loader',
                 options: {
                   configFile: path.resolve(__dirname, '..', '.babelrc'),
+                },
+              },
+            ],
+          },
+          {
+            test: [/directives-angular\/.*\.ts$/, /-angular_spec\.ts$/],
+            use: [
+              {
+                loader: 'ts-loader',
+                options: {
+                  ignoreDiagnostics: [6133],
+                  compilerOptions: {
+                    sourceMap: false,
+                    inlineSourceMap: true,
+                  },
                 },
               },
             ],

--- a/tests/polyfills/.eslintrc
+++ b/tests/polyfills/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../src/.eslintrc"
+  ]
+}

--- a/tests/polyfills/angular.ts
+++ b/tests/polyfills/angular.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import 'core-js/modules/esnext.reflect.metadata';
+import 'core-js/modules/esnext.reflect.define-metadata';
+import 'core-js/modules/esnext.reflect.get-own-metadata';
+
+import 'zone.js/dist/zone';
+import 'zone.js/dist/long-stack-trace-zone';
+import 'zone.js/dist/proxy';
+import 'zone.js/dist/sync-test';
+import 'zone.js/dist/jasmine-patch';
+import 'zone.js/dist/async-test';
+import 'zone.js/dist/fake-async-test';

--- a/tests/spec/checkbox-angular_spec.ts
+++ b/tests/spec/checkbox-angular_spec.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../polyfills/angular';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import BXCheckbox from '../../src/components/checkbox/checkbox';
+import BXToggle from '../../src/components/toggle/toggle';
+import BXCheckboxDirective from '../../src/directives-angular/checkbox';
+
+@Component({
+  template: `
+    <form>
+      <bx-checkbox [(ngModel)]="model.checked" name="checked"></bx-checkbox>
+    </form>
+  `,
+})
+class CheckboxAngularTest {
+  model = {
+    checked: false,
+  };
+}
+
+@Component({
+  template: `
+    <form>
+      <bx-toggle [(ngModel)]="model.checked" name="checked"></bx-toggle>
+    </form>
+  `,
+})
+class ToggleAngularTest {
+  model = {
+    checked: false,
+  };
+}
+
+describe('Angular directive for bx-checkbox', () => {
+  beforeAll(function() {
+    TestBed.resetTestEnvironment();
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+  });
+
+  describe('Working with bx-checkbox', function() {
+    beforeEach(function() {
+      TestBed.configureTestingModule({
+        declarations: [BXCheckboxDirective, CheckboxAngularTest],
+        imports: [FormsModule],
+      });
+    });
+
+    it('should send the value to model upon `input` event', async function() {
+      const fixture = TestBed.createComponent(CheckboxAngularTest);
+      fixture.detectChanges(); // Ensures event handlers are set up
+      await Promise.resolve(); // Ensures event handlers are set up
+      const debugElement = fixture.debugElement.query(By.css('bx-checkbox'));
+      ((debugElement as unknown) as BXCheckbox).checked = true;
+      debugElement.triggerEventHandler('input', { target: debugElement });
+      fixture.detectChanges();
+      expect(fixture.componentInstance.model.checked).toBe(true);
+    });
+  });
+
+  describe('Working with bx-toggle', () => {
+    beforeEach(function() {
+      TestBed.configureTestingModule({
+        declarations: [BXCheckboxDirective, ToggleAngularTest],
+        imports: [FormsModule],
+      });
+    });
+
+    it('should send the value to model upon `input` event', async function() {
+      const fixture = TestBed.createComponent(ToggleAngularTest);
+      fixture.detectChanges(); // Ensures event handlers are set up
+      await Promise.resolve(); // Ensures event handlers are set up
+      const debugElement = fixture.debugElement.query(By.css('bx-toggle'));
+      ((debugElement as unknown) as BXToggle).checked = true;
+      debugElement.triggerEventHandler('input', { target: debugElement });
+      fixture.detectChanges();
+      expect(fixture.componentInstance.model.checked).toBe(true);
+    });
+  });
+});

--- a/tests/spec/checkbox-angular_spec.ts
+++ b/tests/spec/checkbox-angular_spec.ts
@@ -15,7 +15,7 @@ import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import BXCheckbox from '../../src/components/checkbox/checkbox';
 import BXToggle from '../../src/components/toggle/toggle';
-import BXCheckboxDirective from '../../src/directives-angular/checkbox';
+import { BXCheckboxDirective } from '../../src/directives-angular/checkbox';
 
 @Component({
   template: `

--- a/tests/spec/input-angular_spec.ts
+++ b/tests/spec/input-angular_spec.ts
@@ -14,7 +14,7 @@ import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import BXInput from '../../src/components/input/input';
-import BXInputDirective from '../../src/directives-angular/input';
+import { BXInputDirective } from '../../src/directives-angular/input';
 
 @Component({
   template: `

--- a/tests/spec/input-angular_spec.ts
+++ b/tests/spec/input-angular_spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../polyfills/angular';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import BXInput from '../../src/components/input/input';
+import BXInputDirective from '../../src/directives-angular/input';
+
+@Component({
+  template: `
+    <form>
+      <bx-input [(ngModel)]="model.username" name="username"></bx-input>
+    </form>
+  `,
+})
+class InputAngularTest {
+  model = {
+    username: '',
+  };
+}
+
+describe('Angular directive for bx-input', () => {
+  beforeAll(function() {
+    TestBed.resetTestEnvironment();
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+  });
+
+  beforeEach(function() {
+    TestBed.configureTestingModule({
+      declarations: [BXInputDirective, InputAngularTest],
+      imports: [FormsModule],
+    });
+  });
+
+  it('should send the value to model upon `input` event', async function() {
+    const fixture = TestBed.createComponent(InputAngularTest);
+    fixture.detectChanges(); // Ensures event handlers are set up
+    await Promise.resolve(); // Ensures event handlers are set up
+    const debugElement = fixture.debugElement.query(By.css('bx-input'));
+    ((debugElement as unknown) as BXInput).value = 'value-foo';
+    debugElement.triggerEventHandler('input', { target: debugElement });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.model.username).toBe('value-foo');
+  });
+});

--- a/tests/spec/slider-angular_spec.ts
+++ b/tests/spec/slider-angular_spec.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../polyfills/angular';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import BXSliderDirective from '../../src/directives-angular/slider';
+
+@Component({
+  template: `
+    <form>
+      <bx-slider [(ngModel)]="model.number" name="number"></bx-slider>
+    </form>
+  `,
+})
+class SliderAngularTest {
+  model = {
+    number: 0,
+  };
+}
+
+describe('Angular directive for bx-slider', () => {
+  beforeAll(function() {
+    TestBed.resetTestEnvironment();
+    TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+  });
+
+  beforeEach(function() {
+    TestBed.configureTestingModule({
+      declarations: [BXSliderDirective, SliderAngularTest],
+      imports: [FormsModule],
+    });
+  });
+
+  it('should send the value to model upon `input` event', async function() {
+    const fixture = TestBed.createComponent(SliderAngularTest);
+    fixture.detectChanges(); // Ensures event handlers are set up
+    await Promise.resolve(); // Ensures event handlers are set up
+    const debugElement = fixture.debugElement.query(By.css('bx-slider'));
+    debugElement.triggerEventHandler('bx-slider-changed', { target: debugElement, detail: { value: 16 } });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.model.number).toBe(16);
+  });
+});

--- a/tests/spec/slider-angular_spec.ts
+++ b/tests/spec/slider-angular_spec.ts
@@ -13,7 +13,7 @@ import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import BXSliderDirective from '../../src/directives-angular/slider';
+import { BXSliderDirective } from '../../src/directives-angular/slider';
 
 @Component({
   template: `

--- a/tsconfig-angular-esm2015.json
+++ b/tsconfig-angular-esm2015.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "es2015",
+    "target": "es2015",
+    "baseUrl": "./src/directives-angular",
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "outDir": "./es/directives-angular/esm2015",
+    "rootDir": "./src/directives-angular",
+    "skipLibCheck": true,
+    "lib": ["dom", "es2015"]
+  },
+  "files": ["./src/directives-angular/index.ts"],
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true
+  }
+}

--- a/tsconfig-angular-esm5.json
+++ b/tsconfig-angular-esm5.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig-angular-esm2015.json",
+  "compilerOptions": {
+    "target": "es5",
+    "outDir": "./es/directives-angular/esm5",
+    "rootDir": "./src/directives-angular"
+  },
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,56 +2,72 @@
 # yarn lockfile v1
 
 
-"@angular-devkit/core@^7.0.0":
-  version "7.3.9"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-7.3.9.tgz#bef2aaa0be7219c546fb99ea0ba9dd3a6dcd288a"
-  integrity sha512-SaxD+nKFW3iCBKsxNR7+66J30EexW/y7tm8m5AvUH+GwSAgIj0ZYmRUzFEPggcaLVA4WnE/YWqIXZMJW5dT7gw==
+"@angular-devkit/core@^8.0.0":
+  version "8.3.14"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-8.3.14.tgz#b42716a0de44c8f2785a18ae5562ec2f76543c9b"
+  integrity sha512-+IYLbtCxwIpaieRj0wurEXBzZ/fDSdWbyrCfajzDerzsxqghNcafAXSazHXWwISqtbr/pAOuqUNR+mEk2XBz3Q==
   dependencies:
-    ajv "6.9.1"
-    chokidar "2.0.4"
+    ajv "6.10.2"
     fast-json-stable-stringify "2.0.0"
-    rxjs "6.3.3"
+    magic-string "0.25.3"
+    rxjs "6.4.0"
     source-map "0.7.3"
 
 "@angular/common@^8.0.0":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-8.1.3.tgz#ef6628b2eda25e6e9d5134dd3b6a96c906905e34"
-  integrity sha512-AnTlYV+Y3HYjJsAIt2AkIJ63qphvu9RNIJSZS61zQ4YBty29aslAJ/jh3PSWD0Yj9UT/AgzquJhfhhNEuImDRw==
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-8.2.12.tgz#9ec0ed1cc68128013f65167e175b9101b1c2bd9f"
+  integrity sha512-BNz1lo+PP+lwIX3sErRGBRnkMzT5yT8CJ5o/M29AanCdcx9dpoJG2WKgpIgw8UBcj9QlP0CkSmzPtUNtcNMthA==
   dependencies:
     tslib "^1.9.0"
 
+"@angular/compiler-cli@^8.0.0":
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-8.2.12.tgz#4949d9252b5fc2fe93426b5f3e208203c4d5a1f7"
+  integrity sha512-OrNnkJ7OrpbcOtB4TWFBF6D3dtEfUuOQgfc3HBjizZuL8EuX0pU5dv4VTvLTRkmyUT/7fmmWdkEXJL+UQtXqPg==
+  dependencies:
+    canonical-path "1.0.0"
+    chokidar "^2.1.1"
+    convert-source-map "^1.5.1"
+    dependency-graph "^0.7.2"
+    magic-string "^0.25.0"
+    minimist "^1.2.0"
+    reflect-metadata "^0.1.2"
+    source-map "^0.6.1"
+    tslib "^1.9.0"
+    yargs "13.1.0"
+
 "@angular/compiler@^8.0.0":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-8.1.3.tgz#6eea38f4f4511d37e2b5df04da04fefef9303f15"
-  integrity sha512-mKeRkpPy/iBPGBCVQIPF9x4f1S68ilEYaQTTfHoLR0OfivEQsyGuf2GEegwbTosEBX3JF+0JHfCNvsAE1zI5Og==
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-8.2.12.tgz#da843cd0d1ff79ec8a8ad007f2c374102840decf"
+  integrity sha512-V5mDWioGmSZ4cJJ2THo8qHYKwj3sUI7dpJ0oab2Al0FQAN8JCimWO6AQKRtjmnr78ZkMy9Xe/KK6ebl40ewL5Q==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/core@^8.0.0":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-8.1.3.tgz#3b12cf3785419c573cd54116ba80fc798f75448a"
-  integrity sha512-45ocymDkXhmgluhaIX/O6IgqGPCLOlSYEXYpJ660QS1JgprKU7Ae9mWiNSmbBmT0OGV/sKKF8SNMQAGOHgio6Q==
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-8.2.12.tgz#faef656cfa3b0bf4c1579d1498034045981c791a"
+  integrity sha512-wEFwhHCuuXynXAMeA1G+0KIYY0jqXYs7I8p+GO+ufKoUmzWHFTvtMJ6nvKgy+LmZTByO2gf9oVAAlRodNb8ttQ==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/forms@^8.0.0":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-8.1.3.tgz#b23722ab36a5e69384dab71210f9eb3d7e116378"
-  integrity sha512-NabNiUsR1XgrI1/T8hFwbTH0BMqhKd1riSTU+xyJ3qVbdmORq1xnf6/dLbljNGxViMU28P8hBXvyf1BoTS+HyQ==
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-8.2.12.tgz#0a113034075c64311b4c7294b6b51a07b8359e64"
+  integrity sha512-y1UObndCGbTYwLSzUWzCiX7th+mb4n712asApooGmfmIQmgTyHbKxYUJ9Ep1pgd0pqLBBnK249MQLH15NDpbyQ==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/platform-browser-dynamic@^8.0.0":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-8.1.3.tgz#bfa9ee9195b6dc3cb52aec02512fa9a21b048ddc"
-  integrity sha512-tsZWp8aFZNvbJ1TgP75GEfrwLe4SFW02kzEF12o7XlGU/iwnMjEs356rGHeueJZuWMFGS8PLL4mqPic7R5p53Q==
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-8.2.12.tgz#b1b5f7cd1832686ece45692b094d9d1386bd2313"
+  integrity sha512-O4krb+9tj028JOQHPgLk/87lyUlHt8dpNxzuYCT0G6kEmknjpyZBaxhvDPygGjGHXV3LDqlYVH+bh8ygJUhwmw==
   dependencies:
     tslib "^1.9.0"
 
 "@angular/platform-browser@^8.0.0":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-8.1.3.tgz#0ff0e82c6017b6bb9cdab6b915ef82979ada11a6"
-  integrity sha512-ihjoJd3OCmn/LBpYEDeCYnYJ1JRzeY6xYySNBEHNHLc07FX0TTiNwiZJHjbKoxdjr7qe6cj6gpT51M77pRlKKw==
+  version "8.2.12"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-8.2.12.tgz#884c37bcc5b84778096cb30fab576549ef695dc5"
+  integrity sha512-VBvMjmFJapZ2pFlmxZiHtfPwbHp79RRi5mrdMhETjKMaLaC2tAR/99ijCpx2urDMqb/VDm7YHOtoLEpBFVDulg==
   dependencies:
     tslib "^1.9.0"
 
@@ -3130,10 +3146,10 @@ ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@6.9.1:
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
-  integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
+ajv@6.10.2, ajv@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -3154,16 +3170,6 @@ ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
   version "6.6.2"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
   integrity sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.10.2:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
-  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -4699,7 +4705,7 @@ camelcase@^4.1.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -4723,6 +4729,11 @@ caniuse-lite@^1.0.30000984:
   version "1.0.30000984"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz#dc96c3c469e9bcfc6ad5bdd24c77ec918ea76fe0"
   integrity sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==
+
+canonical-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/canonical-path/-/canonical-path-1.0.0.tgz#fcb470c23958def85081856be7a86e904f180d1d"
+  integrity sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==
 
 carbon-components@^10.7.0:
   version "10.7.0"
@@ -4814,7 +4825,26 @@ chardet@^0.7.0:
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@2.0.4, chokidar@^2.0.2:
+chokidar@^2.0.0, chokidar@^2.0.3, chokidar@^2.0.4:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
+  integrity sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   integrity sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
@@ -4834,10 +4864,10 @@ chokidar@2.0.4, chokidar@^2.0.2:
   optionalDependencies:
     fsevents "^1.2.2"
 
-chokidar@^2.0.0, chokidar@^2.0.3, chokidar@^2.0.4:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
-  integrity sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
+chokidar@^2.1.1:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -4963,6 +4993,15 @@ cliui@^3.2.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 clone-buffer@^1.0.0:
@@ -5258,9 +5297,9 @@ conventional-commits-parser@^2.1.0:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@^1.5.0:
+convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.6.0"
-  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
@@ -5754,9 +5793,9 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
@@ -5881,6 +5920,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dependency-graph@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.7.2.tgz#91db9de6eb72699209d88aea4c1fd5221cac1c49"
+  integrity sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ==
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -7468,6 +7512,11 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
@@ -8503,6 +8552,11 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
 ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -9473,6 +9527,13 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
+
 lead@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lead/-/lead-1.0.0.tgz#6f14f99a37be3a9dd784f5495690e5903466ee42"
@@ -9987,6 +10048,20 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
+magic-string@0.25.3:
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.3.tgz#34b8d2a2c7fec9d9bdf9929a3fd81d271ef35be9"
+  integrity sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
+magic-string@^0.25.0:
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.4.tgz#325b8a0a79fc423db109b77fd5a19183b7ba5143"
+  integrity sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -10020,6 +10095,13 @@ mamacro@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
+
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
 
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
@@ -10134,6 +10216,15 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 memoize-one@^5.0.0:
   version "5.0.4"
@@ -10348,6 +10439,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -11196,6 +11292,15 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-locale@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  dependencies:
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -11209,10 +11314,20 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -12605,6 +12720,11 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
+reflect-metadata@^0.1.2:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 refractor@^2.4.1:
   version "2.6.2"
   resolved "https://registry.npmjs.org/refractor/-/refractor-2.6.2.tgz#8e0877ab8864165275aafeea5d9c8eebe871552f"
@@ -12892,6 +13012,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 requireindex@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
@@ -13051,7 +13176,14 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@6.3.3, rxjs@^6.1.0, rxjs@^6.3.3:
+rxjs@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.1.0, rxjs@^6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
@@ -13618,6 +13750,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz#e30a74f0402bad09807640d39e971090a08ce1e9"
+  integrity sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -14455,6 +14592,11 @@ tsconfig-paths@^3.4.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tsickle@^0.37.0:
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.37.1.tgz#2f8a87c1b15766e866457bd06fb6c0e0d84eed09"
+  integrity sha512-0GwgOJEnsmRsrONXCvcbAWY0CvdqF3UugPVoupUpA8Ul0qCPTuqqq0ou/hLqtKZOyyulzCP6MYRjb9/J1g9bJg==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -15214,6 +15356,11 @@ which-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
   integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
 which@1, which@^1.2.1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -15355,12 +15502,37 @@ yargs-parser@^10.0.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^13.0.0:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:
     camelcase "^3.0.0"
+
+yargs@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.1.0.tgz#b2729ce4bfc0c584939719514099d8a916ad2301"
+  integrity sha512-1UhJbXfzHiPqkfXNHYhiz79qM/kZqjTE8yGlEjZa85Q+3+OwcV6NRkV7XOV1W2Eom2bzILeUn55pQYffjVOLAg==
+  dependencies:
+    cliui "^4.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.0.0"
 
 yargs@^7.0.0, yargs@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
(Continuation of #156. Difference from the latest code of #156 is that this PR does APF support by using `ngc`, a primitive behind `ng-packagr`)

This change implements Angular directives that implement `ControlValueAccessor` interface for components that should be able to interact with `<form>` (e.g. `<bx-input>`), so `[(ngModel)]` works with those.

This change relies on automated test cases for testing and manual test case will be in a separate PR. You can take a glance at manual test case [here](https://github.com/asudoh/carbon-custom-elements/tree/form-examples/examples/codesandbox/form/angular), which can be run by the following:

```sh
> git fetch git@github.com:asudoh/carbon-custom-elements.git form-data
> git checkout FETCH_HEAD
> gulp clean
> gulp build
> git fetch git@github.com:asudoh/carbon-custom-elements.git form-examples
> git checkout FETCH_HEAD
> cd examples/codesandbox/form/angular
> yarn install
> cd node_modules/carbon-custom-elements
> rm -Rf es
> cp -r ../../../../../../es .
> cd ../..
> yarn start
```