### PR TITLE
fix(date-picker): support separate invalid prop

### DIFF
--- a/src/components/date-picker/date-picker-input.ts
+++ b/src/components/date-picker/date-picker-input.ts
@@ -129,6 +129,13 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
   hideLabel = false;
 
   /**
+   * Controls the invalid state and visibility of the `validityMessage`.
+   * Corresponds to the attribute with the same name.
+   */
+  @property({ type: Boolean, reflect: true })
+  invalid = false;
+
+  /**
    * Date picker input kind. Corresponds to the attribute with the same name.
    */
   @property({ reflect: true })
@@ -194,15 +201,14 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
     const {
       disabled,
       hideLabel,
+      invalid,
       labelText,
       pattern = constructor.defaultPattern,
       placeholder,
       type = constructor.defaultType,
-      validityMessage,
       value,
       _handleInput: handleInput,
     } = this;
-    const hasValidity = Boolean(validityMessage);
     const labelClasses = classMap({
       [`${prefix}--label`]: true,
       [`${prefix}--visually-hidden`]: hideLabel,
@@ -221,7 +227,7 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
           pattern="${pattern}"
           placeholder="${ifNonNull(placeholder)}"
           .value="${ifNonNull(value)}"
-          ?data-invalid="${hasValidity}"
+          ?data-invalid="${invalid}"
           @input="${handleInput}"
         />
         ${this._renderIcon()}

--- a/src/components/date-picker/date-picker-story-angular.ts
+++ b/src/components/date-picker/date-picker-story-angular.ts
@@ -21,9 +21,11 @@ export const defaultStory = ({ parameters }) => ({
     <bx-date-picker-input
       [disabled]="disabled"
       [hideLabel]="hideLabel"
+      [invalid]="invalid"
       [labelText]="labelText"
       [light]="light"
       [placeholder]="placeholder"
+      [validityMessage]="validityMessage"
     >
     </bx-date-picker-input>
   </bx-date-picker>
@@ -49,10 +51,12 @@ export const singleWithCalendar = ({ parameters }) => ({
     <bx-date-picker-input
       [disabled]="disabled"
       [hideLabel]="hideLabel"
+      [invalid]="invalid"
       kind="single"
       [labelText]="labelText"
       [light]="light"
       [placeholder]="placeholder"
+      [validityMessage]="validityMessage"
       (input)="onInput($event)"
     >
     </bx-date-picker-input>
@@ -79,20 +83,24 @@ export const rangeWithCalendar = ({ parameters }) => ({
     <bx-date-picker-input
       [disabled]="disabled"
       [hideLabel]="hideLabel"
+      [invalid]="invalid"
       kind="from"
       [labelText]="labelText"
       [light]="light"
       [placeholder]="placeholder"
+      [validityMessage]="validityMessage"
       (input)="onInput($event)"
     >
     </bx-date-picker-input>
     <bx-date-picker-input
       [disabled]="disabled"
       [hideLabel]="hideLabel"
+      [invalid]="invalid"
       kind="to"
       [labelText]="labelText"
       [light]="light"
       [placeholder]="placeholder"
+      [validityMessage]="validityMessage"
       (input)="onInput($event)"
     >
     </bx-date-picker-input>

--- a/src/components/date-picker/date-picker-story-react.tsx
+++ b/src/components/date-picker/date-picker-story-react.tsx
@@ -23,16 +23,19 @@ import {
 export { default } from './date-picker-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { open } = parameters?.props?.['bx-date-picker'];
-  const { disabled, hideLabel, labelText, light, placeholder } = parameters?.props?.['bx-date-picker-input'];
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage } = parameters?.props?.[
+    'bx-date-picker-input'
+  ];
   return (
-    <BXDatePicker open={open}>
+    <BXDatePicker>
       <BXDatePickerInput
         disabled={disabled}
         hideLabel={hideLabel}
+        invalid={invalid}
         labelText={labelText}
         light={light}
         placeholder={placeholder}
+        validityMessage={validityMessage}
       />
     </BXDatePicker>
   );
@@ -42,7 +45,9 @@ defaultStory.story = baseDefaultStory.story;
 
 export const singleWithCalendar = ({ parameters }) => {
   const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
-  const { disabled, hideLabel, labelText, light, placeholder, onInput } = parameters?.props?.['bx-date-picker-input'];
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } = parameters?.props?.[
+    'bx-date-picker-input'
+  ];
   return (
     <BXDatePicker
       dateFormat={dateFormat}
@@ -54,10 +59,12 @@ export const singleWithCalendar = ({ parameters }) => {
       <BXDatePickerInput
         disabled={disabled}
         hideLabel={hideLabel}
+        invalid={invalid}
         kind="single"
         labelText={labelText}
         light={light}
         placeholder={placeholder}
+        validityMessage={validityMessage}
         onInput={onInput}
       />
     </BXDatePicker>
@@ -68,7 +75,9 @@ singleWithCalendar.story = baseSingleWithCalendar.story;
 
 export const rangeWithCalendar = ({ parameters }) => {
   const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
-  const { disabled, hideLabel, labelText, light, placeholder, onInput } = parameters?.props?.['bx-date-picker-input'];
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } = parameters?.props?.[
+    'bx-date-picker-input'
+  ];
   return (
     <BXDatePicker
       dateFormat={dateFormat}
@@ -80,19 +89,23 @@ export const rangeWithCalendar = ({ parameters }) => {
       <BXDatePickerInput
         disabled={disabled}
         hideLabel={hideLabel}
+        invalid={invalid}
         kind="from"
         labelText={labelText}
         light={light}
         placeholder={placeholder}
+        validityMessage={validityMessage}
         onInput={onInput}
       />
       <BXDatePickerInput
         disabled={disabled}
         hideLabel={hideLabel}
+        invalid={invalid}
         kind="to"
         labelText={labelText}
         light={light}
         placeholder={placeholder}
+        validityMessage={validityMessage}
         onInput={onInput}
       />
     </BXDatePicker>

--- a/src/components/date-picker/date-picker-story-vue.ts
+++ b/src/components/date-picker/date-picker-story-vue.ts
@@ -22,9 +22,11 @@ export const defaultStory = ({ parameters }) => ({
       <bx-date-picker-input
         :disabled="disabled"
         :hide-label="hideLabel"
+        :invalid="invalid"
         :label-text="labelText"
         :light="light"
         :placeholder="placeholder"
+        :validity-message="validityMessage"
       >
       </bx-date-picker-input>
     </bx-date-picker>
@@ -47,10 +49,12 @@ export const singleWithCalendar = ({ parameters }) => ({
       <bx-date-picker-input
         :disabled="disabled"
         :hide-label="hideLabel"
+        :invalid="invalid"
         kind="single"
         :label-text="labelText"
         :light="light"
         :placeholder="placeholder"
+        :validity-message="validityMessage"
         @input="onInput"
       >
       </bx-date-picker-input>
@@ -74,20 +78,24 @@ export const rangeWithCalendar = ({ parameters }) => ({
       <bx-date-picker-input
         :disabled="disabled"
         :hide-label="hideLabel"
+        :invalid="invalid"
         kind="from"
         :label-text="labelText"
         :light="light"
         :placeholder="placeholder"
+        :validity-message="validityMessage"
         @input="onInput"
       >
       </bx-date-picker-input>
       <bx-date-picker-input
         :disabled="disabled"
         :hide-label="hideLabel"
+        :invalid="invalid"
         kind="to"
         :label-text="labelText"
         :light="light"
         :placeholder="placeholder"
+        :validity-message="validityMessage"
         @input="onInput"
       >
       </bx-date-picker-input>

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -12,15 +12,19 @@ import './date-picker';
 import './date-picker-input';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, hideLabel, labelText, light, placeholder } = parameters?.props?.['bx-date-picker-input'];
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage } = parameters?.props?.[
+    'bx-date-picker-input'
+  ];
   return html`
     <bx-date-picker>
       <bx-date-picker-input
         ?disabled="${disabled}"
         ?hide-label="${hideLabel}"
+        ?invalid="${invalid}"
         label-text="${labelText}"
         ?light="${light}"
         placeholder="${placeholder}"
+        validity-message="${validityMessage}"
       >
       </bx-date-picker-input>
     </bx-date-picker>
@@ -38,7 +42,9 @@ defaultStory.story = {
 
 export const singleWithCalendar = ({ parameters }) => {
   const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
-  const { disabled, hideLabel, labelText, light, placeholder, onInput } = parameters?.props?.['bx-date-picker-input'];
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } = parameters?.props?.[
+    'bx-date-picker-input'
+  ];
   return html`
     <bx-date-picker
       date-format="${dateFormat}"
@@ -51,10 +57,12 @@ export const singleWithCalendar = ({ parameters }) => {
       <bx-date-picker-input
         ?disabled="${disabled}"
         ?hide-label="${hideLabel}"
+        ?invalid="${invalid}"
         kind="single"
         label-text="${labelText}"
         ?light="${light}"
         placeholder="${placeholder}"
+        validity-message="${validityMessage}"
         @input="${onInput}"
       >
       </bx-date-picker-input>
@@ -83,7 +91,9 @@ singleWithCalendar.story = {
 
 export const rangeWithCalendar = ({ parameters }) => {
   const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
-  const { disabled, hideLabel, labelText, light, placeholder, onInput } = parameters?.props?.['bx-date-picker-input'];
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } = parameters?.props?.[
+    'bx-date-picker-input'
+  ];
   return html`
     <bx-date-picker
       date-format="${dateFormat}"
@@ -96,20 +106,24 @@ export const rangeWithCalendar = ({ parameters }) => {
       <bx-date-picker-input
         ?disabled="${disabled}"
         ?hide-label="${hideLabel}"
+        ?invalid="${invalid}"
         kind="from"
         label-text="${labelText}"
         ?light="${light}"
         placeholder="${placeholder}"
+        validity-message="${validityMessage}"
         @input="${onInput}"
       >
       </bx-date-picker-input>
       <bx-date-picker-input
         ?disabled="${disabled}"
         ?hide-label="${hideLabel}"
+        ?invalid="${invalid}"
         kind="to"
         label-text="${labelText}"
         ?light="${light}"
         placeholder="${placeholder}"
+        validity-message="${validityMessage}"
         @input="${onInput}"
       >
       </bx-date-picker-input>
@@ -134,9 +148,11 @@ export default {
       'bx-date-picker-input': () => ({
         disabled: boolean('Disabled (disabled in <bx-date-picker-input>)', false),
         hideLabel: boolean('Hide label (hide-label in <bx-date-picker-input>)', false),
+        invalid: boolean('Show invalid state  (invalid)', false),
         labelText: text('Label text (label-text in <bx-date-picker-input>)', 'Date Picker label'),
         light: boolean('Light variant (light in <bx-date-picker-input>)', false),
         placeholder: text('Placeholder text (placeholder in <bx-date-picker-input>)', 'mm/dd/yyyy'),
+        validityMessage: text('The validity message (validity-message)', ''),
         onInput: action('input'),
       }),
     },


### PR DESCRIPTION
This change adds `invalid` attribute to `<bx-date-picker-input>` to align to `<bx-input>`, etc.