### PR TITLE
chore(devenv): support Storybook CSF

### DIFF
--- a/.storybook/react/config.tsx
+++ b/.storybook/react/config.tsx
@@ -28,18 +28,20 @@ addParameters({
   },
 });
 
-addDecorator(
-  story => <StrictMode>
-    <style>
-      {containerStyles.cssText}
-    </style>
-    <bx-ce-demo-focus-trap href="#main-content" aria-label="Skip to main content">Skip to main content</bx-ce-demo-focus-trap>
+addDecorator(story => (
+  <StrictMode>
+    <style>{containerStyles.cssText}</style>
+    <bx-ce-demo-focus-trap href="#main-content" aria-label="Skip to main content">
+      Skip to main content
+    </bx-ce-demo-focus-trap>
     <div id="main-content" data-floating-menu-container role="main" className="bx--body bx-ce-demo-devenv--container">
       {story()}
     </div>
-    <bx-ce-demo-focus-trap href="#main-content" aria-label="End of content">End of content</bx-ce-demo-focus-trap>
+    <bx-ce-demo-focus-trap href="#main-content" aria-label="End of content">
+      End of content
+    </bx-ce-demo-focus-trap>
   </StrictMode>
-);
+));
 
 addons.getChannel().on(CURRENT_THEME, theme => {
   document.documentElement.setAttribute('storybook-carbon-theme', theme);

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -76,10 +76,22 @@ module.exports = ({ config, mode }) => {
       use: [...babelLoaderRule.use, require.resolve('../svg-result-carbon-icon-loader')],
     },
     {
+      test: /-story\.ts$/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            babelrc: false,
+            plugins: [require.resolve('../babel-plugin-story-add-readme')],
+          },
+        },
+      ],
+    },
+    {
       test: /-story(-(angular|react|vue))?\.[jt]sx?$/,
       use: [
         {
-          loader: require.resolve('@storybook/addon-storysource/loader'),
+          loader: require.resolve('@storybook/source-loader'),
           options: {
             parser: 'typescript',
             prettierConfig: {
@@ -120,7 +132,6 @@ module.exports = ({ config, mode }) => {
                   autoLabel: true,
                 },
               ],
-              require.resolve('../babel-plugin-story-add-readme'),
             ],
           },
         },

--- a/babel-plugin-story-add-readme.js
+++ b/babel-plugin-story-add-readme.js
@@ -11,7 +11,7 @@
 
 const { default: template } = require('@babel/template');
 
-module.exports = function storyAddReadme() {
+module.exports = function storyAddReadme({ types: t }) {
   const getParentClassImportSource = path => {
     const { parentPath } = path;
     if (path.isImportSpecifier() && parentPath.isImportDeclaration && parentPath.get('source').isStringLiteral()) {
@@ -39,6 +39,44 @@ module.exports = function storyAddReadme() {
             `);
             path.skip();
           }
+        }
+      },
+
+      ExportDefaultDeclaration(path) {
+        const declaration = path.get('declaration');
+        if (!declaration.isObjectExpression()) {
+          throw declaration.buildCodeFrameError('The default export must be an object literal.');
+        }
+        const propertiesDefaultExport = declaration.get('properties');
+        const parameters = propertiesDefaultExport.find(item => item.get('key').isIdentifier({ name: 'parameters' }));
+        const readmeIIFEExpression = template.ast`
+          (function () {
+            try {
+              const readme = require('./README.md');
+              return readme && readme.default;
+            } catch {}
+          })()
+        `.expression;
+        if (parameters) {
+          const value = parameters.get('value');
+          if (!value.isObjectExpression()) {
+            throw value.buildCodeFrameError('`parameters` in `.story` must be an object literal.');
+          }
+          const propertiesParameters = value.get('properties');
+          if (!propertiesParameters.some(item => item.get('key').isIdentifier({ name: 'notes' }))) {
+            const clonedParametersValue = t.cloneDeep(value.node);
+            clonedParametersValue.properties.push(t.objectProperty(t.identifier('notes'), readmeIIFEExpression));
+            value.replaceWith(clonedParametersValue);
+          }
+        } else {
+          const clonedStoryRight = t.cloneDeep(declaration.node);
+          clonedStoryRight.properties.push(
+            t.objectProperty(
+              t.identifier('parameters'),
+              t.objectExpression([t.objectProperty(t.identifier('notes'), readmeIIFEExpression)])
+            )
+          );
+          declaration.replaceWith(clonedStoryRight);
         }
       },
     },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@storybook/angular": "^5.2.0",
     "@storybook/polymer": "^5.2.0",
     "@storybook/react": "^5.2.0",
+    "@storybook/source-loader": "^5.2.0",
     "@storybook/vue": "^5.2.0",
     "@types/jasmine": "^3.3.0",
     "@types/webpack-env": "^1.14.0",

--- a/src/components/accordion/accordion-story.ts
+++ b/src/components/accordion/accordion-story.ts
@@ -8,56 +8,65 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './accordion';
 import './accordion-item';
 
-const createProps = () => ({
-  open: boolean('Open the section (open)', false),
-  titleText: text('The title (title-text)', 'Section title'),
-  disableToggle: boolean(
-    'Disable user-initiated toggle action (Call event.preventDefault() in bx-accordion-beingtoggled event)',
-    false
-  ),
-});
+export const defaultStory = ({ parameters }) => {
+  const { open, titleText, disableToggle } =
+    (parameters.props && parameters.props['bx-accordion']) || ({} as typeof parameters.props['bx-accordion']);
+  const beforeToggleAction = action('bx-accordion-item-beingtoggled');
+  const handleBeforeToggle = (event: CustomEvent) => {
+    beforeToggleAction(event);
+    if (disableToggle) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-accordion
+      @bx-accordion-item-beingtoggled="${handleBeforeToggle}"
+      @bx-accordion-item-toggled="${action('bx-accordion-item-toggled')}"
+    >
+      <bx-accordion-item ?open="${open}" title-text=${titleText}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+      </bx-accordion-item>
+      <bx-accordion-item ?open="${open}" title-text=${titleText}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+      </bx-accordion-item>
+      <bx-accordion-item ?open="${open}">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </p>
+        <span slot="title">${titleText}</span>
+      </bx-accordion-item>
+    </bx-accordion>
+  `;
+};
 
-storiesOf('Accordion', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { open, titleText, disableToggle } = createProps();
-    const beforeToggleAction = action('bx-accordion-item-beingtoggled');
-    const handleBeforeToggle = (event: CustomEvent) => {
-      beforeToggleAction(event);
-      if (disableToggle) {
-        event.preventDefault();
-      }
-    };
-    return html`
-      <bx-accordion
-        @bx-accordion-item-beingtoggled="${handleBeforeToggle}"
-        @bx-accordion-item-toggled="${action('bx-accordion-item-toggled')}"
-      >
-        <bx-accordion-item ?open="${open}" title-text=${titleText}>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </p>
-        </bx-accordion-item>
-        <bx-accordion-item ?open="${open}" title-text=${titleText}>
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </p>
-        </bx-accordion-item>
-        <bx-accordion-item ?open="${open}">
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-            aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </p>
-          <span slot="title">${titleText}</span>
-        </bx-accordion-item>
-      </bx-accordion>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Accordion',
+  parameters: {
+    knobs: {
+      'bx-accordion': () => ({
+        open: boolean('Open the section (open)', false),
+        titleText: text('The title (title-text)', 'Section title'),
+        disableToggle: boolean(
+          'Disable user-initiated toggle action (Call event.preventDefault() in bx-accordion-beingtoggled event)',
+          false
+        ),
+      }),
+    },
+  },
+};

--- a/src/components/button/button-story.ts
+++ b/src/components/button/button-story.ts
@@ -9,9 +9,8 @@
 
 import { html } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { BUTTON_KIND } from './button';
 
 const kinds = {
@@ -21,21 +20,31 @@ const kinds = {
   [`Ghost button (${BUTTON_KIND.GHOST})`]: BUTTON_KIND.GHOST,
 };
 
-const createProps = () => ({
-  kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY),
-  disabled: boolean('Disabled (disabled)', false),
-  small: boolean('Small (small)', false),
-  href: text('Link href (href)', ''),
-  onClick: action('click'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { kind, disabled, small, href, onClick } =
+    (parameters.props && parameters.props['bx-btn']) || ({} as typeof parameters.props['bx-btn']);
+  return html`
+    <bx-btn kind=${kind} ?disabled=${disabled} ?small=${small} href=${ifDefined(href || undefined)} @click=${onClick}>
+      Button
+    </bx-btn>
+  `;
+};
 
-storiesOf('Button', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { kind, disabled, small, href, onClick } = createProps();
-    return html`
-      <bx-btn kind=${kind} ?disabled=${disabled} ?small=${small} href=${ifDefined(href || undefined)} @click=${onClick}>
-        Button
-      </bx-btn>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Button',
+  parameters: {
+    knobs: {
+      'bx-btn': () => ({
+        kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY),
+        disabled: boolean('Disabled (disabled)', false),
+        small: boolean('Small (small)', false),
+        href: text('Link href (href)', ''),
+        onClick: action('click'),
+      }),
+    },
+  },
+};

--- a/src/components/checkbox/checkbox-story.ts
+++ b/src/components/checkbox/checkbox-story.ts
@@ -9,36 +9,45 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './checkbox';
 
-const createProps = () => ({
-  checked: boolean('Checked (checked)', false),
-  disabled: boolean('Disabled (disabled)', false),
-  hideLabel: boolean('Hide label (hide-label)', false),
-  indeterminate: boolean('Indeterminate state (indeterminate)', false),
-  labelText: text('Label text (label-text)', 'Checkbox'),
-  name: text('Name (name)', ''),
-  value: text('Value (value)', ''),
-  onInput: action('input'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onInput } =
+    (parameters.props && parameters.props['bx-checkbox']) || ({} as typeof parameters.props['bx-checkbox']);
+  return html`
+    <bx-checkbox
+      ?checked="${checked}"
+      ?disabled="${disabled}"
+      ?hide-label="${hideLabel}"
+      ?indeterminate="${indeterminate}"
+      label-text="${labelText}"
+      name="${ifDefined(!name ? undefined : name)}"
+      value="${ifDefined(!value ? undefined : value)}"
+      @input="${onInput}"
+    ></bx-checkbox>
+  `;
+};
 
-storiesOf('Checkbox', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onInput } = createProps();
-    return html`
-      <bx-checkbox
-        ?checked="${checked}"
-        ?disabled="${disabled}"
-        ?hide-label="${hideLabel}"
-        ?indeterminate="${indeterminate}"
-        label-text="${labelText}"
-        name="${ifDefined(!name ? undefined : name)}"
-        value="${ifDefined(!value ? undefined : value)}"
-        @input="${onInput}"
-      ></bx-checkbox>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Checkbox',
+  parameters: {
+    knobs: {
+      'bx-checkbox': () => ({
+        checked: boolean('Checked (checked)', false),
+        disabled: boolean('Disabled (disabled)', false),
+        hideLabel: boolean('Hide label (hide-label)', false),
+        indeterminate: boolean('Indeterminate state (indeterminate)', false),
+        labelText: text('Label text (label-text)', 'Checkbox'),
+        name: text('Name (name)', ''),
+        value: text('Value (value)', ''),
+        onInput: action('input'),
+      }),
+    },
+  },
+};

--- a/src/components/code-snippet/code-snippet-story.ts
+++ b/src/components/code-snippet/code-snippet-story.ts
@@ -9,132 +9,135 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, number, text } from '@storybook/addon-knobs';
+import { number, text } from '@storybook/addon-knobs';
 import './code-snippet';
 
-const createProps = () => ({
-  codeAssistiveText: text('Assistive text for the code portion (code-assistive-text)', ''),
-  copyButtonAssistiveText: text('Assistive text for the copy button (copy-button-assistive-text)', ''),
-  copyButtonFeedbackText: text('Feedback text for copy button (copy-button-feedback-text)', ''),
-  copyButtonFeedbackTimeout: number('Feedback timeout for copy button (copy-buttobn-feedback-timeout)', 2000),
-  onClick: action('click'),
-});
+const defaultKnobs = {
+  'bx-code-snippet': () => ({
+    codeAssistiveText: text('Assistive text for the code portion (code-assistive-text)', ''),
+    copyButtonAssistiveText: text('Assistive text for the copy button (copy-button-assistive-text)', ''),
+    copyButtonFeedbackText: text('Feedback text for copy button (copy-button-feedback-text)', ''),
+    copyButtonFeedbackTimeout: number('Feedback timeout for copy button (copy-buttobn-feedback-timeout)', 2000),
+    onClick: action('click'),
+  }),
+};
 
-const createMultilineProps = () => ({
-  collapseButtonText: text('The text for the collapse button (collapse-button-text)', ''),
-  expandButtonText: text('The text for the expand button (expand-button-text)', ''),
-});
+export const singleLine = ({ parameters }) => {
+  const { codeAssistiveText, copyButtonAssistiveText, copyButtonFeedbackText, copyButtonFeedbackTimeout, onClick } =
+    (parameters.props && parameters.props['bx-code-snippet']) || ({} as typeof parameters.props['bx-code-snippet']);
+  return html`
+    <bx-code-snippet
+      code-assistive-text="${ifDefined(!codeAssistiveText ? undefined : codeAssistiveText)}"
+      copy-button-assistive-text="${ifDefined(!copyButtonAssistiveText ? undefined : copyButtonAssistiveText)}"
+      copy-button-feedback-text="${ifDefined(!copyButtonFeedbackText ? undefined : copyButtonFeedbackText)}"
+      copy-button-feedback-timeout="${copyButtonFeedbackTimeout}"
+      @click="${onClick}"
+      >node -v Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis, veritatis voluptate id incidunt molestiae
+      officia possimus, quasi itaque alias, architecto hic, dicta fugit? Debitis delectus quidem explicabo vitae fuga
+      laboriosam!</bx-code-snippet
+    >
+  `;
+};
 
-storiesOf('Code snippet', module)
-  .addDecorator(withKnobs)
-  .add(
-    'Single line',
-    () => {
-      const {
-        codeAssistiveText,
-        copyButtonAssistiveText,
-        copyButtonFeedbackText,
-        copyButtonFeedbackTimeout,
-        onClick,
-      } = createProps();
-      return html`
-        <bx-code-snippet
-          code-assistive-text="${ifDefined(!codeAssistiveText ? undefined : codeAssistiveText)}"
-          copy-button-assistive-text="${ifDefined(!copyButtonAssistiveText ? undefined : copyButtonAssistiveText)}"
-          copy-button-feedback-text="${ifDefined(!copyButtonFeedbackText ? undefined : copyButtonFeedbackText)}"
-          copy-button-feedback-timeout="${copyButtonFeedbackTimeout}"
-          @click="${onClick}"
-          >node -v Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis, veritatis voluptate id incidunt molestiae
-          officia possimus, quasi itaque alias, architecto hic, dicta fugit? Debitis delectus quidem explicabo vitae fuga
-          laboriosam!</bx-code-snippet
-        >
-      `;
+singleLine.story = {
+  name: 'Single line',
+  parameters: {
+    docs: {
+      storyDescription: 'The Terminal style is for single-line.',
     },
-    {
-      docs: {
-        storyDescription: 'The Terminal style is for single-line.',
-      },
-    }
-  )
-  .add(
-    'Multi line',
-    () => {
-      const {
-        codeAssistiveText,
-        copyButtonAssistiveText,
-        copyButtonFeedbackText,
-        copyButtonFeedbackTimeout,
-        collapseButtonText,
-        expandButtonText,
-        onClick,
-      } = { ...createProps(), ...createMultilineProps() };
-      // prettier-ignore
-      return html`
-      <bx-code-snippet
-        type="multi"
-        code-assistive-text="${ifDefined(!codeAssistiveText ? undefined : codeAssistiveText)}"
-        copy-button-assistive-text="${ifDefined(!copyButtonAssistiveText ? undefined : copyButtonAssistiveText)}"
-        copy-button-feedback-text="${ifDefined(!copyButtonFeedbackText ? undefined : copyButtonFeedbackText)}"
-        copy-button-feedback-timeout="${copyButtonFeedbackTimeout}"
-        collapse-button-text="${ifDefined(!collapseButtonText ? undefined : collapseButtonText)}"
-        expand-button-text="${ifDefined(!expandButtonText ? undefined : expandButtonText)}"
-        @click="${onClick}"
-      >@mixin grid-container {
-  width: 100%;
-  padding-right: padding(mobile);
-  padding-left: padding(mobile);
+  },
+};
 
-  @include breakpoint(bp--xs--major) {
-    padding-right: padding(xs);
-    padding-left: padding(xs);
-  }
+export const multiLine = ({ parameters }) => {
+  const {
+    codeAssistiveText,
+    copyButtonAssistiveText,
+    copyButtonFeedbackText,
+    copyButtonFeedbackTimeout,
+    collapseButtonText,
+    expandButtonText,
+    onClick,
+  } = (parameters.props && parameters.props['bx-code-snippet']) || ({} as typeof parameters.props['bx-code-snippet']);
+  // prettier-ignore
+  return html`
+  <bx-code-snippet
+    type="multi"
+    code-assistive-text="${ifDefined(!codeAssistiveText ? undefined : codeAssistiveText)}"
+    copy-button-assistive-text="${ifDefined(!copyButtonAssistiveText ? undefined : copyButtonAssistiveText)}"
+    copy-button-feedback-text="${ifDefined(!copyButtonFeedbackText ? undefined : copyButtonFeedbackText)}"
+    copy-button-feedback-timeout="${copyButtonFeedbackTimeout}"
+    collapse-button-text="${ifDefined(!collapseButtonText ? undefined : collapseButtonText)}"
+    expand-button-text="${ifDefined(!expandButtonText ? undefined : expandButtonText)}"
+    @click="${onClick}"
+  >@mixin grid-container {
+width: 100%;
+padding-right: padding(mobile);
+padding-left: padding(mobile);
+
+@include breakpoint(bp--xs--major) {
+padding-right: padding(xs);
+padding-left: padding(xs);
+}
 }
 
 $z-indexes: (
-  modal : 9000,
-  overlay : 8000,
-  dropdown : 7000,
-  header : 6000,
-  footer : 5000,
-  hidden : - 1,
-  overflowHidden: - 1,
-  floating: 10000
+modal : 9000,
+overlay : 8000,
+dropdown : 7000,
+header : 6000,
+footer : 5000,
+hidden : - 1,
+overflowHidden: - 1,
+floating: 10000
 );</bx-code-snippet>
-    `;
+`;
+};
+
+multiLine.story = {
+  name: 'Multi line',
+  parameters: {
+    docs: {
+      storyDescription: 'The Code style is for larger, multi-line code snippets.',
     },
-    {
-      docs: {
-        storyDescription: 'The Code style is for larger, multi-line code snippets.',
-      },
-    }
-  )
-  .add(
-    'Inline',
-    () => {
-      const {
-        codeAssistiveText,
-        copyButtonAssistiveText,
-        copyButtonFeedbackText,
-        copyButtonFeedbackTimeout,
-        onClick,
-      } = createProps();
-      return html`
-        <bx-code-snippet
-          type="inline"
-          code-assistive-text="${ifDefined(!codeAssistiveText ? undefined : codeAssistiveText)}"
-          copy-button-assistive-text="${ifDefined(!copyButtonAssistiveText ? undefined : copyButtonAssistiveText)}"
-          copy-button-feedback-text="${ifDefined(!copyButtonFeedbackText ? undefined : copyButtonFeedbackText)}"
-          copy-button-feedback-timeout="${copyButtonFeedbackTimeout}"
-          @click="${onClick}"
-          >node -v</bx-code-snippet
-        >
-      `;
+    knobs: {
+      'bx-code-snippet': () => ({
+        ...defaultKnobs['bx-code-snippet'](),
+        collapseButtonText: text('The text for the collapse button (collapse-button-text)', ''),
+        expandButtonText: text('The text for the expand button (expand-button-text)', ''),
+      }),
     },
-    {
-      docs: {
-        storyDescription: 'The Inline style is for code used within a block of text.',
-      },
-    }
-  );
+  },
+};
+
+export const inline = ({ parameters }) => {
+  const { codeAssistiveText, copyButtonAssistiveText, copyButtonFeedbackText, copyButtonFeedbackTimeout, onClick } =
+    (parameters.props && parameters.props['bx-code-snippet']) || ({} as typeof parameters.props['bx-code-snippet']);
+  return html`
+    <bx-code-snippet
+      type="inline"
+      code-assistive-text="${ifDefined(!codeAssistiveText ? undefined : codeAssistiveText)}"
+      copy-button-assistive-text="${ifDefined(!copyButtonAssistiveText ? undefined : copyButtonAssistiveText)}"
+      copy-button-feedback-text="${ifDefined(!copyButtonFeedbackText ? undefined : copyButtonFeedbackText)}"
+      copy-button-feedback-timeout="${copyButtonFeedbackTimeout}"
+      @click="${onClick}"
+      >node -v</bx-code-snippet
+    >
+  `;
+};
+
+inline.story = {
+  name: 'Inline',
+  parameters: {
+    docs: {
+      storyDescription: 'The Inline style is for code used within a block of text.',
+    },
+  },
+};
+
+export default {
+  title: 'Code snippet',
+  parameters: {
+    knobs: defaultKnobs,
+  },
+};

--- a/src/components/combo-box/combo-box-story.ts
+++ b/src/components/combo-box/combo-box-story.ts
@@ -8,69 +8,67 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './combo-box';
 import './combo-box-item';
 
-const createProps = () => ({
-  open: boolean('Open (open)', false),
-  disabled: boolean('Disabled (disabled)', false),
-  helperText: text('Helper text (helper-text)', ''),
-  invalid: boolean('Show invalid state  (invalid)', false),
-  labelText: text('Label text (label-text)', ''),
-  light: boolean('Light variant (light)', false),
-  value: text('The value of the selected item (value)', ''),
-  triggerContent: text('The placeholder content (trigger-content)', 'Filter...'),
-  validityMessage: text('The validity message (validity-message)', ''),
-  disableSelection: boolean(
-    'Disable user-initiated selection change (Call event.preventDefault() in bx-combo-box-beingselected event)',
-    false
-  ),
-});
+export const defaultStory = ({ parameters }) => {
+  const { open, disabled, helperText, invalid, labelText, light, value, triggerContent, validityMessage, disableSelection } =
+    (parameters.props && parameters.props['bx-combo-box']) || ({} as typeof parameters.props['bx-combo-box']);
+  const beforeSelectedAction = action('bx-combo-box-beingselected');
+  const handleBeforeSelected = (event: CustomEvent) => {
+    beforeSelectedAction(event);
+    if (disableSelection) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-combo-box
+      ?open=${open}
+      ?disabled=${disabled}
+      ?invalid=${invalid}
+      ?light=${light}
+      helper-text=${helperText}
+      label-text=${labelText}
+      validity-message=${validityMessage}
+      value=${value}
+      trigger-content=${triggerContent}
+      @bx-combo-box-beingselected=${handleBeforeSelected}
+      @bx-combo-box-selected=${action('bx-combo-box-selected')}
+    >
+      <bx-combo-box-item value="all">Option 1</bx-combo-box-item>
+      <bx-combo-box-item value="cloudFoundry">Option 2</bx-combo-box-item>
+      <bx-combo-box-item value="staging">Option 3</bx-combo-box-item>
+      <bx-combo-box-item value="dea">Option 4</bx-combo-box-item>
+      <bx-combo-box-item value="router">Option 5</bx-combo-box-item>
+    </bx-combo-box>
+  `;
+};
 
-storiesOf('Combo box', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const {
-      open,
-      disabled,
-      helperText,
-      invalid,
-      labelText,
-      light,
-      value,
-      triggerContent,
-      validityMessage,
-      disableSelection,
-    } = createProps();
-    const beforeSelectedAction = action('bx-combo-box-beingselected');
-    const handleBeforeSelected = (event: CustomEvent) => {
-      beforeSelectedAction(event);
-      if (disableSelection) {
-        event.preventDefault();
-      }
-    };
-    return html`
-      <bx-combo-box
-        ?open=${open}
-        ?disabled=${disabled}
-        ?invalid=${invalid}
-        ?light=${light}
-        helper-text=${helperText}
-        label-text=${labelText}
-        validity-message=${validityMessage}
-        value=${value}
-        trigger-content=${triggerContent}
-        @bx-combo-box-beingselected=${handleBeforeSelected}
-        @bx-combo-box-selected=${action('bx-combo-box-selected')}
-      >
-        <bx-combo-box-item value="all">Option 1</bx-combo-box-item>
-        <bx-combo-box-item value="cloudFoundry">Option 2</bx-combo-box-item>
-        <bx-combo-box-item value="staging">Option 3</bx-combo-box-item>
-        <bx-combo-box-item value="dea">Option 4</bx-combo-box-item>
-        <bx-combo-box-item value="router">Option 5</bx-combo-box-item>
-      </bx-combo-box>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Combo box',
+  parameters: {
+    knobs: {
+      'bx-combo-box': () => ({
+        open: boolean('Open (open)', false),
+        disabled: boolean('Disabled (disabled)', false),
+        helperText: text('Helper text (helper-text)', ''),
+        invalid: boolean('Show invalid state  (invalid)', false),
+        labelText: text('Label text (label-text)', ''),
+        light: boolean('Light variant (light)', false),
+        value: text('The value of the selected item (value)', ''),
+        triggerContent: text('The placeholder content (trigger-content)', 'Filter...'),
+        validityMessage: text('The validity message (validity-message)', ''),
+        disableSelection: boolean(
+          'Disable user-initiated selection change (Call event.preventDefault() in bx-combo-box-beingselected event)',
+          false
+        ),
+      }),
+    },
+  },
+};

--- a/src/components/copy-button/copy-button-story.ts
+++ b/src/components/copy-button/copy-button-story.ts
@@ -9,28 +9,37 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, number, text } from '@storybook/addon-knobs';
+import { number, text } from '@storybook/addon-knobs';
 import './copy-button';
 
-const createProps = () => ({
-  buttonAssistiveText: text('Assistive text for the button (button-assistive-text)', ''),
-  feedbackText: text('Feedback text (feedback-text)', ''),
-  feedbackTimeout: number('Feedback timeout (feedback-timeout)', 2000),
-  onClick: action('click'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { buttonAssistiveText, feedbackText, feedbackTimeout, onClick } =
+    (parameters.props && parameters.props['bx-copy-button']) || ({} as typeof parameters.props['bx-copy-button']);
+  return html`
+    <bx-copy-button
+      button-assistive-text="${ifDefined(!buttonAssistiveText ? undefined : buttonAssistiveText)}"
+      feedback-text="${ifDefined(!feedbackText ? undefined : feedbackText)}"
+      feedback-timeout="${feedbackTimeout}"
+      @click="${onClick}"
+    ></bx-copy-button>
+  `;
+};
 
-storiesOf('Copy button', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { buttonAssistiveText, feedbackText, feedbackTimeout, onClick } = createProps();
-    return html`
-      <bx-copy-button
-        button-assistive-text="${ifDefined(!buttonAssistiveText ? undefined : buttonAssistiveText)}"
-        feedback-text="${ifDefined(!feedbackText ? undefined : feedbackText)}"
-        feedback-timeout="${feedbackTimeout}"
-        @click="${onClick}"
-      ></bx-copy-button>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Copy button',
+  parameters: {
+    knobs: {
+      'bx-copy-button': () => ({
+        buttonAssistiveText: text('Assistive text for the button (button-assistive-text)', ''),
+        feedbackText: text('Feedback text (feedback-text)', ''),
+        feedbackTimeout: number('Feedback timeout (feedback-timeout)', 2000),
+        onClick: action('click'),
+      }),
+    },
+  },
+};

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -10,9 +10,8 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { repeat } from 'lit-html/directives/repeat';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import '../pagination/pagination';
 import '../pagination/page-sizes-select';
 import '../pagination/pages-select';
@@ -320,155 +319,209 @@ const sizes = {
   [`Tall size (${TABLE_SIZE.TALL})`]: TABLE_SIZE.TALL,
 };
 
-const createProps = ({ sortable }: { sortable?: boolean } = {}) => {
-  const hasSelection = sortable && boolean('Supports selection feature (has-selection)', false);
-  return {
-    hasSelection,
-    size: select('Table size (size)', sizes, TABLE_SIZE.REGULAR),
-    zebra: boolean('Supports zebra stripe (zebra in `<bx-table-body>`)', false),
-    disableChangeSelection:
-      hasSelection &&
-      boolean(
-        'Disable user-initiated change in selection ' +
-          '(Call event.preventDefault() in bx-table-row-change-selection/bx-table-change-selection-all events)',
-        false
-      ),
-    disableChangeSort:
-      sortable &&
-      boolean('Disable user-initiated change in sorting (Call event.preventDefault() in bx-table-header-cell-sort event)', false),
-  };
+export const defaultStory = ({ parameters }) => {
+  const { 'bx-table': tableProps, 'bx-table-body': tableBodyProps } = parameters.props || ({} as typeof parameters.props);
+  const { size } = tableProps || ({} as typeof tableProps);
+  const { zebra } = tableBodyProps || ({} as typeof tableBodyProps);
+  return html`
+    <bx-table size="${size}">
+      <bx-table-head>
+        <bx-table-header-row>
+          <bx-table-header-cell>Name</bx-table-header-cell>
+          <bx-table-header-cell>Protocol</bx-table-header-cell>
+          <bx-table-header-cell>Port</bx-table-header-cell>
+          <bx-table-header-cell>Rule</bx-table-header-cell>
+          <bx-table-header-cell>Attached Groups</bx-table-header-cell>
+          <bx-table-header-cell>Status</bx-table-header-cell>
+        </bx-table-header-row>
+      </bx-table-head>
+      <bx-table-body ?zebra="${zebra}">
+        <bx-table-row>
+          <bx-table-cell>Load Balancer 1</bx-table-cell>
+          <bx-table-cell>HTTP</bx-table-cell>
+          <bx-table-cell>80</bx-table-cell>
+          <bx-table-cell>Round Robin</bx-table-cell>
+          <bx-table-cell>Maureen's VM Groups</bx-table-cell>
+          <bx-table-cell>Active</bx-table-cell>
+        </bx-table-row>
+        <bx-table-row>
+          <bx-table-cell>Load Balancer 2</bx-table-cell>
+          <bx-table-cell>HTTP</bx-table-cell>
+          <bx-table-cell>80</bx-table-cell>
+          <bx-table-cell>Round Robin</bx-table-cell>
+          <bx-table-cell>Maureen's VM Groups</bx-table-cell>
+          <bx-table-cell>Active</bx-table-cell>
+        </bx-table-row>
+        <bx-table-row>
+          <bx-table-cell>Load Balancer 3</bx-table-cell>
+          <bx-table-cell>HTTP</bx-table-cell>
+          <bx-table-cell>80</bx-table-cell>
+          <bx-table-cell>Round Robin</bx-table-cell>
+          <bx-table-cell>Maureen's VM Groups</bx-table-cell>
+          <bx-table-cell>Active</bx-table-cell>
+        </bx-table-row>
+      </bx-table-body>
+    </bx-table>
+  `;
 };
 
-storiesOf('Data table', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { size, zebra } = createProps();
-    return html`
-      <bx-table size="${size}">
-        <bx-table-head>
-          <bx-table-header-row>
-            <bx-table-header-cell>Name</bx-table-header-cell>
-            <bx-table-header-cell>Protocol</bx-table-header-cell>
-            <bx-table-header-cell>Port</bx-table-header-cell>
-            <bx-table-header-cell>Rule</bx-table-header-cell>
-            <bx-table-header-cell>Attached Groups</bx-table-header-cell>
-            <bx-table-header-cell>Status</bx-table-header-cell>
-          </bx-table-header-row>
-        </bx-table-head>
-        <bx-table-body ?zebra="${zebra}">
-          <bx-table-row>
-            <bx-table-cell>Load Balancer 1</bx-table-cell>
-            <bx-table-cell>HTTP</bx-table-cell>
-            <bx-table-cell>80</bx-table-cell>
-            <bx-table-cell>Round Robin</bx-table-cell>
-            <bx-table-cell>Maureen's VM Groups</bx-table-cell>
-            <bx-table-cell>Active</bx-table-cell>
-          </bx-table-row>
-          <bx-table-row>
-            <bx-table-cell>Load Balancer 2</bx-table-cell>
-            <bx-table-cell>HTTP</bx-table-cell>
-            <bx-table-cell>80</bx-table-cell>
-            <bx-table-cell>Round Robin</bx-table-cell>
-            <bx-table-cell>Maureen's VM Groups</bx-table-cell>
-            <bx-table-cell>Active</bx-table-cell>
-          </bx-table-row>
-          <bx-table-row>
-            <bx-table-cell>Load Balancer 3</bx-table-cell>
-            <bx-table-cell>HTTP</bx-table-cell>
-            <bx-table-cell>80</bx-table-cell>
-            <bx-table-cell>Round Robin</bx-table-cell>
-            <bx-table-cell>Maureen's VM Groups</bx-table-cell>
-            <bx-table-cell>Active</bx-table-cell>
-          </bx-table-row>
-        </bx-table-body>
-      </bx-table>
-    `;
-  })
-  .add('Sortable', () => {
-    const { hasSelection, size, zebra, disableChangeSelection, disableChangeSort } = createProps({ sortable: true });
-    const beforeChangeSelectionAction = action('bx-table-row-change-selection');
-    const beforeChangeSelectionAllAction = action('bx-table-change-selection-all');
-    const beforeChangeSelectionHandler = {
-      handleEvent(event: CustomEvent) {
-        if (event.type === 'bx-table-change-selection-all') {
-          beforeChangeSelectionAllAction(event);
-        } else {
-          beforeChangeSelectionAction(event);
-        }
-        if (disableChangeSelection) {
-          event.preventDefault();
-        }
+defaultStory.story = {
+  name: 'Default',
+  parameters: {
+    knobs: {
+      'bx-table': () => ({
+        size: select('Table size (size)', sizes, TABLE_SIZE.REGULAR),
+      }),
+      'bx-table-body': () => ({
+        zebra: boolean('Supports zebra stripe (zebra in `<bx-table-body>`)', false),
+      }),
+    },
+  },
+};
+
+export const sortableStory = ({ parameters }) => {
+  const {
+    'bx-table': tableProps,
+    'bx-table-body': tableBodyProps,
+    'bx-table-row': tableRowProps,
+    'bx-table-header-cell': tableHeaderCellProps,
+  } = parameters.props || ({} as typeof parameters.props);
+  const { size } = tableProps || ({} as typeof tableProps);
+  const { zebra } = tableBodyProps || ({} as typeof tableBodyProps);
+  const { hasSelection, disableChangeSelection } = tableRowProps || ({} as typeof tableRowProps);
+  const { disableChangeSort } = tableHeaderCellProps || ({} as typeof tableHeaderCellProps);
+  const beforeChangeSelectionAction = action('bx-table-row-change-selection');
+  const beforeChangeSelectionAllAction = action('bx-table-change-selection-all');
+  const beforeChangeSelectionHandler = {
+    handleEvent(event: CustomEvent) {
+      if (event.type === 'bx-table-change-selection-all') {
+        beforeChangeSelectionAllAction(event);
+      } else {
+        beforeChangeSelectionAction(event);
+      }
+      if (disableChangeSelection) {
+        event.preventDefault();
+      }
+    },
+    capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
+  };
+  const beforeChangeSortAction = action('bx-table-header-cell-sort');
+  const beforeChangeSortHandler = {
+    handleEvent(event: CustomEvent) {
+      beforeChangeSortAction(event);
+      if (disableChangeSort) {
+        event.preventDefault();
+      }
+    },
+    capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
+  };
+  return html`
+    <!-- Refer to <bx-ce-demo-data-table> implementation at the top for details -->
+    <bx-ce-demo-data-table
+      .columns=${demoColumns}
+      .rows=${demoRows}
+      .sortInfo=${demoSortInfo}
+      ?has-selection=${hasSelection}
+      size="${size}"
+      ?zebra="${zebra}"
+      @bx-table-row-change-selection=${beforeChangeSelectionHandler}
+      @bx-table-change-selection-all=${beforeChangeSelectionHandler}
+      @bx-table-header-cell-sort=${beforeChangeSortHandler}
+    >
+    </bx-ce-demo-data-table>
+  `;
+};
+
+sortableStory.story = {
+  name: 'Sortable',
+  parameters: {
+    knobs: {
+      ...defaultStory.story.parameters.knobs,
+      'bx-table-row': () => {
+        const hasSelection = boolean('Supports selection feature (has-selection)', false);
+        return {
+          hasSelection,
+          disableChangeSelection:
+            hasSelection &&
+            boolean(
+              'Disable user-initiated change in selection ' +
+                '(Call event.preventDefault() in bx-table-row-change-selection/bx-table-change-selection-all events)',
+              false
+            ),
+        };
       },
-      capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
-    };
-    const beforeChangeSortAction = action('bx-table-header-cell-sort');
-    const beforeChangeSortHandler = {
-      handleEvent(event: CustomEvent) {
-        beforeChangeSortAction(event);
-        if (disableChangeSort) {
-          event.preventDefault();
-        }
-      },
-      capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
-    };
-    return html`
-      <!-- Refer to <bx-ce-demo-data-table> implementation at the top for details -->
-      <bx-ce-demo-data-table
-        .columns=${demoColumns}
-        .rows=${demoRows}
-        .sortInfo=${demoSortInfo}
-        ?has-selection=${hasSelection}
-        size="${size}"
-        ?zebra="${zebra}"
-        @bx-table-row-change-selection=${beforeChangeSelectionHandler}
-        @bx-table-change-selection-all=${beforeChangeSelectionHandler}
-        @bx-table-header-cell-sort=${beforeChangeSortHandler}
-      >
-      </bx-ce-demo-data-table>
-    `;
-  })
-  .add('Sortable with pagination', () => {
-    const { hasSelection, size, zebra, disableChangeSelection, disableChangeSort } = createProps({ sortable: true });
-    const beforeChangeSelectionAction = action('bx-table-row-change-selection');
-    const beforeChangeSelectionAllAction = action('bx-table-change-selection-all');
-    const beforeChangeSelectionHandler = {
-      handleEvent(event: CustomEvent) {
-        if (event.type === 'bx-table-change-selection-all') {
-          beforeChangeSelectionAllAction(event);
-        } else {
-          beforeChangeSelectionAction(event);
-        }
-        if (disableChangeSelection) {
-          event.preventDefault();
-        }
-      },
-      capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
-    };
-    const beforeChangeSortAction = action('bx-table-header-cell-sort');
-    const beforeChangeSortHandler = {
-      handleEvent(event: CustomEvent) {
-        beforeChangeSortAction(event);
-        if (disableChangeSort) {
-          event.preventDefault();
-        }
-      },
-      capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
-    };
-    return html`
-      <!-- Refer to <bx-ce-demo-data-table> implementation at the top for details -->
-      <bx-ce-demo-data-table
-        .columns=${demoColumns}
-        .rows=${demoRowsMany}
-        .sortInfo=${demoSortInfo}
-        ?has-selection=${hasSelection}
-        page-size="5"
-        size="${size}"
-        start="0"
-        ?zebra="${zebra}"
-        @bx-table-row-change-selection=${beforeChangeSelectionHandler}
-        @bx-table-change-selection-all=${beforeChangeSelectionHandler}
-        @bx-table-header-cell-sort=${beforeChangeSortHandler}
-      >
-      </bx-ce-demo-data-table>
-    `;
-  });
+      'bx-table-header-cell': () => ({
+        disableChangeSort: boolean(
+          'Disable user-initiated change in sorting (Call event.preventDefault() in bx-table-header-cell-sort event)',
+          false
+        ),
+      }),
+    },
+  },
+};
+
+export const sortableWithPagination = ({ parameters }) => {
+  const {
+    'bx-table': tableProps,
+    'bx-table-body': tableBodyProps,
+    'bx-table-row': tableRowProps,
+    'bx-table-header-cell': tableHeaderCellProps,
+  } = parameters.props || ({} as typeof parameters.props);
+  const { size } = tableProps || ({} as typeof tableProps);
+  const { zebra } = tableBodyProps || ({} as typeof tableBodyProps);
+  const { hasSelection, disableChangeSelection } = tableRowProps || ({} as typeof tableRowProps);
+  const { disableChangeSort } = tableHeaderCellProps || ({} as typeof tableHeaderCellProps);
+  const beforeChangeSelectionAction = action('bx-table-row-change-selection');
+  const beforeChangeSelectionAllAction = action('bx-table-change-selection-all');
+  const beforeChangeSelectionHandler = {
+    handleEvent(event: CustomEvent) {
+      if (event.type === 'bx-table-change-selection-all') {
+        beforeChangeSelectionAllAction(event);
+      } else {
+        beforeChangeSelectionAction(event);
+      }
+      if (disableChangeSelection) {
+        event.preventDefault();
+      }
+    },
+    capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
+  };
+  const beforeChangeSortAction = action('bx-table-header-cell-sort');
+  const beforeChangeSortHandler = {
+    handleEvent(event: CustomEvent) {
+      beforeChangeSortAction(event);
+      if (disableChangeSort) {
+        event.preventDefault();
+      }
+    },
+    capture: true, // To prevent the default behavior before `<bx-ce-demo-data-table>` handles the event
+  };
+  return html`
+    <!-- Refer to <bx-ce-demo-data-table> implementation at the top for details -->
+    <bx-ce-demo-data-table
+      .columns=${demoColumns}
+      .rows=${demoRowsMany}
+      .sortInfo=${demoSortInfo}
+      ?has-selection=${hasSelection}
+      page-size="5"
+      size="${size}"
+      start="0"
+      ?zebra="${zebra}"
+      @bx-table-row-change-selection=${beforeChangeSelectionHandler}
+      @bx-table-change-selection-all=${beforeChangeSelectionHandler}
+      @bx-table-header-cell-sort=${beforeChangeSortHandler}
+    >
+    </bx-ce-demo-data-table>
+  `;
+};
+
+sortableWithPagination.story = {
+  name: 'Sortable with pagination',
+  parameters: {
+    knobs: sortableStory.story.parameters.knobs,
+  },
+};
+
+export default {
+  title: 'Data table',
+};

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -6,126 +6,143 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './date-picker';
 import './date-picker-input';
 
-const createProps = () => ({
-  enabledRange: text('Minimum/maximum dates in ISO8601 date format, separated by `/` (enabled-range)', ''),
-  open: boolean('Open (open)', false),
-  value: text('Value in ISO8601 date format, separated by `/` (value)', ''),
-  onAfterChanged: action('bx-date-picker-changed'),
-  onFlatpickrError: action('bx-date-picker-flatpickr-error'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { disabled, hideLabel, labelText, light, placeholder } =
+    (parameters.props && parameters.props['bx-date-picker-input']) || ({} as typeof parameters.props['bx-date-picker-input']);
+  return html`
+    <bx-date-picker>
+      <bx-date-picker-input
+        ?disabled="${disabled}"
+        ?hide-label="${hideLabel}"
+        label-text="${labelText}"
+        ?light="${light}"
+        placeholder="${placeholder}"
+      >
+      </bx-date-picker-input>
+    </bx-date-picker>
+  `;
+};
 
-const createInputProps = () => ({
-  disabled: boolean('Disabled (disabled in <bx-date-picker-input>)', false),
-  hideLabel: boolean('Hide label (hide-label in <bx-date-picker-input>)', false),
-  labelText: text('Label text (label-text in <bx-date-picker-input>)', 'Date Picker label'),
-  light: boolean('Light variant (light in <bx-date-picker-input>)', false),
-  placeholder: text('Placeholder text (placeholder in <bx-date-picker-input>)', 'mm/dd/yyyy'),
-  onInput: action('input'),
-});
+defaultStory.story = {
+  name: 'Default',
+  parameters: {
+    docs: {
+      storyDescription: 'A simple Date Picker consists of an input field and no calendar.',
+    },
+    knobs: {
+      'bx-date-picker': () => ({}),
+    },
+  },
+};
 
-storiesOf('Date picker', module)
-  .addDecorator(withKnobs)
-  .add(
-    'Default',
-    () => {
-      const { open } = createProps();
-      const { disabled, hideLabel, labelText, light, placeholder } = createInputProps();
-      return html`
-        <bx-date-picker ?open="${open}">
-          <bx-date-picker-input
-            ?disabled="${disabled}"
-            ?hide-label="${hideLabel}"
-            label-text="${labelText}"
-            ?light="${light}"
-            placeholder="${placeholder}"
-          >
-          </bx-date-picker-input>
-        </bx-date-picker>
-      `;
+export const singleWithCalendarStory = ({ parameters }) => {
+  const { 'bx-date-picker': datePickerProps, 'bx-date-picker-input': datePickerInputProps } =
+    parameters.props || ({} as typeof parameters.props);
+  const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = datePickerProps || ({} as typeof datePickerProps);
+  const { disabled, hideLabel, labelText, light, placeholder, onInput } =
+    datePickerInputProps || ({} as typeof datePickerInputProps);
+  return html`
+    <bx-date-picker
+      enabled-range="${enabledRange}"
+      ?open="${open}"
+      value="${value}"
+      @bx-date-picker-changed="${onAfterChanged}"
+      @bx-date-picker-flatpickr-error="${onFlatpickrError}"
+    >
+      <bx-date-picker-input
+        ?disabled="${disabled}"
+        ?hide-label="${hideLabel}"
+        kind="single"
+        label-text="${labelText}"
+        ?light="${light}"
+        placeholder="${placeholder}"
+        @input="${onInput}"
+      >
+      </bx-date-picker-input>
+    </bx-date-picker>
+  `;
+};
+
+singleWithCalendarStory.story = {
+  name: 'Single with calendar',
+  parameters: {
+    docs: {
+      storyDescription: 'A single Date Picker consists of an input field and a calendar.',
     },
-    {
-      docs: {
-        storyDescription: 'A simple Date Picker consists of an input field and no calendar.',
-      },
-    }
-  )
-  .add(
-    'Single with calendar',
-    () => {
-      const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = createProps();
-      const { disabled, hideLabel, labelText, light, placeholder, onInput } = createInputProps();
-      return html`
-        <bx-date-picker
-          enabled-range="${enabledRange}"
-          ?open="${open}"
-          value="${value}"
-          @bx-date-picker-changed="${onAfterChanged}"
-          @bx-date-picker-flatpickr-error="${onFlatpickrError}"
-        >
-          <bx-date-picker-input
-            ?disabled="${disabled}"
-            ?hide-label="${hideLabel}"
-            kind="single"
-            label-text="${labelText}"
-            ?light="${light}"
-            placeholder="${placeholder}"
-            @input="${onInput}"
-          >
-          </bx-date-picker-input>
-        </bx-date-picker>
-      `;
+  },
+};
+
+export const rangeWithCalendarStory = ({ parameters }) => {
+  const { 'bx-date-picker': datePickerProps, 'bx-date-picker-input': datePickerInputProps } =
+    parameters.props || ({} as typeof parameters.props);
+  const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = datePickerProps || ({} as typeof datePickerProps);
+  const { disabled, hideLabel, labelText, light, placeholder, onInput } =
+    datePickerInputProps || ({} as typeof datePickerInputProps);
+  return html`
+    <bx-date-picker
+      enabled-range="${enabledRange}"
+      ?open="${open}"
+      value="${value}"
+      @bx-date-picker-changed="${onAfterChanged}"
+      @bx-date-picker-flatpickr-error="${onFlatpickrError}"
+    >
+      <bx-date-picker-input
+        ?disabled="${disabled}"
+        ?hide-label="${hideLabel}"
+        kind="from"
+        label-text="${labelText}"
+        ?light="${light}"
+        placeholder="${placeholder}"
+        @input="${onInput}"
+      >
+      </bx-date-picker-input>
+      <bx-date-picker-input
+        ?disabled="${disabled}"
+        ?hide-label="${hideLabel}"
+        kind="to"
+        label-text="${labelText}"
+        ?light="${light}"
+        placeholder="${placeholder}"
+        @input="${onInput}"
+      >
+      </bx-date-picker-input>
+    </bx-date-picker>
+  `;
+};
+
+rangeWithCalendarStory.story = {
+  name: 'Range with calendar',
+  parameters: {
+    docs: {
+      storyDescription: 'A range Date Picker consists of two input fields and a calendar.',
     },
-    {
-      docs: {
-        storyDescription: 'A single Date Picker consists of an input field and a calendar.',
-      },
-    }
-  )
-  .add(
-    'Range with calendar',
-    () => {
-      const { enabledRange, open, value, onAfterChanged, onFlatpickrError } = createProps();
-      const { disabled, hideLabel, labelText, light, placeholder, onInput } = createInputProps();
-      return html`
-        <bx-date-picker
-          enabled-range="${enabledRange}"
-          ?open="${open}"
-          value="${value}"
-          @bx-date-picker-changed="${onAfterChanged}"
-          @bx-date-picker-flatpickr-error="${onFlatpickrError}"
-        >
-          <bx-date-picker-input
-            ?disabled="${disabled}"
-            ?hide-label="${hideLabel}"
-            kind="from"
-            label-text="${labelText}"
-            ?light="${light}"
-            placeholder="${placeholder}"
-            @input="${onInput}"
-          >
-          </bx-date-picker-input>
-          <bx-date-picker-input
-            ?disabled="${disabled}"
-            ?hide-label="${hideLabel}"
-            kind="to"
-            label-text="${labelText}"
-            ?light="${light}"
-            placeholder="${placeholder}"
-            @input="${onInput}"
-          >
-          </bx-date-picker-input>
-        </bx-date-picker>
-      `;
+  },
+};
+
+export default {
+  title: 'Date picker',
+  parameters: {
+    knobs: {
+      'bx-date-picker': () => ({
+        enabledRange: text('Minimum/maximum dates in ISO8601 date format, separated by `/` (enabled-range)', ''),
+        open: boolean('Open (open)', false),
+        value: text('Value in ISO8601 date format, separated by `/` (value)', ''),
+        onAfterChanged: action('bx-date-picker-changed'),
+        onFlatpickrError: action('bx-date-picker-flatpickr-error'),
+      }),
+      'bx-date-picker-input': () => ({
+        disabled: boolean('Disabled (disabled in <bx-date-picker-input>)', false),
+        hideLabel: boolean('Hide label (hide-label in <bx-date-picker-input>)', false),
+        labelText: text('Label text (label-text in <bx-date-picker-input>)', 'Date Picker label'),
+        light: boolean('Light variant (light in <bx-date-picker-input>)', false),
+        placeholder: text('Placeholder text (placeholder in <bx-date-picker-input>)', 'mm/dd/yyyy'),
+        onInput: action('input'),
+      }),
     },
-    {
-      docs: {
-        storyDescription: 'A range Date Picker consists of two input fields and a calendar.',
-      },
-    }
-  );
+  },
+};

--- a/src/components/dropdown/dropdown-story.ts
+++ b/src/components/dropdown/dropdown-story.ts
@@ -8,54 +8,63 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './dropdown';
 import './dropdown-item';
 
-const createProps = () => ({
-  open: boolean('Open (open)', false),
-  disabled: boolean('Disabled (disabled)', false),
-  helperText: text('Helper text (helper-text)', ''),
-  labelText: text('Label text (label-text)', ''),
-  light: boolean('Light variant (light)', false),
-  value: text('The value of the selected item (value)', ''),
-  triggerContent: text('The default content of the trigger button (trigger-content)', 'Select an item'),
-  disableSelection: boolean(
-    'Disable user-initiated selection change (Call event.preventDefault() in bx-dropdown-beingselected event)',
-    false
-  ),
-});
+export const defaultStory = ({ parameters }) => {
+  const { open, disabled, helperText, labelText, light, value, triggerContent, disableSelection } =
+    (parameters.props && parameters.props['bx-dropdown']) || ({} as typeof parameters.props['bx-dropdown']);
+  const beforeSelectedAction = action('bx-dropdown-beingselected');
+  const handleBeforeSelected = (event: CustomEvent) => {
+    beforeSelectedAction(event);
+    if (disableSelection) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-dropdown
+      ?open=${open}
+      ?disabled=${disabled}
+      ?light=${light}
+      helper-text=${helperText}
+      label-text=${labelText}
+      value=${value}
+      trigger-content=${triggerContent}
+      @bx-dropdown-beingselected=${handleBeforeSelected}
+      @bx-dropdown-selected=${action('bx-dropdown-selected')}
+    >
+      <bx-dropdown-item value="all">Option 1</bx-dropdown-item>
+      <bx-dropdown-item value="cloudFoundry">Option 2</bx-dropdown-item>
+      <bx-dropdown-item value="staging">Option 3</bx-dropdown-item>
+      <bx-dropdown-item value="dea">Option 4</bx-dropdown-item>
+      <bx-dropdown-item value="router">Option 5</bx-dropdown-item>
+    </bx-dropdown>
+  `;
+};
 
-storiesOf('Dropdown', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { open, disabled, helperText, labelText, light, value, triggerContent, disableSelection } = createProps();
-    const beforeSelectedAction = action('bx-dropdown-beingselected');
-    const handleBeforeSelected = (event: CustomEvent) => {
-      beforeSelectedAction(event);
-      if (disableSelection) {
-        event.preventDefault();
-      }
-    };
-    return html`
-      <bx-dropdown
-        ?open=${open}
-        ?disabled=${disabled}
-        ?light=${light}
-        helper-text=${helperText}
-        label-text=${labelText}
-        value=${value}
-        trigger-content=${triggerContent}
-        @bx-dropdown-beingselected=${handleBeforeSelected}
-        @bx-dropdown-selected=${action('bx-dropdown-selected')}
-      >
-        <bx-dropdown-item value="all">Option 1</bx-dropdown-item>
-        <bx-dropdown-item value="cloudFoundry">Option 2</bx-dropdown-item>
-        <bx-dropdown-item value="staging">Option 3</bx-dropdown-item>
-        <bx-dropdown-item value="dea">Option 4</bx-dropdown-item>
-        <bx-dropdown-item value="router">Option 5</bx-dropdown-item>
-      </bx-dropdown>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Dropdown',
+  parameters: {
+    knobs: {
+      'bx-dropdown': () => ({
+        open: boolean('Open (open)', false),
+        disabled: boolean('Disabled (disabled)', false),
+        helperText: text('Helper text (helper-text)', ''),
+        labelText: text('Label text (label-text)', ''),
+        light: boolean('Light variant (light)', false),
+        value: text('The value of the selected item (value)', ''),
+        triggerContent: text('The default content of the trigger button (trigger-content)', 'Select an item'),
+        disableSelection: boolean(
+          'Disable user-initiated selection change (Call event.preventDefault() in bx-dropdown-beingselected event)',
+          false
+        ),
+      }),
+    },
+  },
+};

--- a/src/components/icon/icon-story.ts
+++ b/src/components/icon/icon-story.ts
@@ -8,59 +8,66 @@
  */
 
 import { html, svg } from 'lit-html';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs } from '@storybook/addon-knobs';
 
 import Add16 from '@carbon/icons/lib/add/16';
 import Add20 from '@carbon/icons/lib/add/20';
 import Add24 from '@carbon/icons/lib/add/24';
 import Add32 from '@carbon/icons/lib/add/32';
 
-storiesOf('Icon', module)
-  .addDecorator(withKnobs)
-  .add(
-    'Default',
-    () => html`
-      ${Add16()} ${Add20()} ${Add24()} ${Add32()}
-    `
-  )
-  .add(
-    'With custom class',
-    () => html`
-      <style>
-        .test-class {
-          fill: #0062ff;
-        }
-      </style>
-      ${Add16({ class: 'test-class' })} ${Add20({ class: 'test-class' })} ${Add24({ class: 'test-class' })}
-      ${Add32({ class: 'test-class' })}
-    `
-  )
-  .add(
-    'With aria-label',
-    () => html`
-      ${Add16({ 'aria-label': 'add' })} ${Add20({ 'aria-label': 'add' })} ${Add24({ 'aria-label': 'add' })}
-      ${Add32({ 'aria-label': 'add' })}
-    `
-  )
-  .add(
-    'With title',
-    () => html`
-      ${Add16({
-        'aria-describedby': 'id-title-1',
-        children: svg`<title id="id-title-1">add</title>`,
-      })}
-      ${Add20({
-        'aria-describedby': 'id-title-2',
-        children: svg`<title id="id-title-2">add</title>`,
-      })}
-      ${Add24({
-        'aria-describedby': 'id-title-3',
-        children: svg`<title id="id-title-3">add</title>`,
-      })}
-      ${Add32({
-        'aria-describedby': 'id-title-4',
-        children: svg`<title id="id-title-4">add</title>`,
-      })}
-    `
-  );
+export const defaultStory = () => html`
+  ${Add16()} ${Add20()} ${Add24()} ${Add32()}
+`;
+
+defaultStory.story = {
+  name: 'Default',
+};
+
+export const withCustomClass = () => html`
+  <style>
+    .test-class {
+      fill: #0062ff;
+    }
+  </style>
+  ${Add16({ class: 'test-class' })} ${Add20({ class: 'test-class' })} ${Add24({ class: 'test-class' })}
+  ${Add32({ class: 'test-class' })}
+`;
+
+withCustomClass.story = {
+  name: 'With custom class',
+};
+
+export const withAriaLabel = () => html`
+  ${Add16({ 'aria-label': 'add' })} ${Add20({ 'aria-label': 'add' })} ${Add24({ 'aria-label': 'add' })}
+  ${Add32({ 'aria-label': 'add' })}
+`;
+
+withAriaLabel.story = {
+  name: 'With aria-label',
+};
+
+export const withTitle = () => html`
+  ${Add16({
+    'aria-describedby': 'id-title-1',
+    children: svg`<title id="id-title-1">add</title>`,
+  })}
+  ${Add20({
+    'aria-describedby': 'id-title-2',
+    children: svg`<title id="id-title-2">add</title>`,
+  })}
+  ${Add24({
+    'aria-describedby': 'id-title-3',
+    children: svg`<title id="id-title-3">add</title>`,
+  })}
+  ${Add32({
+    'aria-describedby': 'id-title-4',
+    children: svg`<title id="id-title-4">add</title>`,
+  })}
+`;
+
+withTitle.story = {
+  name: 'With title',
+};
+
+export default {
+  title: 'Icon',
+};

--- a/src/components/inline-loading/inline-loading-story.ts
+++ b/src/components/inline-loading/inline-loading-story.ts
@@ -8,8 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs, select } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 import { INLINE_LOADING_STATE } from './inline-loading';
 
 const states = {
@@ -19,15 +18,25 @@ const states = {
   [`Failed (${INLINE_LOADING_STATE.ERROR})`]: INLINE_LOADING_STATE.ERROR,
 };
 
-const createProps = () => ({
-  status: select('Loading status (status)', states, INLINE_LOADING_STATE.ACTIVE),
-});
+export const defaultStory = ({ parameters }) => {
+  const { status } =
+    (parameters.props && parameters.props['bx-inline-loading']) || ({} as typeof parameters.props['bx-inline-loading']);
+  return html`
+    <bx-inline-loading status="${status}">Loading data...</bx-inline-loading>
+  `;
+};
 
-storiesOf('Inline loading', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { status } = createProps();
-    return html`
-      <bx-inline-loading status="${status}">Loading data...</bx-inline-loading>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Inline loading',
+  parameters: {
+    knobs: {
+      'bx-inline-loading': () => ({
+        status: select('Loading status (status)', states, INLINE_LOADING_STATE.ACTIVE),
+      }),
+    },
+  },
+};

--- a/src/components/input/input-story.ts
+++ b/src/components/input/input-story.ts
@@ -8,46 +8,69 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import * as knobs from '@storybook/addon-knobs';
 import './input';
 import '../form/form-item';
 import createProps from './stories/helpers';
 
-storiesOf('Input', module)
-  .addDecorator(knobs.withKnobs)
-  .add('Default', () => {
-    const { disabled, value, placeholder, invalid, type, onInput } = createProps(knobs);
-    return html`
-      <bx-input
-        ?disabled="${disabled}"
-        value="${value}"
-        type="${type}"
-        placeholder="${placeholder}"
-        ?invalid="${invalid}"
-        @input="${onInput}"
-      ></bx-input>
-    `;
-  })
-  .add('Form item', () => {
-    const { disabled, value, placeholder, invalid, onInput } = createProps(knobs);
-    return html`
-      <bx-form-item>
-        <bx-input value="${value}" placeholder="${placeholder}" @input="${onInput}" ?invalid="${invalid}" ?disabled="${disabled}">
-          <span slot="label-text">Label text</span>
-          <span slot="helper-text">Optional helper text</span>
-          <span slot="validity-message">Something isn't right</span>
-        </bx-input>
-      </bx-form-item>
-    `;
-  })
-  .add('Without form item wrapper', () => {
-    const { disabled, value, placeholder, invalid, onInput } = createProps(knobs);
-    return html`
+export const defaultStory = ({ parameters }) => {
+  const { disabled, value, placeholder, invalid, type, onInput } =
+    (parameters.props && parameters.props['bx-input']) || ({} as typeof parameters.props['bx-input']);
+  return html`
+    <bx-input
+      ?disabled="${disabled}"
+      value="${value}"
+      type="${type}"
+      placeholder="${placeholder}"
+      ?invalid="${invalid}"
+      @input="${onInput}"
+    ></bx-input>
+  `;
+};
+
+defaultStory.story = {
+  name: 'Default',
+};
+
+export const formItem = ({ parameters }) => {
+  const { disabled, value, placeholder, invalid, onInput } =
+    (parameters.props && parameters.props['bx-input']) || ({} as typeof parameters.props['bx-input']);
+  return html`
+    <bx-form-item>
       <bx-input value="${value}" placeholder="${placeholder}" @input="${onInput}" ?invalid="${invalid}" ?disabled="${disabled}">
         <span slot="label-text">Label text</span>
         <span slot="helper-text">Optional helper text</span>
         <span slot="validity-message">Something isn't right</span>
       </bx-input>
-    `;
-  });
+    </bx-form-item>
+  `;
+};
+
+formItem.story = {
+  name: 'Form item',
+};
+
+export const withoutFormItemWrapper = ({ parameters }) => {
+  const { disabled, value, placeholder, invalid, onInput } =
+    (parameters.props && parameters.props['bx-input']) || ({} as typeof parameters.props['bx-input']);
+  return html`
+    <bx-input value="${value}" placeholder="${placeholder}" @input="${onInput}" ?invalid="${invalid}" ?disabled="${disabled}">
+      <span slot="label-text">Label text</span>
+      <span slot="helper-text">Optional helper text</span>
+      <span slot="validity-message">Something isn't right</span>
+    </bx-input>
+  `;
+};
+
+withoutFormItemWrapper.story = {
+  name: 'Without form item wrapper',
+};
+
+export default {
+  title: 'Input',
+  parameters: {
+    knobs: {
+      'bx-input': () => createProps(knobs),
+    },
+  },
+};

--- a/src/components/loading/loading-story.ts
+++ b/src/components/loading/loading-story.ts
@@ -8,8 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { LOADING_TYPE } from './loading';
 
 const types = {
@@ -18,16 +17,25 @@ const types = {
   [`With overlay (${LOADING_TYPE.OVERLAY})`]: LOADING_TYPE.OVERLAY,
 };
 
-const createProps = () => ({
-  inactive: boolean('Inactive (inactive)', false),
-  type: select('The spinner type (type)', types, LOADING_TYPE.REGULAR),
-});
+export const defaultStory = ({ parameters }) => {
+  const props = (parameters.props && parameters.props['bx-loading']) || ({} as typeof parameters.props['bx-loading']);
+  return html`
+    <bx-loading ?inactive=${props.inactive} type=${props.type}></bx-loading>
+  `;
+};
 
-storiesOf('Loading', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const props = createProps();
-    return html`
-      <bx-loading ?inactive=${props.inactive} type=${props.type}></bx-loading>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Loading',
+  parameters: {
+    knobs: {
+      'bx-loading': () => ({
+        inactive: boolean('Inactive (inactive)', false),
+        type: select('The spinner type (type)', types, LOADING_TYPE.REGULAR),
+      }),
+    },
+  },
+};

--- a/src/components/modal/modal-story.ts
+++ b/src/components/modal/modal-story.ts
@@ -8,9 +8,8 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import '../button/button';
 import './modal';
 import './modal-header';
@@ -20,40 +19,53 @@ import './modal-label';
 import './modal-body';
 import './modal-footer';
 
-const createProps = () => ({
-  open: boolean('Open (open)', true),
-  danger: boolean('Danger mode (danger)', false),
-  disableClose: boolean('Disable user-initiated close action (Call event.preventDefault() in bx-modal-beingclosed event)', false),
-});
+export const defaultStory = ({ parameters }) => {
+  const { danger, open, disableClose } =
+    (parameters.props && parameters.props['bx-modal']) || ({} as typeof parameters.props['bx-modal']);
+  const beforeSelectedAction = action('bx-modal-beingclosed');
+  const handleBeforeClose = (event: CustomEvent) => {
+    beforeSelectedAction(event);
+    if (disableClose) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-modal
+      ?danger="${danger}"
+      ?open="${open}"
+      @bx-modal-beingclosed=${handleBeforeClose}
+      @bx-modal-closed=${action('bx-modal-closed')}
+    >
+      <bx-modal-header>
+        <bx-modal-close-button></bx-modal-close-button>
+        <bx-modal-label>Label (Optional)</bx-modal-label>
+        <bx-modal-heading>Modal Title</bx-modal-heading>
+      </bx-modal-header>
+      <bx-modal-body><p>Modal text description</p></bx-modal-body>
+      <bx-modal-footer>
+        <bx-btn kind="secondary" data-modal-close>Cancel</bx-btn>
+        <bx-btn kind="primary">Save</bx-btn>
+      </bx-modal-footer>
+    </bx-modal>
+  `;
+};
 
-storiesOf('Modal', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { danger, open, disableClose } = createProps();
-    const beforeSelectedAction = action('bx-modal-beingclosed');
-    const handleBeforeClose = (event: CustomEvent) => {
-      beforeSelectedAction(event);
-      if (disableClose) {
-        event.preventDefault();
-      }
-    };
-    return html`
-      <bx-modal
-        ?danger="${danger}"
-        ?open="${open}"
-        @bx-modal-beingclosed=${handleBeforeClose}
-        @bx-modal-closed=${action('bx-modal-closed')}
-      >
-        <bx-modal-header>
-          <bx-modal-close-button></bx-modal-close-button>
-          <bx-modal-label>Label (Optional)</bx-modal-label>
-          <bx-modal-heading>Modal Title</bx-modal-heading>
-        </bx-modal-header>
-        <bx-modal-body><p>Modal text description</p></bx-modal-body>
-        <bx-modal-footer>
-          <bx-btn kind="secondary" data-modal-close>Cancel</bx-btn>
-          <bx-btn kind="primary">Save</bx-btn>
-        </bx-modal-footer>
-      </bx-modal>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Modal',
+  parameters: {
+    knobs: {
+      'bx-modal': () => ({
+        open: boolean('Open (open)', true),
+        danger: boolean('Danger mode (danger)', false),
+        disableClose: boolean(
+          'Disable user-initiated close action (Call event.preventDefault() in bx-modal-beingclosed event)',
+          false
+        ),
+      }),
+    },
+  },
+};

--- a/src/components/multi-select/multi-select-story.ts
+++ b/src/components/multi-select/multi-select-story.ts
@@ -8,9 +8,8 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { DROPDOWN_TYPE } from '../dropdown/dropdown';
 import './multi-select';
 import './multi-select-item';
@@ -20,72 +19,81 @@ const types = {
   [`Inline (${DROPDOWN_TYPE.INLINE})`]: DROPDOWN_TYPE.INLINE,
 };
 
-const createProps = () => ({
-  clearSelectionLabel: text('a11y label for the icon to clear selection (clear-selection-label)', ''),
-  disabled: boolean('Disabled (disabled)', false),
-  helperText: text('Helper text (helper-text)', 'This is not helper text'),
-  invalid: boolean('Show invalid state  (invalid)', false),
-  labelText: text('Label text (label-text)', 'Multiselect title'),
-  light: boolean('Light variant (light)', false),
-  open: boolean('Open (open)', false),
-  toggleLabelClosed: text('a11y label for the UI indicating the closed state (toggle-label-closed)', ''),
-  toggleLabelOpen: text('a11y label for the UI indicating the closed state (toggle-label-open)', ''),
-  triggerContent: text('The default content of the trigger button (trigger-content)', 'Select items'),
-  type: select('UI type (type)', types, DROPDOWN_TYPE.REGULAR),
-  validityMessage: text('The validity message (validity-message)', ''),
-  disableSelection: boolean(
-    'Disable user-initiated selection change (Call event.preventDefault() in bx-multi-select-beingselected event)',
-    false
-  ),
-});
+export const defaultStory = ({ parameters }) => {
+  const {
+    clearSelectionLabel,
+    disabled,
+    helperText,
+    invalid,
+    labelText,
+    light,
+    open,
+    toggleLabelClosed,
+    toggleLabelOpen,
+    triggerContent,
+    type,
+    validityMessage,
+    disableSelection,
+  } = (parameters.props && parameters.props['bx-multi-select']) || ({} as typeof parameters.props['bx-multi-select']);
+  const beforeSelectedAction = action('bx-multi-select-beingselected');
+  const handleBeforeSelected = (event: CustomEvent) => {
+    beforeSelectedAction(event);
+    if (disableSelection) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-multi-select
+      ?disabled=${disabled}
+      ?invalid=${invalid}
+      ?light=${light}
+      ?open=${open}
+      clear-selection-label=${clearSelectionLabel}
+      helper-text=${helperText}
+      label-text=${labelText}
+      toggle-label-closed=${toggleLabelClosed}
+      toggle-label-open=${toggleLabelOpen}
+      trigger-content=${triggerContent}
+      type=${type}
+      validity-message=${validityMessage}
+      @bx-multi-select-beingselected=${handleBeforeSelected}
+      @bx-multi-select-selected=${action('bx-multi-select-selected')}
+    >
+      <bx-multi-select-item value="all">Option 1</bx-multi-select-item>
+      <bx-multi-select-item value="cloudFoundry">Option 2</bx-multi-select-item>
+      <bx-multi-select-item value="staging">Option 3</bx-multi-select-item>
+      <bx-multi-select-item value="dea">Option 4</bx-multi-select-item>
+      <bx-multi-select-item value="router">Option 5</bx-multi-select-item>
+    </bx-multi-select>
+  `;
+};
 
-storiesOf('Multi select', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const {
-      clearSelectionLabel,
-      disabled,
-      helperText,
-      invalid,
-      labelText,
-      light,
-      open,
-      toggleLabelClosed,
-      toggleLabelOpen,
-      triggerContent,
-      type,
-      validityMessage,
-      disableSelection,
-    } = createProps();
-    const beforeSelectedAction = action('bx-multi-select-beingselected');
-    const handleBeforeSelected = (event: CustomEvent) => {
-      beforeSelectedAction(event);
-      if (disableSelection) {
-        event.preventDefault();
-      }
-    };
-    return html`
-      <bx-multi-select
-        ?disabled=${disabled}
-        ?invalid=${invalid}
-        ?light=${light}
-        ?open=${open}
-        clear-selection-label=${clearSelectionLabel}
-        helper-text=${helperText}
-        label-text=${labelText}
-        toggle-label-closed=${toggleLabelClosed}
-        toggle-label-open=${toggleLabelOpen}
-        trigger-content=${triggerContent}
-        type=${type}
-        validity-message=${validityMessage}
-        @bx-multi-select-beingselected=${handleBeforeSelected}
-        @bx-multi-select-selected=${action('bx-multi-select-selected')}
-      >
-        <bx-multi-select-item value="all">Option 1</bx-multi-select-item>
-        <bx-multi-select-item value="cloudFoundry">Option 2</bx-multi-select-item>
-        <bx-multi-select-item value="staging">Option 3</bx-multi-select-item>
-        <bx-multi-select-item value="dea">Option 4</bx-multi-select-item>
-        <bx-multi-select-item value="router">Option 5</bx-multi-select-item>
-      </bx-multi-select>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Multi select',
+  parameters: {
+    knobs: {
+      'bx-multi-select': () => ({
+        clearSelectionLabel: text('a11y label for the icon to clear selection (clear-selection-label)', ''),
+        disabled: boolean('Disabled (disabled)', false),
+        helperText: text('Helper text (helper-text)', 'This is not helper text'),
+        invalid: boolean('Show invalid state  (invalid)', false),
+        labelText: text('Label text (label-text)', 'Multiselect title'),
+        light: boolean('Light variant (light)', false),
+        open: boolean('Open (open)', false),
+        toggleLabelClosed: text('a11y label for the UI indicating the closed state (toggle-label-closed)', ''),
+        toggleLabelOpen: text('a11y label for the UI indicating the closed state (toggle-label-open)', ''),
+        triggerContent: text('The default content of the trigger button (trigger-content)', 'Select items'),
+        type: select('UI type (type)', types, DROPDOWN_TYPE.REGULAR),
+        validityMessage: text('The validity message (validity-message)', ''),
+        disableSelection: boolean(
+          'Disable user-initiated selection change (Call event.preventDefault() in bx-multi-select-beingselected event)',
+          false
+        ),
+      }),
+    },
+  },
+};

--- a/src/components/notification/notification-story.ts
+++ b/src/components/notification/notification-story.ts
@@ -9,9 +9,8 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { NOTIFICATION_KIND } from './inline-notification';
 import './toast-notification';
 
@@ -22,107 +21,104 @@ const kinds = {
   [`Error (${NOTIFICATION_KIND.ERROR})`]: NOTIFICATION_KIND.ERROR,
 };
 
-const createInlineProps = () => ({
-  kind: select('The notification kind (kind)', kinds, NOTIFICATION_KIND.INFO),
-  title: text('Title (title)', 'Notification title'),
-  subtitle: text('Subtitle (subtitle)', 'Subtitle text goes here.'),
-  hideCloseButton: boolean('Hide the close button (hide-close-button)', false),
-  closeButtonLabel: text('a11y label for the close button (close-button-label)', ''),
-  iconLabel: text('a11y label for the icon (icon-label)', ''),
-  open: boolean('Open (open)', true),
-  disableClose: boolean(
-    'Disable user-initiated close action (Call event.preventDefault() in bx-notification-beingclosed event)',
-    false
-  ),
-});
+export const inline = ({ parameters }) => {
+  const { kind, title, subtitle, hideCloseButton, closeButtonLabel, iconLabel, open, disableClose } =
+    (parameters.props && parameters.props['bx-inline-notification']) || ({} as typeof parameters.props['bx-inline-notification']);
+  const beforeSelectedAction = action('bx-notification-beingclosed');
+  const handleBeforeClose = (event: CustomEvent) => {
+    beforeSelectedAction(event);
+    if (disableClose) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-inline-notification
+      style="min-width: 30rem; margin-bottom: .5rem"
+      kind="${kind}"
+      title="${title}"
+      subtitle="${subtitle}"
+      ?hide-close-button="${hideCloseButton}"
+      close-button-label="${ifDefined(!closeButtonLabel ? undefined : closeButtonLabel)}"
+      icon-label="${ifDefined(!iconLabel ? undefined : iconLabel)}"
+      ?open="${open}"
+      @bx-notification-beingclosed="${handleBeforeClose}"
+      @bx-notification-closed="${action('bx-notification-closed')}"
+    >
+    </bx-inline-notification>
+  `;
+};
 
-const createToastProps = () => ({
-  ...createInlineProps(),
-  caption: text('Caption (caption)', 'Time stamp [00:00:00]'),
-});
-
-storiesOf('Notifications', module)
-  .addDecorator(withKnobs)
-  .add(
-    'Inline',
-    () => {
-      const { kind, title, subtitle, hideCloseButton, closeButtonLabel, iconLabel, open, disableClose } = createInlineProps();
-      const beforeSelectedAction = action('bx-notification-beingclosed');
-      const handleBeforeClose = (event: CustomEvent) => {
-        beforeSelectedAction(event);
-        if (disableClose) {
-          event.preventDefault();
-        }
-      };
-      return html`
-        <bx-inline-notification
-          style="min-width: 30rem; margin-bottom: .5rem"
-          kind="${kind}"
-          title="${title}"
-          subtitle="${subtitle}"
-          ?hide-close-button="${hideCloseButton}"
-          close-button-label="${ifDefined(!closeButtonLabel ? undefined : closeButtonLabel)}"
-          icon-label="${ifDefined(!iconLabel ? undefined : iconLabel)}"
-          ?open="${open}"
-          @bx-notification-beingclosed="${handleBeforeClose}"
-          @bx-notification-closed="${action('bx-notification-closed')}"
-        >
-        </bx-inline-notification>
-      `;
-    },
-    {
-      docs: {
-        storyDescription: `
+inline.story = {
+  parameters: {
+    docs: {
+      storyDescription: `
 Inline notifications show up in task flows, to notify users of the status of an action.
 They usually appear at the top of the primary content area.
-      `,
-      },
-    }
-  )
-  .add(
-    'Toast',
-    () => {
-      const {
-        kind,
-        title,
-        subtitle,
-        caption,
-        hideCloseButton,
-        closeButtonLabel,
-        iconLabel,
-        open,
-        disableClose,
-      } = createToastProps();
-      const beforeSelectedAction = action('bx-notification-beingclosed');
-      const handleBeforeClose = (event: CustomEvent) => {
-        beforeSelectedAction(event);
-        if (disableClose) {
-          event.preventDefault();
-        }
-      };
-      return html`
-        <bx-toast-notification
-          style="min-width: 30rem; margin-bottom: .5rem"
-          kind="${kind}"
-          title="${title}"
-          subtitle="${subtitle}"
-          caption="${caption}"
-          ?hide-close-button="${hideCloseButton}"
-          close-button-label="${ifDefined(!closeButtonLabel ? undefined : closeButtonLabel)}"
-          icon-label="${ifDefined(!iconLabel ? undefined : iconLabel)}"
-          ?open="${open}"
-          @bx-notification-beingclosed="${handleBeforeClose}"
-          @bx-notification-closed="${action('bx-notification-closed')}"
-        >
-        </bx-toast-notification>
-      `;
+    `,
     },
-    {
-      docs: {
-        storyDescription: `
+    knobs: {
+      'bx-inline-notification': () => ({
+        kind: select('The notification kind (kind)', kinds, NOTIFICATION_KIND.INFO),
+        title: text('Title (title)', 'Notification title'),
+        subtitle: text('Subtitle (subtitle)', 'Subtitle text goes here.'),
+        hideCloseButton: boolean('Hide the close button (hide-close-button)', false),
+        closeButtonLabel: text('a11y label for the close button (close-button-label)', ''),
+        iconLabel: text('a11y label for the icon (icon-label)', ''),
+        open: boolean('Open (open)', true),
+        disableClose: boolean(
+          'Disable user-initiated close action (Call event.preventDefault() in bx-notification-beingclosed event)',
+          false
+        ),
+      }),
+    },
+  },
+};
+
+export const toast = ({ parameters }) => {
+  const { kind, title, subtitle, caption, hideCloseButton, closeButtonLabel, iconLabel, open, disableClose } =
+    (parameters.props && parameters.props['bx-toast-notification']) || ({} as typeof parameters.props['bx-toast-notification']);
+  const beforeSelectedAction = action('bx-notification-beingclosed');
+  const handleBeforeClose = (event: CustomEvent) => {
+    beforeSelectedAction(event);
+    if (disableClose) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-toast-notification
+      style="min-width: 30rem; margin-bottom: .5rem"
+      kind="${kind}"
+      title="${title}"
+      subtitle="${subtitle}"
+      caption="${caption}"
+      ?hide-close-button="${hideCloseButton}"
+      close-button-label="${ifDefined(!closeButtonLabel ? undefined : closeButtonLabel)}"
+      icon-label="${ifDefined(!iconLabel ? undefined : iconLabel)}"
+      ?open="${open}"
+      @bx-notification-beingclosed="${handleBeforeClose}"
+      @bx-notification-closed="${action('bx-notification-closed')}"
+    >
+    </bx-toast-notification>
+  `;
+};
+
+toast.story = {
+  parameters: {
+    docs: {
+      storyDescription: `
 Toasts are non-modal, time-based window elements used to display short messages;
 they usually appear at the bottom of the screen and disappear after a few seconds.
-      `,
-      },
-    }
-  );
+    `,
+    },
+    knobs: {
+      'bx-toast-notification': () => ({
+        ...inline.story.parameters.knobs['bx-inline-notification'](),
+        caption: text('Caption (caption)', 'Time stamp [00:00:00]'),
+      }),
+    },
+  },
+};
+
+export default {
+  title: 'Notifications',
+};

--- a/src/components/overflow-menu/overflow-menu-story.ts
+++ b/src/components/overflow-menu/overflow-menu-story.ts
@@ -8,8 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { FLOATING_MENU_DIRECTION } from '../floating-menu/floating-menu';
 import './overflow-menu';
 import './overflow-menu-body';
@@ -20,25 +19,35 @@ const directions = {
   [`Top (${FLOATING_MENU_DIRECTION.TOP})`]: FLOATING_MENU_DIRECTION.TOP,
 };
 
-const createProps = () => ({
-  open: boolean('Open (open)', false),
-  disabled: boolean('Disabled (disabled)', false),
-  direction: select('Direction (direction in <bx-overflow-menu-body>)', directions, FLOATING_MENU_DIRECTION.BOTTOM),
-});
+export const defaultStory = ({ parameters }) => {
+  const { open, disabled, direction } =
+    (parameters.props && parameters.props['bx-overflow-menu']) || ({} as typeof parameters.props['bx-overflow-menu']);
+  return html`
+    <bx-overflow-menu ?open="${open}" ?disabled="${disabled}">
+      <bx-overflow-menu-body direction="${direction}">
+        <bx-overflow-menu-item>Option 1</bx-overflow-menu-item>
+        <bx-overflow-menu-item>Option 2</bx-overflow-menu-item>
+        <bx-overflow-menu-item>Option 3</bx-overflow-menu-item>
+        <bx-overflow-menu-item>Option 4</bx-overflow-menu-item>
+        <bx-overflow-menu-item>Option 5</bx-overflow-menu-item>
+      </bx-overflow-menu-body>
+    </bx-overflow-menu>
+  `;
+};
 
-storiesOf('Overflow menu', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { open, disabled, direction } = createProps();
-    return html`
-      <bx-overflow-menu ?open="${open}" ?disabled="${disabled}">
-        <bx-overflow-menu-body direction="${direction}">
-          <bx-overflow-menu-item>Option 1</bx-overflow-menu-item>
-          <bx-overflow-menu-item>Option 2</bx-overflow-menu-item>
-          <bx-overflow-menu-item>Option 3</bx-overflow-menu-item>
-          <bx-overflow-menu-item>Option 4</bx-overflow-menu-item>
-          <bx-overflow-menu-item>Option 5</bx-overflow-menu-item>
-        </bx-overflow-menu-body>
-      </bx-overflow-menu>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Overflow menu',
+  parameters: {
+    knobs: {
+      'bx-overflow-menu': () => ({
+        open: boolean('Open (open)', false),
+        disabled: boolean('Disabled (disabled)', false),
+        direction: select('Direction (direction in <bx-overflow-menu-body>)', directions, FLOATING_MENU_DIRECTION.BOTTOM),
+      }),
+    },
+  },
+};

--- a/src/components/pagination/pageination-story.ts
+++ b/src/components/pagination/pageination-story.ts
@@ -8,41 +8,50 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, number } from '@storybook/addon-knobs';
+import { boolean, number } from '@storybook/addon-knobs';
 import './pagination';
 import './page-sizes-select';
 import './pages-select';
 
-const createProps = () => ({
-  atLastPage: boolean('Explicitly state that the user is at the last page (at-last-apge)', false),
-  pageSize: number('Number of rows per page (page-size)', 10),
-  start: number('Start row index of the current page (start)', 0),
-  total: number('Total rows count (total)', 100),
-  onChangedCurrent: action('bx-pagination-changed-current'),
-  onChangedPageSizesSelect: action('bx-page-sizes-select-changed'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { atLastPage, pageSize, start, total, onChangedCurrent, onChangedPageSizesSelect } =
+    (parameters.props && parameters.props['bx-pagination']) || ({} as typeof parameters.props['bx-pagination']);
+  return html`
+    <bx-pagination
+      ?at-last-page="${atLastPage || undefined}"
+      page-size="${pageSize}"
+      start="${start}"
+      total="${total}"
+      @bx-pagination-changed-current="${onChangedCurrent}"
+      @bx-page-sizes-select-changed="${onChangedPageSizesSelect}"
+    >
+      <bx-page-sizes-select slot="page-sizes-select">
+        <option value="10">10</option>
+        <option value="20">20</option>
+        <option value="30">30</option>
+      </bx-page-sizes-select>
+      <bx-pages-select></bx-pages-select>
+    </bx-pagination>
+  `;
+};
 
-storiesOf('Pagination', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { atLastPage, pageSize, start, total, onChangedCurrent, onChangedPageSizesSelect } = createProps();
-    return html`
-      <bx-pagination
-        ?at-last-page="${atLastPage || undefined}"
-        page-size="${pageSize}"
-        start="${start}"
-        total="${total}"
-        @bx-pagination-changed-current="${onChangedCurrent}"
-        @bx-page-sizes-select-changed="${onChangedPageSizesSelect}"
-      >
-        <bx-page-sizes-select slot="page-sizes-select">
-          <option value="10">10</option>
-          <option value="20">20</option>
-          <option value="30">30</option>
-        </bx-page-sizes-select>
-        <bx-pages-select></bx-pages-select>
-      </bx-pagination>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Pagination',
+  parameters: {
+    knobs: {
+      'bx-pagination': () => ({
+        atLastPage: boolean('Explicitly state that the user is at the last page (at-last-apge)', false),
+        pageSize: number('Number of rows per page (page-size)', 10),
+        start: number('Start row index of the current page (start)', 0),
+        total: number('Total rows count (total)', 100),
+        onChangedCurrent: action('bx-pagination-changed-current'),
+        onChangedPageSizesSelect: action('bx-page-sizes-select-changed'),
+      }),
+    },
+  },
+};

--- a/src/components/radio-button/radio-button-story.ts
+++ b/src/components/radio-button/radio-button-story.ts
@@ -9,9 +9,8 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { RADIO_BUTTON_ORIENTATION } from './radio-button-group';
 import { RADIO_BUTTON_LABEL_POSITION } from './radio-button';
 
@@ -25,37 +24,48 @@ const labelPositions = {
   [`Right (${RADIO_BUTTON_LABEL_POSITION.RIGHT})`]: RADIO_BUTTON_LABEL_POSITION.RIGHT,
 };
 
-const createGroupProps = () => ({
-  disabled: boolean('Disabled (disabled)', false),
-  labelPosition: select('Label position (label-position)', labelPositions, RADIO_BUTTON_LABEL_POSITION.RIGHT),
-  orientation: select('Orientation (orientation)', orientations, RADIO_BUTTON_ORIENTATION.HORIZONTAL),
-  name: text('Name (name)', 'radio-group'),
-  value: text('Value (value)', ''),
-  onAfterChange: action('bx-radio-button-group-changed'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { 'bx-radio-button-group': radioButtonGroupProps, 'bx-radio-button': radioButtonProps } =
+    parameters.props || ({} as typeof parameters.props);
+  const { disabled, labelPosition, orientation, name, value, onAfterChange } =
+    radioButtonGroupProps || ({} as typeof radioButtonGroupProps);
+  const { hideLabel, labelText } = radioButtonProps || ({} as typeof radioButtonProps);
+  return html`
+    <bx-radio-button-group
+      ?disabled="${disabled}"
+      label-position="${labelPosition}"
+      orientation="${orientation}"
+      name="${ifDefined(!name ? undefined : name)}"
+      value="${ifDefined(!value ? undefined : value)}"
+      @bx-radio-button-group-changed="${onAfterChange}"
+    >
+      <bx-radio-button ?hide-label="${hideLabel}" label-text="${labelText}" value="all"></bx-radio-button>
+      <bx-radio-button ?hide-label="${hideLabel}" label-text="${labelText}" value="cloudFoundry"></bx-radio-button>
+      <bx-radio-button ?hide-label="${hideLabel}" label-text="${labelText}" value="staging"></bx-radio-button>
+    </bx-radio-button-group>
+  `;
+};
 
-const createProps = () => ({
-  hideLabel: boolean('Hide label (hide-label)', false),
-  labelText: text('Label text (label-text)', 'Radio button'),
-});
+defaultStory.story = {
+  name: 'Default',
+};
 
-storiesOf('Radio button', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { disabled, labelPosition, orientation, name, value, onAfterChange } = createGroupProps();
-    const { hideLabel, labelText } = createProps();
-    return html`
-      <bx-radio-button-group
-        ?disabled="${disabled}"
-        label-position="${labelPosition}"
-        orientation="${orientation}"
-        name="${ifDefined(!name ? undefined : name)}"
-        value="${ifDefined(!value ? undefined : value)}"
-        @bx-radio-button-group-changed="${onAfterChange}"
-      >
-        <bx-radio-button ?hide-label="${hideLabel}" label-text="${labelText}" value="all"></bx-radio-button>
-        <bx-radio-button ?hide-label="${hideLabel}" label-text="${labelText}" value="cloudFoundry"></bx-radio-button>
-        <bx-radio-button ?hide-label="${hideLabel}" label-text="${labelText}" value="staging"></bx-radio-button>
-      </bx-radio-button-group>
-    `;
-  });
+export default {
+  title: 'Radio button',
+  parameters: {
+    knobs: {
+      'bx-radio-button-group': () => ({
+        disabled: boolean('Disabled (disabled)', false),
+        labelPosition: select('Label position (label-position)', labelPositions, RADIO_BUTTON_LABEL_POSITION.RIGHT),
+        orientation: select('Orientation (orientation)', orientations, RADIO_BUTTON_ORIENTATION.HORIZONTAL),
+        name: text('Name (name)', 'radio-group'),
+        value: text('Value (value)', ''),
+        onAfterChange: action('bx-radio-button-group-changed'),
+      }),
+      'bx-radio-button': () => ({
+        hideLabel: boolean('Hide label (hide-label)', false),
+        labelText: text('Label text (label-text)', 'Radio button'),
+      }),
+    },
+  },
+};

--- a/src/components/search/search-story.ts
+++ b/src/components/search/search-story.ts
@@ -9,9 +9,8 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { SEARCH_SIZE } from './search';
 
 const sizes = {
@@ -19,46 +18,45 @@ const sizes = {
   [`Regular size (${SEARCH_SIZE.REGULAR})`]: SEARCH_SIZE.REGULAR,
 };
 
-const createProps = () => ({
-  closeButtonAssistiveText: text('The label text for the close button (close-button-assistive-text)', 'Clear search input'),
-  disabled: boolean('Disabled (disabled)', false),
-  light: boolean('Light variant (light)', false),
-  labelText: text('Label text (label-text)', 'Search'),
-  name: text('Name (name)', ''),
-  placeholder: text('Placeholder text (placeholder)', ''),
-  size: select('Searh size (size)', sizes, SEARCH_SIZE.REGULAR),
-  type: text('The type of the <input> (type)', ''),
-  value: text('Value (value)', ''),
-  onAfterInput: action('bx-search-input'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { closeButtonAssistiveText, disabled, light, labelText, name, placeholder, size, type, value, onAfterInput } =
+    (parameters.props && parameters.props['bx-search']) || ({} as typeof parameters.props['bx-search']);
+  return html`
+    <bx-search
+      close-button-assistive-text="${ifDefined(!closeButtonAssistiveText ? undefined : closeButtonAssistiveText)}"
+      ?disabled="${disabled}"
+      ?light="${light}"
+      label-text="${labelText}"
+      name="${ifDefined(!name ? undefined : name)}"
+      placeholder="${ifDefined(!placeholder ? undefined : placeholder)}"
+      size="${size}"
+      type="${ifDefined(!type ? undefined : type)}"
+      value="${ifDefined(!value ? undefined : value)}"
+      @bx-search-input="${onAfterInput}"
+    ></bx-search>
+  `;
+};
 
-storiesOf('Search', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const {
-      closeButtonAssistiveText,
-      disabled,
-      light,
-      labelText,
-      name,
-      placeholder,
-      size,
-      type,
-      value,
-      onAfterInput,
-    } = createProps();
-    return html`
-      <bx-search
-        close-button-assistive-text="${ifDefined(!closeButtonAssistiveText ? undefined : closeButtonAssistiveText)}"
-        ?disabled="${disabled}"
-        ?light="${light}"
-        label-text="${labelText}"
-        name="${ifDefined(!name ? undefined : name)}"
-        placeholder="${ifDefined(!placeholder ? undefined : placeholder)}"
-        size="${size}"
-        type="${ifDefined(!type ? undefined : type)}"
-        value="${ifDefined(!value ? undefined : value)}"
-        @bx-search-input="${onAfterInput}"
-      ></bx-search>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Search',
+  parameters: {
+    knobs: {
+      'bx-search': () => ({
+        closeButtonAssistiveText: text('The label text for the close button (close-button-assistive-text)', 'Clear search input'),
+        disabled: boolean('Disabled (disabled)', false),
+        light: boolean('Light variant (light)', false),
+        labelText: text('Label text (label-text)', 'Search'),
+        name: text('Name (name)', ''),
+        placeholder: text('Placeholder text (placeholder)', ''),
+        size: select('Searh size (size)', sizes, SEARCH_SIZE.REGULAR),
+        type: text('The type of the <input> (type)', ''),
+        value: text('Value (value)', ''),
+        onAfterInput: action('bx-search-input'),
+      }),
+    },
+  },
+};

--- a/src/components/slider/slider-story.ts
+++ b/src/components/slider/slider-story.ts
@@ -8,55 +8,70 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, number, text } from '@storybook/addon-knobs';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './slider';
 import './slider-input';
 
-const createProps = () => ({
-  disabled: boolean('Disabled (disabled)', false),
-  labelText: text('Label text (label-text)', 'Slider'),
-  name: text('Name (name)', ''),
-  max: number('The maximum value (max)', 100),
-  min: number('The minimum value (min)', 0),
-  step: number('The step (step)', 1),
-  value: number('Value (value)', 50),
-  onAfterChange: action('bx-slider-changed'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { disabled, labelText, max, min, name, step, value, onAfterChange } =
+    (parameters.props && parameters.props['bx-slider']) || ({} as typeof parameters.props['bx-slider']);
+  return html`
+    <bx-slider
+      ?disabled="${disabled}"
+      label-text="${labelText}"
+      max="${max}"
+      min="${min}"
+      name="${ifNonNull(name)}"
+      step="${step}"
+      value="${value}"
+      @bx-slider-changed="${onAfterChange}"
+    ></bx-slider>
+  `;
+};
 
-storiesOf('Slider', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { disabled, labelText, max, min, name, step, value, onAfterChange } = createProps();
-    return html`
-      <bx-slider
-        ?disabled="${disabled}"
-        label-text="${labelText}"
-        max="${max}"
-        min="${min}"
-        name="${ifNonNull(name)}"
-        step="${step}"
-        value="${value}"
-        @bx-slider-changed="${onAfterChange}"
-      ></bx-slider>
-    `;
-  })
-  .add('With input box', () => {
-    const { disabled, labelText, max, min, name, step, value, onAfterChange } = createProps();
-    return html`
-      <bx-slider
-        ?disabled="${disabled}"
-        label-text="${labelText}"
-        max="${max}"
-        min="${min}"
-        name="${ifNonNull(name)}"
-        step="${step}"
-        value="${value}"
-        @bx-slider-changed="${onAfterChange}"
-      >
-        <bx-slider-input aria-label="Slider value" type="number"></bx-slider-input>
-      </bx-slider>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export const withInputBox = ({ parameters }) => {
+  const { disabled, labelText, max, min, name, step, value, onAfterChange } =
+    (parameters.props && parameters.props['bx-slider']) || ({} as typeof parameters.props['bx-slider']);
+  return html`
+    <bx-slider
+      ?disabled="${disabled}"
+      label-text="${labelText}"
+      max="${max}"
+      min="${min}"
+      name="${ifNonNull(name)}"
+      step="${step}"
+      value="${value}"
+      @bx-slider-changed="${onAfterChange}"
+    >
+      <bx-slider-input aria-label="Slider value" type="number"></bx-slider-input>
+    </bx-slider>
+  `;
+};
+
+withInputBox.story = {
+  name: 'With input box',
+};
+
+export default {
+  title: 'Slider',
+  parameters: {
+    knobs: {
+      'bx-slider': () => ({
+        disabled: boolean('Disabled (disabled)', false),
+        labelText: text('Label text (label-text)', 'Slider'),
+        name: text('Name (name)', ''),
+        max: number('The maximum value (max)', 100),
+        min: number('The minimum value (min)', 0),
+        step: number('The step (step)', 1),
+        value: number('Value (value)', 50),
+        onAfterChange: action('bx-slider-changed'),
+      }),
+    },
+  },
+};

--- a/src/components/structured-list/structured-list-story.ts
+++ b/src/components/structured-list/structured-list-story.ts
@@ -9,61 +9,70 @@
 
 import { html } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import './structured-list';
 import './structured-list-head';
 import './structured-list-header-row';
 import './structured-list-body';
 import './structured-list-row';
 
-const createProps = () => ({
-  hasSelection: boolean('Supports selection feature (has-selection)', false),
-});
+export const defaultStory = ({ parameters }) => {
+  const { hasSelection } =
+    (parameters.props && parameters.props['bx-structured-list']) || ({} as typeof parameters.props['bx-structured-list']);
+  const selectionName = !hasSelection ? undefined : 'structured-list-selection';
+  const selectionValues = !hasSelection
+    ? []
+    : ['structured-list-selection-0', 'structured-list-selection-1', 'structured-list-selection-2'];
+  return html`
+    <bx-structured-list ?has-selection=${hasSelection}>
+      <bx-structured-list-head>
+        <bx-structured-list-header-row ?has-selection=${hasSelection}>
+          <bx-structured-list-header>ColumnA</bx-structured-list-header>
+          <bx-structured-list-header>ColumnB</bx-structured-list-header>
+          <bx-structured-list-header>ColumnC</bx-structured-list-header>
+        </bx-structured-list-header-row>
+      </bx-structured-list-head>
+      <bx-structured-list-body>
+        <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[0])}>
+          <bx-structured-list-cell>Row 1</bx-structured-list-cell>
+          <bx-structured-list-cell>Row 1</bx-structured-list-cell>
+          <bx-structured-list-cell
+            >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
+            augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
+          >
+        </bx-structured-list-row>
+        <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[1])}>
+          <bx-structured-list-cell>Row 2</bx-structured-list-cell>
+          <bx-structured-list-cell>Row 2</bx-structured-list-cell>
+          <bx-structured-list-cell
+            >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
+            augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
+          >
+        </bx-structured-list-row>
+        <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[2])}>
+          <bx-structured-list-cell>Row 3</bx-structured-list-cell>
+          <bx-structured-list-cell>Row 3</bx-structured-list-cell>
+          <bx-structured-list-cell
+            >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
+            augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
+          >
+        </bx-structured-list-row>
+      </bx-structured-list-body>
+    </bx-structured-list>
+  `;
+};
 
-storiesOf('Structured list', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { hasSelection } = createProps();
-    const selectionName = !hasSelection ? undefined : 'structured-list-selection';
-    const selectionValues = !hasSelection
-      ? []
-      : ['structured-list-selection-0', 'structured-list-selection-1', 'structured-list-selection-2'];
-    return html`
-      <bx-structured-list ?has-selection=${hasSelection}>
-        <bx-structured-list-head>
-          <bx-structured-list-header-row ?has-selection=${hasSelection}>
-            <bx-structured-list-header>ColumnA</bx-structured-list-header>
-            <bx-structured-list-header>ColumnB</bx-structured-list-header>
-            <bx-structured-list-header>ColumnC</bx-structured-list-header>
-          </bx-structured-list-header-row>
-        </bx-structured-list-head>
-        <bx-structured-list-body>
-          <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[0])}>
-            <bx-structured-list-cell>Row 1</bx-structured-list-cell>
-            <bx-structured-list-cell>Row 1</bx-structured-list-cell>
-            <bx-structured-list-cell
-              >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
-              augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
-            >
-          </bx-structured-list-row>
-          <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[1])}>
-            <bx-structured-list-cell>Row 2</bx-structured-list-cell>
-            <bx-structured-list-cell>Row 2</bx-structured-list-cell>
-            <bx-structured-list-cell
-              >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
-              augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
-            >
-          </bx-structured-list-row>
-          <bx-structured-list-row selection-name=${ifDefined(selectionName)} selection-value=${ifDefined(selectionValues[2])}>
-            <bx-structured-list-cell>Row 3</bx-structured-list-cell>
-            <bx-structured-list-cell>Row 3</bx-structured-list-cell>
-            <bx-structured-list-cell
-              >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed, aliquet bibendum
-              augue. Aenean posuere sem vel euismod dignissim.</bx-structured-list-cell
-            >
-          </bx-structured-list-row>
-        </bx-structured-list-body>
-      </bx-structured-list>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Structured list',
+  parameters: {
+    knobs: {
+      'bx-structured-list': () => ({
+        hasSelection: boolean('Supports selection feature (has-selection)', false),
+      }),
+    },
+  },
+};

--- a/src/components/textarea/textarea-story.ts
+++ b/src/components/textarea/textarea-story.ts
@@ -8,53 +8,36 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import * as knobs from '@storybook/addon-knobs';
 import './textarea';
 import '../form/form-item';
 import createProps from './stories/helpers';
 
-storiesOf('Textarea', module)
-  .addDecorator(knobs.withKnobs)
-  .add('Default', () => {
-    const { disabled, value, placeholder, invalid, onInput, rows, cols } = createProps(knobs);
-    return html`
-      <bx-textarea
-        ?disabled="${disabled}"
-        value="${value}"
-        placeholder="${placeholder}"
-        ?invalid="${invalid}"
-        @input="${onInput}"
-        rows="${rows}"
-        cols="${cols}"
-      >
-      </bx-textarea>
-    `;
-  })
-  .add('Form item', () => {
-    const { disabled, value, placeholder, invalid, onInput, rows, cols } = createProps(knobs);
-    return html`
-      <bx-form-item>
-        <bx-textarea
-          placeholder="${placeholder}"
-          @input="${onInput}"
-          ?invalid="${invalid}"
-          ?disabled="${disabled}"
-          value="${value}"
-          rows="${rows}"
-          cols="${cols}"
-        >
-          <span slot="label-text">Label text</span>
-          <span slot="helper-text">Optional helper text</span>
-          <span slot="validity-message">Something isn't right</span>
-          ${value}
-        </bx-textarea>
-      </bx-form-item>
-    `;
-  })
-  .add('Without form item wrapper', () => {
-    const { disabled, value, placeholder, invalid, onInput, rows, cols } = createProps(knobs);
-    return html`
+export const defaultStory = () => {
+  const { disabled, value, placeholder, invalid, onInput, rows, cols } = createProps(knobs);
+  return html`
+    <bx-textarea
+      ?disabled="${disabled}"
+      value="${value}"
+      placeholder="${placeholder}"
+      ?invalid="${invalid}"
+      @input="${onInput}"
+      rows="${rows}"
+      cols="${cols}"
+    >
+    </bx-textarea>
+  `;
+};
+
+defaultStory.story = {
+  name: 'Default',
+};
+
+export const formItem = ({ parameters }) => {
+  const { disabled, value, placeholder, invalid, onInput, rows, cols } =
+    (parameters.props && parameters.props['bx-textarea']) || ({} as typeof parameters.props['bx-textarea']);
+  return html`
+    <bx-form-item>
       <bx-textarea
         placeholder="${placeholder}"
         @input="${onInput}"
@@ -67,7 +50,46 @@ storiesOf('Textarea', module)
         <span slot="label-text">Label text</span>
         <span slot="helper-text">Optional helper text</span>
         <span slot="validity-message">Something isn't right</span>
-        <span>${value}</span>
+        ${value}
       </bx-textarea>
-    `;
-  });
+    </bx-form-item>
+  `;
+};
+
+formItem.story = {
+  name: 'Form item',
+};
+
+export const withoutFormItemWrapper = ({ parameters }) => {
+  const { disabled, value, placeholder, invalid, onInput, rows, cols } =
+    (parameters.props && parameters.props['bx-textarea']) || ({} as typeof parameters.props['bx-textarea']);
+  return html`
+    <bx-textarea
+      placeholder="${placeholder}"
+      @input="${onInput}"
+      ?invalid="${invalid}"
+      ?disabled="${disabled}"
+      value="${value}"
+      rows="${rows}"
+      cols="${cols}"
+    >
+      <span slot="label-text">Label text</span>
+      <span slot="helper-text">Optional helper text</span>
+      <span slot="validity-message">Something isn't right</span>
+      <span>${value}</span>
+    </bx-textarea>
+  `;
+};
+
+withoutFormItemWrapper.story = {
+  name: 'Without form item wrapper',
+};
+
+export default {
+  title: 'Textarea',
+  parameters: {
+    knobs: {
+      'bx-textarea': () => createProps(knobs),
+    },
+  },
+};

--- a/src/components/tile/tile-story.ts
+++ b/src/components/tile/tile-story.ts
@@ -9,168 +9,194 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './tile';
 import './clickable-tile';
 import './radio-tile';
 import './selectable-tile';
 import './expandable-tile';
 
-const createClickableProps = () => ({
-  href: text('Href for clickable UI (href)', ''),
-});
+export const defaultStory = () => html`
+  <bx-tile>Default tile</bx-tile>
+`;
 
-const createSelectableProps = () => ({
-  checkmarkLabel: text('Label text for the checkmark icon (checkmark-label)', ''),
-  name: text('Name (name)', 'selectable-tile'),
-  selected: boolean('Selected (selected)', false),
-  value: text('Value (value)', ''),
-  onInput: action('input'),
-});
-
-const createExpandableProps = () => ({
-  expanded: boolean('Expanded (expanded)', false),
-  disableChange: boolean(
-    'Disable user-initiated change in expanded state (Call event.preventDefault() in bx-expandable-tile-beingchanged event)',
-    false
-  ),
-});
-
-storiesOf('Tile', module)
-  .addDecorator(withKnobs)
-  .addDecorator(
-    story =>
-      html`
-        <div>${story()}</div>
-      `
-  )
-  .add(
-    'Default',
-    () => html`
-      <bx-tile>Default tile</bx-tile>
-    `,
-    {
-      docs: {
-        storyDescription: `
+defaultStory.story = {
+  name: 'Default',
+  parameters: {
+    docs: {
+      storyDescription: `
 Read-only tiles are used to display information to the user, such as features or services offered.
 Read-only tiles are often seen on marketing pages to promote content.
 These tiles can have internal calls-to-action (CTAs), such as a button or a link.
-      `,
-      },
-    }
-  )
-  .add(
-    'Clickable',
-    () => {
-      const { href } = createClickableProps();
-      return html`
-        <bx-clickable-tile href="${href}">Clickable tile</bx-clickable-tile>
-      `;
+    `,
     },
-    {
-      docs: {
-        storyDescription: `
+  },
+};
+
+export const clickable = ({ parameters }) => {
+  const { href } =
+    (parameters.props && parameters.props['bx-clickable-tile']) || ({} as typeof parameters.props['bx-clickable-tile']);
+  return html`
+    <bx-clickable-tile href="${href}">Clickable tile</bx-clickable-tile>
+  `;
+};
+
+clickable.story = {
+  parameters: {
+    docs: {
+      storyDescription: `
 Clickable tiles can be used as navigational items, where the entire tile is a clickable state,
 which redirects the user to a new page.
 Clickable tiles cannot contain separate internal CTAs.
-      `,
-      },
-    }
-  )
-  .add(
-    'Single-selectable',
-    () => {
-      const { checkmarkLabel, name, value, onInput } = createSelectableProps();
-      return html`
-        <fieldset>
-          <legend>Single-select tiles</legend>
-          <bx-radio-tile
-            checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
-            name="${ifDefined(!name ? undefined : name)}"
-            value="${ifDefined(!value ? undefined : value)}"
-            @input="${onInput}"
-          >
-            Single-select Tile
-          </bx-radio-tile>
-          <bx-radio-tile
-            checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
-            name="${ifDefined(!name ? undefined : name)}"
-            value="${ifDefined(!value ? undefined : value)}"
-            @input="${onInput}"
-          >
-            Single-select Tile
-          </bx-radio-tile>
-          <bx-radio-tile
-            checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
-            name="${ifDefined(!name ? undefined : name)}"
-            value="${ifDefined(!value ? undefined : value)}"
-            @input="${onInput}"
-          >
-            Single-select Tile
-          </bx-radio-tile>
-        </fieldset>
-      `;
+    `,
     },
-    {
-      docs: {
-        storyDescription: `
-Selectable tiles work like a radio button, where the entire tile is a click target.
-Selectable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
-Selectable tiles work well for presenting options to a user in a structured manner, such as a set of pricing plans.
-      `,
-      },
-    }
-  )
-  .add('Multi-selectable', () => {
-    const { checkmarkLabel, name, selected, value, onInput } = createSelectableProps();
-    return html`
-      <bx-selectable-tile
+    knobs: {
+      'bx-clickable-tile': () => ({
+        href: text('Href for clickable UI (href)', ''),
+      }),
+    },
+  },
+};
+
+export const singleSelectable = ({ parameters }) => {
+  const { checkmarkLabel, name, value, onInput } =
+    (parameters.props && parameters.props['bx-radio-tile']) || ({} as typeof parameters.props['bx-radio-tile']);
+  return html`
+    <fieldset>
+      <legend>Single-select tiles</legend>
+      <bx-radio-tile
         checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
         name="${ifDefined(!name ? undefined : name)}"
-        ?selected="${selected}"
         value="${ifDefined(!value ? undefined : value)}"
         @input="${onInput}"
       >
-        Multi-select Tile
-      </bx-selectable-tile>
-    `;
-  })
-  .add(
-    'Expandable',
-    () => {
-      const { expanded, disableChange } = createExpandableProps();
-      const beforeChangedAction = action('bx-expandable-tile-beingchanged');
-      const handleBeforeChanged = (event: CustomEvent) => {
-        beforeChangedAction(event);
-        if (disableChange) {
-          event.preventDefault();
-        }
-      };
-      return html`
-        <bx-expandable-tile
-          ?expanded="${expanded}"
-          @bx-expandable-tile-beingchanged=${handleBeforeChanged}
-          @bx-expandable-tile-changed=${action('bx-expandable-tile-changed')}
-        >
-          <bx-tile-above-the-fold-content style="height: 200px">
-            Above the fold content here
-          </bx-tile-above-the-fold-content>
-          <bx-tile-below-the-fold-content style="height: 300px">
-            Below the fold content here
-          </bx-tile-below-the-fold-content>
-        </bx-expandable-tile>
-      `;
+        Single-select Tile
+      </bx-radio-tile>
+      <bx-radio-tile
+        checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
+        name="${ifDefined(!name ? undefined : name)}"
+        value="${ifDefined(!value ? undefined : value)}"
+        @input="${onInput}"
+      >
+        Single-select Tile
+      </bx-radio-tile>
+      <bx-radio-tile
+        checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
+        name="${ifDefined(!name ? undefined : name)}"
+        value="${ifDefined(!value ? undefined : value)}"
+        @input="${onInput}"
+      >
+        Single-select Tile
+      </bx-radio-tile>
+    </fieldset>
+  `;
+};
+
+singleSelectable.story = {
+  name: 'Single-selectable',
+  parameters: {
+    docs: {
+      storyDescription: `
+Selectable tiles work like a radio button, where the entire tile is a click target.
+Selectable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
+Selectable tiles work well for presenting options to a user in a structured manner, such as a set of pricing plans.
+    `,
     },
-    {
-      docs: {
-        storyDescription: `
+    knobs: {
+      'bx-radio-tile': () => ({
+        checkmarkLabel: text('Label text for the checkmark icon (checkmark-label)', ''),
+        name: text('Name (name)', 'selectable-tile'),
+        value: text('Value (value)', ''),
+        onInput: action('input'),
+      }),
+    },
+  },
+};
+
+export const multiSelectable = ({ parameters }) => {
+  const { checkmarkLabel, name, selected, value, onInput } =
+    (parameters.props && parameters.props['bx-selectable-tile']) || ({} as typeof parameters.props['bx-selectable-tile']);
+  return html`
+    <bx-selectable-tile
+      checkmark-label="${ifDefined(!checkmarkLabel ? undefined : checkmarkLabel)}"
+      name="${ifDefined(!name ? undefined : name)}"
+      ?selected="${selected}"
+      value="${ifDefined(!value ? undefined : value)}"
+      @input="${onInput}"
+    >
+      Multi-select Tile
+    </bx-selectable-tile>
+  `;
+};
+
+multiSelectable.story = {
+  name: 'Multi-selectable',
+  parameters: {
+    knobs: {
+      'bx-selectable-tile': () => ({
+        ...singleSelectable.story.parameters.knobs['bx-radio-tile'](),
+        selected: boolean('Selected (selected)', false),
+      }),
+    },
+  },
+};
+
+export const expandable = ({ parameters }) => {
+  const { expanded, disableChange } =
+    (parameters.props && parameters.props['bx-expandable-tile']) || ({} as typeof parameters.props['bx-expandable-tile']);
+  const beforeChangedAction = action('bx-expandable-tile-beingchanged');
+  const handleBeforeChanged = (event: CustomEvent) => {
+    beforeChangedAction(event);
+    if (disableChange) {
+      event.preventDefault();
+    }
+  };
+  return html`
+    <bx-expandable-tile
+      ?expanded="${expanded}"
+      @bx-expandable-tile-beingchanged=${handleBeforeChanged}
+      @bx-expandable-tile-changed=${action('bx-expandable-tile-changed')}
+    >
+      <bx-tile-above-the-fold-content style="height: 200px">
+        Above the fold content here
+      </bx-tile-above-the-fold-content>
+      <bx-tile-below-the-fold-content style="height: 300px">
+        Below the fold content here
+      </bx-tile-below-the-fold-content>
+    </bx-expandable-tile>
+  `;
+};
+
+expandable.story = {
+  parameters: {
+    docs: {
+      storyDescription: `
 Expandable tiles are helpful for hiding/showing larger amounts of content to a user.
 They can only be stacked in a single column, and cannot live in a row or horizontal grid.
 When expanded, tiles push content down the page.
 Expandable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
+    `,
+    },
+    knobs: {
+      'bx-expandable-tile': () => ({
+        expanded: boolean('Expanded (expanded)', false),
+        disableChange: boolean(
+          'Disable user-initiated change in expanded state ' +
+            '(Call event.preventDefault() in bx-expandable-tile-beingchanged event)',
+          false
+        ),
+      }),
+    },
+  },
+};
+
+export default {
+  title: 'Tile',
+  decorators: [
+    story =>
+      html`
+        <div>${story()}</div>
       `,
-      },
-    }
-  );
+  ],
+};

--- a/src/components/toggle/toggle-story.ts
+++ b/src/components/toggle/toggle-story.ts
@@ -9,38 +9,47 @@
 
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import './toggle';
 
-const createProps = () => ({
-  checked: boolean('Checked (checked)', false),
-  checkedText: text('Text for checked state (checked-text)', 'On'),
-  disabled: boolean('Disabled (disabled)', false),
-  labelText: text('Label text (label-text)', 'Toggle'),
-  name: text('Name (name)', ''),
-  small: boolean('Use small variant (small)', false),
-  uncheckedText: text('Text for unchecked state (unchecked-text)', 'Off'),
-  value: text('Value (value)', ''),
-  onInput: action('input'),
-});
+export const defaultStory = ({ parameters }) => {
+  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onInput } =
+    (parameters.props && parameters.props['bx-toggle']) || ({} as typeof parameters.props['bx-toggle']);
+  return html`
+    <bx-toggle
+      ?checked="${checked}"
+      checked-text="${checkedText}"
+      ?disabled="${disabled}"
+      label-text="${labelText}"
+      name="${ifDefined(!name ? undefined : name)}"
+      ?small="${small}"
+      unchecked-text="${uncheckedText}"
+      value="${ifDefined(!value ? undefined : value)}"
+      @input="${onInput}"
+    ></bx-toggle>
+  `;
+};
 
-storiesOf('Toggle', module)
-  .addDecorator(withKnobs)
-  .add('Default', () => {
-    const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onInput } = createProps();
-    return html`
-      <bx-toggle
-        ?checked="${checked}"
-        checked-text="${checkedText}"
-        ?disabled="${disabled}"
-        label-text="${labelText}"
-        name="${ifDefined(!name ? undefined : name)}"
-        ?small="${small}"
-        unchecked-text="${uncheckedText}"
-        value="${ifDefined(!value ? undefined : value)}"
-        @input="${onInput}"
-      ></bx-toggle>
-    `;
-  });
+defaultStory.story = {
+  name: 'Default',
+};
+
+export default {
+  title: 'Toggle',
+  parameters: {
+    knobs: {
+      'bx-toggle': () => ({
+        checked: boolean('Checked (checked)', false),
+        checkedText: text('Text for checked state (checked-text)', 'On'),
+        disabled: boolean('Disabled (disabled)', false),
+        labelText: text('Label text (label-text)', 'Toggle'),
+        name: text('Name (name)', ''),
+        small: boolean('Use small variant (small)', false),
+        uncheckedText: text('Text for unchecked state (unchecked-text)', 'Off'),
+        value: text('Value (value)', ''),
+        onInput: action('input'),
+      }),
+    },
+  },
+};

--- a/src/components/tooltip/tooltip-story.ts
+++ b/src/components/tooltip/tooltip-story.ts
@@ -8,8 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import '../button/button';
 import './tooltip';
 import { FLOATING_MENU_DIRECTION } from '../floating-menu/floating-menu';
@@ -24,40 +23,49 @@ const directions = {
   [`Right (${FLOATING_MENU_DIRECTION.RIGHT})`]: FLOATING_MENU_DIRECTION.RIGHT,
 };
 
-const createProps = () => ({
-  open: boolean('Open (open)', false),
-  direction: select('Direction (direction in <bx-tooltip-body>)', directions, FLOATING_MENU_DIRECTION.BOTTOM),
-});
+export const defaultStory = ({ parameters }) => {
+  const { 'bx-tooltip': tooltipProps, 'bx-tooltip-body': tooltipBodyProps } = parameters.props || ({} as typeof parameters.props);
+  const { open } = tooltipProps || ({} as typeof tooltipProps);
+  const { direction } = tooltipBodyProps || ({} as typeof tooltipBodyProps);
+  return html`
+    <style>
+      ${styles}
+    </style>
+    <bx-tooltip ?open="${open}">
+      <bx-tooltip-body direction="${direction}">
+        <p>
+          This is some tooltip text. This box shows the maximum amount of text that should appear inside. If more room is needed
+          please use a modal instead.
+        </p>
+        <bx-tooltip-footer> <a href="#" class="bx--link">Learn More</a><bx-btn kind="primary">Create</bx-btn> </bx-tooltip-footer>
+      </bx-tooltip-body>
+    </bx-tooltip>
+  `;
+};
 
-storiesOf('Tooltip', module)
-  .addDecorator(withKnobs)
-  .add(
-    'Default',
-    () => {
-      const { open, direction } = createProps();
-      return html`
-        <style>
-          ${styles}
-        </style>
-        <bx-tooltip ?open="${open}">
-          <bx-tooltip-body direction="${direction}">
-            <p>
-              This is some tooltip text. This box shows the maximum amount of text that should appear inside. If more room is
-              needed please use a modal instead.
-            </p>
-            <bx-tooltip-footer>
-              <a href="#" class="bx--link">Learn More</a><bx-btn kind="primary">Create</bx-btn>
-            </bx-tooltip-footer>
-          </bx-tooltip-body>
-        </bx-tooltip>
-      `;
-    },
-    {
-      docs: {
-        storyDescription: `
+defaultStory.story = {
+  name: 'Default',
+
+  parameters: {
+    docs: {
+      storyDescription: `
 Interactive tooltip should be used if there are actions a user can take in the tooltip (e.g. a link or a button).
 For more regular use cases, e.g. giving the user more text information about something, use definition tooltip or icon tooltip.
-      `,
-      },
-    }
-  );
+    `,
+    },
+  },
+};
+
+export default {
+  title: 'Tooltip',
+  parameters: {
+    knobs: {
+      'bx-tooltip': () => ({
+        open: boolean('Open (open)', false),
+      }),
+      'bx-tooltip-body': () => ({
+        direction: select('Direction (direction in <bx-tooltip-body>)', directions, FLOATING_MENU_DIRECTION.BOTTOM),
+      }),
+    },
+  },
+};

--- a/src/components/ui-shell/ui-shell-story.ts
+++ b/src/components/ui-shell/ui-shell-story.ts
@@ -8,8 +8,7 @@
  */
 
 import { html } from 'lit-element';
-import { storiesOf } from '@storybook/polymer';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import Fade16 from '@carbon/icons/lib/fade/16';
 import contentStyles from 'carbon-components/scss/components/ui-shell/_content.scss';
 import './side-nav';
@@ -76,129 +75,164 @@ const StoryContent = () => html`
   </main>
 `;
 
-const createProps = () => ({
-  expanded: boolean('Expanded (expanded)', true),
-  fixed: boolean('Fixed (fixed)', false),
-  href: text('Link href (href)', 'javascript:void 0'), // eslint-disable-line no-script-url
-});
+export const sideNav = ({ parameters }) => {
+  const { 'bx-side-nav': sideNavProps, 'bx-side-nav-menu-item': sideNavMenuItemProps } =
+    parameters.props || ({} as typeof parameters.props);
+  const { expanded, fixed } = sideNavProps || ({} as typeof sideNavProps);
+  const { href } = sideNavMenuItemProps || ({} as typeof sideNavMenuItemProps);
+  const result = html`
+    <bx-side-nav aria-label="Side navigation" ?expanded=${expanded} ?fixed=${fixed}>
+      <bx-side-nav-items>
+        <bx-side-nav-menu title="L0 menu">
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+        </bx-side-nav-menu>
+        <bx-side-nav-menu title="L0 menu">
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item active aria-current="page" href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+        </bx-side-nav-menu>
+        <bx-side-nav-menu title="L0 menu">
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+        </bx-side-nav-menu>
+        <bx-side-nav-link href="javascript:void(0)">L0 link</bx-side-nav-link>
+        <bx-side-nav-link href="javascript:void(0)">L0 link</bx-side-nav-link>
+      </bx-side-nav-items>
+    </bx-side-nav>
+    ${StoryContent()}
+  `;
+  (result as any).hasMainTag = true;
+  return result;
+};
 
-storiesOf('UI Shell', module)
-  .addDecorator(withKnobs)
-  .add('Side nav', () => {
-    const { expanded, fixed, href } = createProps();
-    const result = html`
-      <bx-side-nav aria-label="Side navigation" ?expanded=${expanded} ?fixed=${fixed}>
-        <bx-side-nav-items>
-          <bx-side-nav-menu title="L0 menu">
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-          </bx-side-nav-menu>
-          <bx-side-nav-menu title="L0 menu">
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item active aria-current="page" href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-          </bx-side-nav-menu>
-          <bx-side-nav-menu title="L0 menu">
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-          </bx-side-nav-menu>
-          <bx-side-nav-link href="javascript:void(0)">L0 link</bx-side-nav-link>
-          <bx-side-nav-link href="javascript:void(0)">L0 link</bx-side-nav-link>
-        </bx-side-nav-items>
-      </bx-side-nav>
-      ${StoryContent()}
-    `;
-    (result as any).hasMainTag = true;
-    return result;
-  })
-  .add('Side nav with icons', () => {
-    const { expanded, fixed, href } = createProps();
-    const result = html`
-      <bx-side-nav aria-label="Side navigation" ?expanded=${expanded} ?fixed=${fixed}>
-        <bx-side-nav-items>
-          <bx-side-nav-menu title="L0 menu">
-            ${Fade16({ slot: 'title-icon' })}
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-          </bx-side-nav-menu>
-          <bx-side-nav-menu title="L0 menu">
-            ${Fade16({ slot: 'title-icon' })}
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item active aria-current="page" href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-          </bx-side-nav-menu>
-          <bx-side-nav-menu title="L0 menu">
-            ${Fade16({ slot: 'title-icon' })}
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-            <bx-side-nav-menu-item href="${href}">
-              L0 menu item
-            </bx-side-nav-menu-item>
-          </bx-side-nav-menu>
-          <bx-side-nav-link href="javascript:void(0)">${Fade16({ slot: 'title-icon' })}L0 link</bx-side-nav-link>
-          <bx-side-nav-link href="javascript:void(0)">${Fade16({ slot: 'title-icon' })}L0 link</bx-side-nav-link>
-        </bx-side-nav-items>
-      </bx-side-nav>
-      ${StoryContent()}
-    `;
-    (result as any).hasMainTag = true;
-    return result;
-  })
-  .add('Header', () => {
-    const result = html`
-      <bx-header aria-label="IBM Platform Name">
-        <bx-header-menu-button button-label-active="Close menu" button-label-inactive="Open menu"></bx-header-menu-button>
-        <bx-header-name href="javascript:void 0" prefix="IBM">[Platform]</bx-header-name>
-        <bx-header-nav menu-bar-label="IBM [Platform]">
-          <bx-header-nav-item href="javascript:void 0">Link 1</bx-header-nav-item>
-          <bx-header-nav-item href="javascript:void 0">Link 2</bx-header-nav-item>
-          <bx-header-nav-item href="javascript:void 0">Link 3</bx-header-nav-item>
-          <bx-header-menu menu-label="Link 4" trigger-content="Link 4">
-            <bx-header-menu-item href="javascript:void 0">Sub-link 1</bx-header-menu-item>
-            <bx-header-menu-item href="javascript:void 0">Sub-link 2</bx-header-menu-item>
-            <bx-header-menu-item href="javascript:void 0">Sub-link 3</bx-header-menu-item>
-          </bx-header-menu>
-        </bx-header-nav>
-      </bx-header>
-      ${StoryContent()}
-    `;
-    (result as any).hasMainTag = true;
-    return result;
-  });
+sideNav.story = {
+  name: 'Side nav',
+  parameters: {
+    knobs: {
+      'bx-side-nav': () => ({
+        expanded: boolean('Expanded (expanded)', true),
+        fixed: boolean('Fixed (fixed)', false),
+      }),
+      'bx-side-nav-menu-item': () => ({
+        href: text('Link href (href)', 'javascript:void 0'), // eslint-disable-line no-script-url
+      }),
+    },
+  },
+};
+
+export const sideNavWithIcons = ({ parameters }) => {
+  const { 'bx-side-nav': sideNavProps, 'bx-side-nav-menu-item': sideNavMenuItemProps } =
+    parameters.props || ({} as typeof parameters.props);
+  const { expanded, fixed } = sideNavProps || ({} as typeof sideNavProps);
+  const { href } = sideNavMenuItemProps || ({} as typeof sideNavMenuItemProps);
+  const result = html`
+    <bx-side-nav aria-label="Side navigation" ?expanded=${expanded} ?fixed=${fixed}>
+      <bx-side-nav-items>
+        <bx-side-nav-menu title="L0 menu">
+          ${Fade16({ slot: 'title-icon' })}
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+        </bx-side-nav-menu>
+        <bx-side-nav-menu title="L0 menu">
+          ${Fade16({ slot: 'title-icon' })}
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item active aria-current="page" href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+        </bx-side-nav-menu>
+        <bx-side-nav-menu title="L0 menu">
+          ${Fade16({ slot: 'title-icon' })}
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+          <bx-side-nav-menu-item href="${href}">
+            L0 menu item
+          </bx-side-nav-menu-item>
+        </bx-side-nav-menu>
+        <bx-side-nav-link href="javascript:void(0)">${Fade16({ slot: 'title-icon' })}L0 link</bx-side-nav-link>
+        <bx-side-nav-link href="javascript:void(0)">${Fade16({ slot: 'title-icon' })}L0 link</bx-side-nav-link>
+      </bx-side-nav-items>
+    </bx-side-nav>
+    ${StoryContent()}
+  `;
+  (result as any).hasMainTag = true;
+  return result;
+};
+
+sideNavWithIcons.story = {
+  name: 'Side nav with icons',
+  parameters: {
+    knobs: sideNav.story.parameters.knobs,
+  },
+};
+
+export const header = () => {
+  const result = html`
+    <bx-header aria-label="IBM Platform Name">
+      <bx-header-menu-button button-label-active="Close menu" button-label-inactive="Open menu"></bx-header-menu-button>
+      <bx-header-name href="javascript:void 0" prefix="IBM">[Platform]</bx-header-name>
+      <bx-header-nav menu-bar-label="IBM [Platform]">
+        <bx-header-nav-item href="javascript:void 0">Link 1</bx-header-nav-item>
+        <bx-header-nav-item href="javascript:void 0">Link 2</bx-header-nav-item>
+        <bx-header-nav-item href="javascript:void 0">Link 3</bx-header-nav-item>
+        <bx-header-menu menu-label="Link 4" trigger-content="Link 4">
+          <bx-header-menu-item href="javascript:void 0">Sub-link 1</bx-header-menu-item>
+          <bx-header-menu-item href="javascript:void 0">Sub-link 2</bx-header-menu-item>
+          <bx-header-menu-item href="javascript:void 0">Sub-link 3</bx-header-menu-item>
+        </bx-header-menu>
+      </bx-header-nav>
+    </bx-header>
+    ${StoryContent()}
+  `;
+  (result as any).hasMainTag = true;
+  return result;
+};
+
+header.story = {
+  parameters: {
+    knobs: {
+      'bx-side-nav': () => ({}),
+      'bx-side-nav-menu-item': () => ({}),
+    },
+  },
+};
+
+export default {
+  title: 'UI Shell',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,6 +2247,19 @@
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
+"@storybook/addons@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.2.6.tgz#c1278137acb3502e068b0b0d07a8371c607e9c02"
+  integrity sha512-5MF64lsAhIEMxTbVpYROz5Wez595iwSw45yXyP8gWt12d+EmFO5tdy7cYJCxcMuVhDfaCI78tFqS9orr1atVyA==
+  dependencies:
+    "@storybook/api" "5.2.6"
+    "@storybook/channels" "5.2.6"
+    "@storybook/client-logger" "5.2.6"
+    "@storybook/core-events" "5.2.6"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/angular@^5.2.0":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/angular/-/angular-5.2.1.tgz#d0e4affe7e4cf758e34f7518a2b299920acfb890"
@@ -2310,6 +2323,29 @@
     telejson "^3.0.2"
     util-deprecate "^1.0.2"
 
+"@storybook/api@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.2.6.tgz#43d3c20b90e585e6c94b36e29845d39704ae2135"
+  integrity sha512-X/di44/SAL68mD6RHTX2qdWwhjRW6BgcfPtu0dMd38ErB3AfsfP4BITXs6kFOeSM8kWiaQoyuw0pOBzA8vlYug==
+  dependencies:
+    "@storybook/channels" "5.2.6"
+    "@storybook/client-logger" "5.2.6"
+    "@storybook/core-events" "5.2.6"
+    "@storybook/router" "5.2.6"
+    "@storybook/theming" "5.2.6"
+    core-js "^3.0.1"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    prop-types "^15.6.2"
+    react "^16.8.3"
+    semver "^6.0.0"
+    shallow-equal "^1.1.0"
+    store2 "^2.7.1"
+    telejson "^3.0.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-5.2.1.tgz#85541f926d61eedbe2a687bb394d37fc06252751"
@@ -2332,6 +2368,13 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.2.5.tgz#d6ca2b490281dacb272096563fe760ccb353c4bb"
   integrity sha512-I+zB3ym5ozBcNBqyzZbvB6gRIG/ZKKkqy5k6LwKd5NMx7NU7zU74+LQUBBOcSIrigj8kCArZz7rlgb0tlSKXxQ==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/channels@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.2.6.tgz#e2837508864dc4d5b5e03f078886f0ce113762ea"
+  integrity sha512-/UsktYsXuvb1efjVPCEivhh5ywRhm7hl73pQnpJLJHRqyLMM2I5nGPFELTTNuU9yWy7sP9QL5gRqBBPe1sqjZQ==
   dependencies:
     core-js "^3.0.1"
 
@@ -2367,6 +2410,13 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.2.5.tgz#6f386ac6f81b4a783c57d54bb328281abbea1bab"
   integrity sha512-6DyYUrMgAvF+th0foH7UNz+2JJpRdvNbpvYKtvi/+hlvRIaI6AqANgLkPUgMibaif5TLzjCr0bLdAYcjeJz03w==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/client-logger@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.2.6.tgz#cfc4536e9b724b086f7509c2bb34c221016713c9"
+  integrity sha512-hJvPD267cCwLIRMOISjDH8h9wbwOcXIJip29UlJbU9iMtZtgE+YelmlpmZJvqcDfUiXWWrOh7tP76mj8EAfwIQ==
   dependencies:
     core-js "^3.0.1"
 
@@ -2430,6 +2480,13 @@
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.2.5.tgz#62881164a4a01aa99ff0691e70eaed2dd58e229e"
   integrity sha512-O5GM8XEBbYNbM6Z7a4H1bbnbO2cxQrXMhEwansC7a7YinQdkTPiuGxke3NiyK+7pLDh778kpQyjoCjXq6UfAoQ==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.2.6.tgz#34c9aae256e7e5f4a565b81f1e77dda8bccc6752"
+  integrity sha512-W8kLJ7tc0aAxs11CPUxUOCReocKL4MYGyjTg8qwk0USLzPUb/FUQWmhcm2ilFz6Nz8dXLcKrXdRVYTmiMsgAeg==
   dependencies:
     core-js "^3.0.1"
 
@@ -2584,6 +2641,19 @@
     memoizerific "^1.11.3"
     qs "^6.6.0"
 
+"@storybook/router@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.2.6.tgz#5180d3785501699283c6c3717986c877f84fead5"
+  integrity sha512-/FZd3fYg5s2QzOqSIP8UMOSnCIFFIlli/jKlOxvm3WpcpxgwQOY4lfHsLO+r9ThCLs2UvVg2R/HqGrOHqDFU7A==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+
 "@storybook/source-loader@5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.2.1.tgz#87b47899c47e301d890f4135f85301a24a3313aa"
@@ -2606,6 +2676,21 @@
   dependencies:
     "@storybook/addons" "5.2.5"
     "@storybook/router" "5.2.5"
+    core-js "^3.0.1"
+    estraverse "^4.2.0"
+    global "^4.3.2"
+    loader-utils "^1.2.3"
+    prettier "^1.16.4"
+    prop-types "^15.7.2"
+    regenerator-runtime "^0.12.1"
+
+"@storybook/source-loader@^5.2.0":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.2.6.tgz#06e6b5e93ea4c635c7d05c517ad8711de9030ba3"
+  integrity sha512-OJWmmLlt84efk+xLEqkyVQBlD5n9tbPlkrepQKtGBpR0JXeGyyvJ/3S8jnpW3NYUrFjUgHPkSWBp/c5CfzPwSw==
+  dependencies:
+    "@storybook/addons" "5.2.6"
+    "@storybook/router" "5.2.6"
     core-js "^3.0.1"
     estraverse "^4.2.0"
     global "^4.3.2"
@@ -2640,6 +2725,24 @@
     "@emotion/core" "^10.0.14"
     "@emotion/styled" "^10.0.14"
     "@storybook/client-logger" "5.2.5"
+    common-tags "^1.8.0"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.14"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    prop-types "^15.7.2"
+    resolve-from "^5.0.0"
+
+"@storybook/theming@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.2.6.tgz#e04170b3e53dcfc791b2381c8a39192ae88cd291"
+  integrity sha512-Xa9R/H8DDgmvxsCHloJUJ2d9ZQl80AeqHrL+c/AKNpx05s9lV74DcinusCf0kz72YGUO/Xt1bAjuOvLnAaS8Gw==
+  dependencies:
+    "@emotion/core" "^10.0.14"
+    "@emotion/styled" "^10.0.14"
+    "@storybook/client-logger" "5.2.6"
     common-tags "^1.8.0"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"


### PR DESCRIPTION
This change introduces Component Story Format to `lit-html`-based stories. It allows us to re-use story code for snapshot tests as well as for a11y tests.

The change is done based on the codemod with Storybook CLI (`sb migrate`), along with a change to move knobs from story to story parameters (so tests can reuse story code without knobs dependency).

Migration of Angular/React/Vue stories will follow, once this PR has been merged.