### PR TITLE
feat(date-picker): propagate error from Flatpickr

### DIFF
--- a/src/components/date-picker/date-picker-story-angular.ts
+++ b/src/components/date-picker/date-picker-story-angular.ts
@@ -19,6 +19,7 @@ const createProps = () => ({
   open: boolean('Open (open)', false),
   value: text('Value in ISO8601 date format, separated by `/` (value)', ''),
   onAfterChanged: action('bx-date-picker-changed'),
+  onFlatpickrError: action('bx-date-picker-flatpickr-error'),
 });
 
 const createInputProps = () => ({
@@ -67,6 +68,7 @@ storiesOf('Date picker', module)
         [open]="open"
         [value]="value"
         (bx-date-picker-changed)="onAfterChanged($event)"
+        (bx-date-picker-flatpickr-error)="onFlatpickrError($event)"
       >
         <bx-date-picker-input
           [disabled]="disabled"
@@ -100,6 +102,7 @@ storiesOf('Date picker', module)
         [open]="open"
         [value]="value"
         (bx-date-picker-changed)="onAfterChanged($event)"
+        (bx-date-picker-flatpickr-error)="onFlatpickrError($event)"
       >
         <bx-date-picker-input
           [disabled]="disabled"

--- a/src/components/date-picker/date-picker-story-react.tsx
+++ b/src/components/date-picker/date-picker-story-react.tsx
@@ -23,6 +23,7 @@ const createProps = () => ({
   open: boolean('Open (open)', false),
   value: text('Value in ISO8601 date format, separated by `/` (value)', ''),
   onAfterChanged: action('onAfterChanged'),
+  onFlatpickrError: action('onFlatpickrError'),
 });
 
 const createInputProps = () => ({
@@ -62,10 +63,15 @@ storiesOf('Date picker', module)
   .add(
     'Single with calendar',
     () => {
-      const { enabledRange, open, value, onAfterChanged } = createProps();
+      const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = createProps();
       const { disabled, hideLabel, labelText, light, placeholder, onInput } = createInputProps();
       return (
-        <BXDatePicker enabledRange={enabledRange} open={open} value={value} onAfterChanged={onAfterChanged}>
+        <BXDatePicker
+          enabledRange={enabledRange}
+          open={open}
+          value={value}
+          onAfterChanged={onAfterChanged}
+          onFlatpickrError={onFlatpickrError}>
           <BXDatePickerInput
             disabled={disabled}
             hideLabel={hideLabel}
@@ -87,10 +93,15 @@ storiesOf('Date picker', module)
   .add(
     'Range with calendar',
     () => {
-      const { enabledRange, open, value, onAfterChanged } = createProps();
+      const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = createProps();
       const { disabled, hideLabel, labelText, light, placeholder, onInput } = createInputProps();
       return (
-        <BXDatePicker enabledRange={enabledRange} open={open} value={value} onAfterChanged={onAfterChanged}>
+        <BXDatePicker
+          enabledRange={enabledRange}
+          open={open}
+          value={value}
+          onAfterChanged={onAfterChanged}
+          onFlatpickrError={onFlatpickrError}>
           <BXDatePickerInput
             disabled={disabled}
             hideLabel={hideLabel}

--- a/src/components/date-picker/date-picker-story-vue.ts
+++ b/src/components/date-picker/date-picker-story-vue.ts
@@ -20,6 +20,7 @@ const createProps = () => ({
   value: text('Value in ISO8601 date format, separated by `/` (value)', ''),
   placeholder: text('Placeholder text (placeholder in <bx-date-picker-input>)', 'mm/dd/yyyy'),
   onAfterChanged: action('bx-date-picker-changed'),
+  onFlatpickrError: action('bx-date-picker-flatpickr-error'),
 });
 
 const createInputProps = () => ({
@@ -64,6 +65,7 @@ storiesOf('Date picker', module)
         :open="open"
         :value="value"
         @bx-date-picker-changed="onAfterChanged"
+        @bx-date-picker-flatpickr-error="onFlatpickrError"
       >
         <bx-date-picker-input
           :disabled="disabled"
@@ -94,6 +96,7 @@ storiesOf('Date picker', module)
         :open="open"
         :value="value"
         @bx-date-picker-changed="onAfterChanged"
+        @bx-date-picker-flatpickr-error="onFlatpickrError"
       >
         <bx-date-picker-input
           :disabled="disabled"

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -17,6 +17,7 @@ const createProps = () => ({
   open: boolean('Open (open)', false),
   value: text('Value in ISO8601 date format, separated by `/` (value)', ''),
   onAfterChanged: action('bx-date-picker-changed'),
+  onFlatpickrError: action('bx-date-picker-flatpickr-error'),
 });
 
 const createInputProps = () => ({
@@ -57,7 +58,7 @@ storiesOf('Date picker', module)
   .add(
     'Single with calendar',
     () => {
-      const { enabledRange, open, value, onAfterChanged } = createProps();
+      const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = createProps();
       const { disabled, hideLabel, labelText, light, placeholder, onInput } = createInputProps();
       return html`
         <bx-date-picker
@@ -65,6 +66,7 @@ storiesOf('Date picker', module)
           ?open="${open}"
           value="${value}"
           @bx-date-picker-changed="${onAfterChanged}"
+          @bx-date-picker-flatpickr-error="${onFlatpickrError}"
         >
           <bx-date-picker-input
             ?disabled="${disabled}"
@@ -88,7 +90,7 @@ storiesOf('Date picker', module)
   .add(
     'Range with calendar',
     () => {
-      const { enabledRange, open, value, onAfterChanged } = createProps();
+      const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = createProps();
       const { disabled, hideLabel, labelText, light, placeholder, onInput } = createInputProps();
       return html`
         <bx-date-picker
@@ -96,6 +98,7 @@ storiesOf('Date picker', module)
           ?open="${open}"
           value="${value}"
           @bx-date-picker-changed="${onAfterChanged}"
+          @bx-date-picker-flatpickr-error="${onFlatpickrError}"
         >
           <bx-date-picker-input
             ?disabled="${disabled}"

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -167,6 +167,7 @@ class BXDatePicker extends LitElement {
       _dateInteractNode: dateInteractNode,
       _floatingMenuContainerNode: floatingMenuContainerNode,
       _datePickerPlugins: plugins,
+      _handleFlatpickrError: handleFlatpickrError,
     } = this;
     const dateFormat = this.dateFormat == null ? (this.constructor as typeof BXDatePicker).defaultDateFormat : this.dateFormat;
     // We use `<bx-date-picker-input>` to communicate values/events with Flatpickr,
@@ -177,6 +178,7 @@ class BXDatePicker extends LitElement {
       allowInput: true,
       appendTo: floatingMenuContainerNode,
       dateFormat,
+      errorHandler: handleFlatpickrError,
       locale,
       maxDate,
       minDate,
@@ -209,6 +211,22 @@ class BXDatePicker extends LitElement {
       this._instantiateDatePicker();
     }
   }
+
+  /**
+   * Fires a custom event to notify an error in Flatpickr.
+   */
+  private _handleFlatpickrError = (error: Error) => {
+    this.dispatchEvent(
+      new CustomEvent((this.constructor as typeof BXDatePicker).eventFlatpickrError, {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        detail: {
+          error,
+        },
+      })
+    );
+  };
 
   /**
    * Instantiates Flatpickr.
@@ -478,6 +496,13 @@ class BXDatePicker extends LitElement {
    */
   static get selectorInputTo() {
     return `${prefix}-date-picker-input[kind="to"]`;
+  }
+
+  /**
+   * The name of the custom event when Flatpickr throws an error.
+   */
+  static get eventFlatpickrError() {
+    return `${prefix}-date-picker-flatpickr-error`;
   }
 
   /**


### PR DESCRIPTION
With this change, `<bx-date-picker>` emits `bx-date-picker-flatpickr-error` event when Flatpickr calls its error callback. With this event, application can detect if user commits a date with a wrong date format, etc.
