### PR TITLE
docs(rtl): add RTL example

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -28,6 +28,29 @@ The color of the button in the code below changes to the one in the `g100` theme
 
 The names of CSS Custom Properties you can use are the Carbon theme tokens prefixed with `--cds-`. The list of Carbon theme tokens can be found at [here](https://github.com/carbon-design-system/carbon/blob/v10.7.0/packages/themes/scss/generated/_themes.scss#L14-L454).
 
+## Dependency injection
+
+You can let our custom elements modules load alternate `CSSResult` module. Below example uses [Webpack `NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to let our custom elements modules load RTL version of `CSSResult` module that is shipped alongside with default `CSSResult` modules, instead of loading the default version:
+
+[![Edit carbon-custom-elements with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/rtl)
+
+```javascript
+const reCssBundle = /\.css\.js$/i;
+
+...
+
+module.exports = {
+  ...
+  plugins: [
+    ...
+    new webpack.NormalModuleReplacementPlugin(reCssBundle, resource => {
+      resource.request = resource.request.replace(reCssBundle, '.rtl.css.js');
+    }),
+  ],
+  ...
+};
+```
+
 ## Creating derived components with different style
 
 You can create a derived class of our component and override [static `styles` property](https://lit-element.polymer-project.org/guide/styles#static-styles), like:

--- a/examples/codesandbox/rtl/.gitignore
+++ b/examples/codesandbox/rtl/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.cache
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/examples/codesandbox/rtl/package.json
+++ b/examples/codesandbox/rtl/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "carbon-custom-elements-rtl-getting-started",
+  "version": "0.1.0",
+  "description": "Sample project for getting started with the Web Components from the Carbon Design System with IE.",
+  "scripts": {
+    "start": "webpack-dev-server --mode development --port 8080"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2",
+  "devDependencies": {
+    "@babel/core": "^7.5.0",
+    "@babel/plugin-transform-runtime": "^7.5.0",
+    "@babel/preset-env": "^7.5.0",
+    "@babel/runtime": "^7.5.0",
+    "accept-language-parser": "^1.5.0",
+    "carbon-components": "~10.7.0",
+    "carbon-custom-elements": "^0.3.0",
+    "classnames": "^2.2.0",
+    "es6-promise": "^4.1.0",
+    "html-webpack-plugin": "^3.2.0",
+    "lit-element": "^2.1.0",
+    "lit-html": "^1.1.0",
+    "lodash-es": "^4.17.0",
+    "rtl-detect": "^1.0.0",
+    "webpack": "^4.39.0",
+    "webpack-cli": "^3.3.0",
+    "webpack-dev-server": "^3.8.0"
+  }
+}

--- a/examples/codesandbox/rtl/sandbox.config.json
+++ b/examples/codesandbox/rtl/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}

--- a/examples/codesandbox/rtl/src/index.ejs
+++ b/examples/codesandbox/rtl/src/index.ejs
@@ -1,0 +1,48 @@
+<!--
+@license
+
+Copyright IBM Corp. 2019
+
+This source code is licensed under the Apache-2.0 license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+<html dir="<%= dir %>">
+  <head>
+    <title>carbon-custom-elements example</title>
+    <meta charset="UTF-8" />
+    <style type="text/css">
+      body {
+        font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+      }
+
+      #app {
+        width: 300px;
+      }
+
+      bx-slider,
+      bx-slider-input {
+        visibility: hidden;
+      }
+
+      bx-slider:defined,
+      bx-slider-input:defined {
+        visibility: inherit;
+      }
+    </style>
+    <script src="dist/bundle<%= dir !== 'rtl' ? '' : '-rtl' %>.js"></script>
+  </head>
+  <body>
+    <h1>Hello World! 👋</h1>
+    <div id="app">
+      <bx-slider
+        label-text="Slider label"
+        min="0"
+        max="100"
+        value="50"
+      >
+        <bx-slider-input aria-label="Slider value" type="number" value="50"></bx-slider-input>
+      </bx-slider>
+    </div>
+  </body>
+</html>

--- a/examples/codesandbox/rtl/src/index.js
+++ b/examples/codesandbox/rtl/src/index.js
@@ -1,0 +1,11 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import 'carbon-custom-elements/es/components/slider/slider';
+import 'carbon-custom-elements/es/components/slider/slider-input';

--- a/examples/codesandbox/rtl/webpack.config.js
+++ b/examples/codesandbox/rtl/webpack.config.js
@@ -1,0 +1,76 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const path = require('path');
+const webpack = require('webpack');
+const acceptLanguageParser = require('accept-language-parser');
+const rtlDetect = require('rtl-detect');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const reCssBundle = /\.css\.js$/i;
+
+const devServer = {
+  open: true,
+  contentBase: path.resolve(__dirname, 'src'),
+  publicPath: '/dist',
+  setup(app, server) {
+    app.get('/', (req, res) => {
+      const { fileSystem, waitUntilValid } = server.middleware;
+      waitUntilValid(() => {
+        const isRtl = rtlDetect.isRtlLang(acceptLanguageParser.parse(req.headers['accept-language'])[0].code);
+        res.setHeader('Content-Type', 'text/html');
+        res.setHeader('Cache-Control', 'public, max-age=0');
+        res.send(fileSystem.readFileSync(path.resolve(__dirname, `dist/index${!isRtl ? '' : '-rtl'}.html`)));
+        res.end();
+      });
+    });
+  },
+};
+
+module.exports = [
+  {
+    entry: './src/index.js',
+    output: {
+      filename: 'bundle.js',
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        filename: 'index.html',
+        inject: false,
+        template: './src/index.ejs',
+        templateParameters: {
+          dir: 'ltr',
+        },
+      }),
+    ],
+    devServer,
+  },
+  {
+    entry: './src/index.js',
+    output: {
+      filename: 'bundle-rtl.js',
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        filename: 'index-rtl.html',
+        inject: false,
+        template: './src/index.ejs',
+        templateParameters: {
+          dir: 'rtl',
+        },
+      }),
+      new webpack.NormalModuleReplacementPlugin(reCssBundle, resource => {
+        resource.request = resource.request.replace(reCssBundle, '.rtl.css.js');
+      }),
+    ],
+    devServer,
+  },
+];


### PR DESCRIPTION
Will get this PR out of draft once we cut a release with the series of RTL changes. This example can be run by the following for now:

1. Checkout #201
2. Cherry-pick #206 onto above
3. `yarn clean && yarn build`
4. Checkout this commit
5. `cd /path/to/carbon-custom-elements/examples/codesandbox/rtl`
6. `yarn install`
7. `cd node_modules/carbon-custom-elements`
8. `rm -Rf es`
9. `cp -r /path/to/carbon-custom-elements/es .`
10. `cd ../..`
11. `yarn start`
12. Open Chrome
12. Go to chrome://settings/?search=language and click on the Language section highlighted
14. Add a RTL language (e.g. Arabic) and move it to the top
15. Open localhost:8080