### PR TITLE
chore(build): support setter-only properties

### DIFF
--- a/babel-plugin-create-react-custom-element-type.js
+++ b/babel-plugin-create-react-custom-element-type.js
@@ -234,7 +234,10 @@ module.exports = function generateCreateReactCustomElementType(api) {
 
       const metadata = getPropertyMetadata(path);
       if (metadata) {
-        if (!parentPath.isClassProperty() && (!parentPath.isClassMethod() || parentPath.node.kind !== 'get')) {
+        if (
+          !parentPath.isClassProperty() &&
+          (!parentPath.isClassMethod() || (parentPath.node.kind !== 'get' && parentPath.node.kind !== 'set'))
+        ) {
           throw parentPath.buildCodeFrameError('`@property()` must target class properties.');
         }
         declaredProps[parent.key.name] = metadata;


### PR DESCRIPTION
This change to React wrapper Babel plugin makes it support setter-only declared properties or one whose setter is defined first.

Refs #230.