### PR TITLE
chore(build): update browserlist

### DIFF
--- a/examples/codesandbox/angular/browserslist
+++ b/examples/codesandbox/angular/browserslist
@@ -1,6 +1,9 @@
 last 1 version
 Firefox ESR
 not opera > 0
+not op_mini > 0
+not op_mob > 0
 not android > 0
 not edge > 0
 not ie > 0
+not ie_mob > 0

--- a/examples/codesandbox/custom-style/package.json
+++ b/examples/codesandbox/custom-style/package.json
@@ -27,8 +27,11 @@
     "last 1 version",
     "Firefox ESR",
     "not opera > 0",
+    "not op_mini > 0",
+    "not op_mob > 0",
     "not android > 0",
     "not edge > 0",
-    "not ie > 0"
+    "not ie > 0",
+    "not ie_mob > 0"
   ]
 }

--- a/examples/codesandbox/react/package.json
+++ b/examples/codesandbox/react/package.json
@@ -25,8 +25,11 @@
     "last 1 version",
     "Firefox ESR",
     "not opera > 0",
+    "not op_mini > 0",
+    "not op_mob > 0",
     "not android > 0",
     "not edge > 0",
-    "not ie > 0"    
+    "not ie > 0",
+    "not ie_mob > 0"
   ]
 }

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -152,7 +152,17 @@ module.exports = {
                   '@babel/preset-env',
                   {
                     modules: false,
-                    targets: ['last 1 version', 'Firefox ESR', 'not opera > 0', 'not android > 0', 'not edge > 0', 'not ie > 0'],
+                    targets: [
+                      'last 1 version',
+                      'Firefox ESR',
+                      'not opera > 0',
+                      'not op_mini > 0',
+                      'not op_mob > 0',
+                      'not android > 0',
+                      'not edge > 0',
+                      'not ie > 0',
+                      'not ie_mob > 0',
+                    ],
                   },
                 ],
               ],


### PR DESCRIPTION
This change updates `browserlist` configurations for ES2015+ compile target. Notably `ie_mob` is added for exclusion that caused ES5 transpilation in some environments (Parcel-based CodeSandbox examples).