### PR TITLE
chore(components): misc slot supports

### DIFF
--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -106,7 +106,7 @@ class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
         value="${ifDefined(value == null ? undefined : value)}"
         @change="${handleChange}"
       />
-      <label for="checkbox" class="${labelClasses}">${labelText}</label>
+      <label for="checkbox" class="${labelClasses}"><slot>${labelText}</slot></label>
     `;
   }
 

--- a/src/components/code-snippet/code-snippet.ts
+++ b/src/components/code-snippet/code-snippet.ts
@@ -270,7 +270,9 @@ class BXCodeSnippet extends LitElement {
         ${!showExpando
           ? undefined
           : renderExpando({
-              children: expanded ? collapseButtonText : expandButtonText,
+              children: expanded
+                ? html`<slot name="collapse-button-text">${collapseButtonText}</slot>`
+                : html`<slot name="expand-button-text">${expandButtonText}</slot>`,
               handleClick: handleClickExpando,
             })}
       `;

--- a/src/components/pagination/page-sizes-select.ts
+++ b/src/components/pagination/page-sizes-select.ts
@@ -68,7 +68,7 @@ class BXPageSizesSelect extends LitElement {
   render() {
     const { labelText, value, _handleChange: handleChange, _handleSlotChange: handleSlotChange } = this;
     return html`
-      <label for="select" class="${prefix}--pagination__text">${labelText}<slot name="label-text"></slot></label>
+      <label for="select" class="${prefix}--pagination__text"><slot name="label-text">${labelText}</slot></label>
       <div class="${prefix}--select__item-count">
         <select id="select" class="${prefix}--select-input" .value="${value}" @change=${handleChange}></select>
         ${ChevronDown16({ class: `${prefix}--select__arrow` })}

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -156,7 +156,7 @@ class BXSearch extends FocusMixin(LitElement) {
         role: 'img',
       })}
       <label for="input" class="${prefix}--label">
-        ${labelText}
+        <slot>${labelText}</slot>
       </label>
       <input
         id="input"

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -72,10 +72,10 @@ class BXToggle extends BXCheckbox {
         <span class="${prefix}--toggle__switch">
           ${this._renderCheckmark()}
           <span class="${prefix}--toggle__text--off" aria-hidden="true">
-            <slot name="off-text">${uncheckedText}</slot>
+            <slot name="unchecked-text">${uncheckedText}</slot>
           </span>
           <span class="${prefix}--toggle__text--on" aria-hidden="true">
-            <slot name="on-text">${checkedText}</slot>
+            <slot name="checked-text">${checkedText}</slot>
           </span>
         </span>
       </label>

--- a/tests/snapshots/bx-checkbox.md
+++ b/tests/snapshots/bx-checkbox.md
@@ -15,6 +15,8 @@
   class="bx--checkbox-label"
   for="checkbox"
 >
+  <slot>
+  </slot>
 </label>
 
 ```
@@ -35,7 +37,9 @@
   class="bx--checkbox-label bx--visually-hidden"
   for="checkbox"
 >
-  label-text-foo
+  <slot>
+    label-text-foo
+  </slot>
 </label>
 
 ```

--- a/tests/snapshots/bx-code-snippet.md
+++ b/tests/snapshots/bx-code-snippet.md
@@ -189,7 +189,9 @@
     class="bx--snippet-btn--text"
     id="button-text"
   >
-    expand-button-text-foo
+    <slot name="expand-button-text">
+      expand-button-text-foo
+    </slot>
   </span>
 </button>
 

--- a/tests/snapshots/bx-toggle.md
+++ b/tests/snapshots/bx-toggle.md
@@ -22,14 +22,14 @@
       aria-hidden="true"
       class="bx--toggle__text--off"
     >
-      <slot name="off-text">
+      <slot name="unchecked-text">
       </slot>
     </span>
     <span
       aria-hidden="true"
       class="bx--toggle__text--on"
     >
-      <slot name="on-text">
+      <slot name="checked-text">
       </slot>
     </span>
   </span>
@@ -61,7 +61,7 @@
       aria-hidden="true"
       class="bx--toggle__text--off"
     >
-      <slot name="off-text">
+      <slot name="unchecked-text">
         unchecked-text-foo
       </slot>
     </span>
@@ -69,7 +69,7 @@
       aria-hidden="true"
       class="bx--toggle__text--on"
     >
-      <slot name="on-text">
+      <slot name="checked-text">
         checked-text-foo
       </slot>
     </span>


### PR DESCRIPTION
This change supports `<slot>`s corresponding to some text attributes where it makes sense.