### PR TITLE
fix(slider): normalize properties to string

### DIFF
--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -47,6 +47,26 @@ const THUMB_DIRECTION = {
 @customElement(`${prefix}-slider`)
 class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   /**
+   * The internal value of `max` property.
+   */
+  private _max = '100';
+
+  /**
+   * The internal value of `min` property.
+   */
+  private _min = '0';
+
+  /**
+   * The internal value of `step` property.
+   */
+  private _step = '1';
+
+  /**
+   * The internal value of `stepRatio` property.
+   */
+  private _stepRatio = '4';
+
+  /**
    * The handle for the listener of `${prefix}-slider-input` event.
    */
   private _hChangeInput: Handle | null = null;
@@ -68,12 +88,13 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   private get _rate() {
     const { max, min, value } = this;
     // Copes with out-of-range value coming programmatically or from `<bx-slider-input>`
-    return Math.min(max, Math.max(min, value)) / (max - min);
+    return Math.min(Number(max), Math.max(Number(min), value)) / (Number(max) - Number(min));
   }
 
   private set _rate(rate: number) {
     const { max, min, step } = this;
-    this.value = min + Math.round(((max - min) * Math.min(1, Math.max(0, rate))) / step) * step;
+    this.value =
+      Number(min) + Math.round(((Number(max) - Number(min)) * Math.min(1, Math.max(0, rate))) / Number(step)) * Number(step);
   }
 
   /**
@@ -110,7 +131,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
     if (!this.disabled) {
       if (key in THUMB_DIRECTION) {
         const { max, min, step, stepRatio } = this;
-        this.value += (!shiftKey ? step : (max - min) / stepRatio) * THUMB_DIRECTION[key];
+        this.value += (!shiftKey ? Number(step) : (Number(max) - Number(min)) / Number(stepRatio)) * THUMB_DIRECTION[key];
         this.dispatchEvent(
           new CustomEvent((this.constructor as typeof BXSlider).eventAfterChange, {
             bubbles: true,
@@ -240,14 +261,14 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
    * Should be changed upon the locale the UI is rendered with.
    */
   @property({ attribute: false })
-  formatMaxText = ({ max }) => String(max);
+  formatMaxText = ({ max }: { max: string }) => max;
 
   /**
    * The formatter for the text for minimum value.
    * Should be changed upon the locale the UI is rendered with.
    */
   @property({ attribute: false })
-  formatMinText = ({ min }) => String(min);
+  formatMinText = ({ min }: { min: string }) => min;
 
   /**
    * The label text. Corresponds to `label-text` attribute.
@@ -258,14 +279,30 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   /**
    * The maximum value.
    */
-  @property({ type: Number })
-  max = 100;
+  @property({ type: Number, reflect: true })
+  get max() {
+    return this._max.toString();
+  }
+
+  set max(value) {
+    const { max: oldMax } = this;
+    this._max = value;
+    this.requestUpdate('max', oldMax);
+  }
 
   /**
    * The minimum value.
    */
-  @property({ type: Number })
-  min = 0;
+  @property({ type: Number, reflect: true })
+  get min() {
+    return this._min.toString();
+  }
+
+  set min(value) {
+    const { min: oldMin } = this;
+    this._min = value;
+    this.requestUpdate('min', oldMin);
+  }
 
   /**
    * The form name. Corresponds to the attribute with the same name.
@@ -276,16 +313,32 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   /**
    * The snapping step of the value. Corresponds to the attribute with the same name.
    */
-  @property({ type: Number })
-  step = 1;
+  @property({ type: Number, reflect: true })
+  get step() {
+    return this._step.toString();
+  }
+
+  set step(value) {
+    const { step: oldStep } = this;
+    this._step = value;
+    this.requestUpdate('step', oldStep);
+  }
 
   /**
    * A value determining how much the value should increase/decrease by Shift+arrow keys,
    * which will be `(max - min) / stepRatio`.
    * Corresponds to `step-ratio` attribute.
    */
-  @property({ type: Number, attribute: 'step-ratio' })
-  stepRatio = 4;
+  @property({ type: Number, reflect: true, attribute: 'step-ratio' })
+  get stepRatio() {
+    return this._stepRatio.toString();
+  }
+
+  set stepRatio(value) {
+    const { stepRatio: oldStepRatio } = this;
+    this._stepRatio = value;
+    this.requestUpdate('stepRatio', oldStepRatio);
+  }
 
   /**
    * The value. Corresponds to the attribute with the same name.


### PR DESCRIPTION
This change ensures `<bx-slider>`'s `min`, `max`, `step` and `stepRatio` properties are kept as string, to better align with the APIs of `<input type="range">` as well as `<bx-number-input>`.