### PR TITLE
chore(lint): add file extensions to cover

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,5 @@
 dist
 docs/js
 es
+node_modules
 tests/coverage

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:dist": "yarn lint:license:dist",
     "lint:license:src": "gulp lint:license:src",
     "lint:license:dist": "gulp lint:license:dist",
-    "lint:scripts": "eslint .",
+    "lint:scripts": "eslint --ext .js,.ts,.tsx .",
     "lint:license:staged": "tools/check-license.js",
     "lint:scripts:staged": "eslint",
     "test": "gulp test",
@@ -206,7 +206,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,ts}": [
+    "*.{js,ts,tsx}": [
       "yarn format:staged",
       "yarn lint:license:staged",
       "yarn lint:scripts:staged",

--- a/src/components/input/input-story-react.tsx
+++ b/src/components/input/input-story-react.tsx
@@ -10,14 +10,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import * as knobs from '@storybook/addon-knobs';
-import createProps from './stories/helpers';
 // Below path will be there when an application installs `carbon-custom-elements` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the genrated file.
 // @ts-ignore
 import BXInput from 'carbon-custom-elements/es/components-react/input/input';
 // @ts-ignore
 import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
-
+import createProps from './stories/helpers';
 
 storiesOf('Input', module)
   .addDecorator(knobs.withKnobs)
@@ -42,10 +41,10 @@ storiesOf('Input', module)
   .add('Without form item wrapper', () => {
     const { disabled, value, placeholder, invalid, type, onInput } = createProps(knobs);
     return (
-        <BXInput type={type} value={value} placeholder={placeholder} onInput={onInput} disabled={disabled} invalid={invalid}>
-          <span slot="label-text">Label text</span>
-          <span slot="helper-text">Optional helper text</span>
-          <span slot="validity-message">Something isn't right</span>
-        </BXInput>
+      <BXInput type={type} value={value} placeholder={placeholder} onInput={onInput} disabled={disabled} invalid={invalid}>
+        <span slot="label-text">Label text</span>
+        <span slot="helper-text">Optional helper text</span>
+        <span slot="validity-message">Something isn't right</span>
+      </BXInput>
     );
   });

--- a/src/components/textarea/textarea-story-react.tsx
+++ b/src/components/textarea/textarea-story-react.tsx
@@ -10,21 +10,19 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import * as knobs from '@storybook/addon-knobs';
-import createProps from './stories/helpers';
 // Below path will be there when an application installs `carbon-custom-elements` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the genrated file.
 // @ts-ignore
 import BXTextarea from 'carbon-custom-elements/es/components-react/textarea/textarea';
 // @ts-ignore
 import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
+import createProps from './stories/helpers';
 
 storiesOf('Textarea', module)
   .addDecorator(knobs.withKnobs)
   .add('Default', () => {
     const { disabled, value, placeholder, invalid, onInput } = createProps(knobs);
-    return (
-      <BXTextarea disabled={disabled} invalid={invalid} value={value} placeholder={placeholder} onInput={onInput} />
-    );
+    return <BXTextarea disabled={disabled} invalid={invalid} value={value} placeholder={placeholder} onInput={onInput} />;
   })
   .add('Form item', () => {
     const { disabled, value, placeholder, invalid, onInput } = createProps(knobs);


### PR DESCRIPTION
This change ensures `.tsx` files, etc. are covered in `yarn lint:scripts` task and `lint-staged`.