### PR TITLE
chore(devenv): introduce MDX in stories

### DIFF
--- a/.storybook/_container.scss
+++ b/.storybook/_container.scss
@@ -35,6 +35,17 @@ body,
   height: 100%;
 }
 
+// Reverts Carbon reset style of lists for docs page
+#docs-root {
+  ol {
+    list-style-type: decimal;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+}
+
 .bx-ce-demo-devenv--container {
   padding: 3em;
   display: flex;

--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -11,11 +11,9 @@ import '../src/polyfills';
 import { html } from 'lit-html'; // eslint-disable-line import/first
 import addons from '@storybook/addons';
 import { configure, addDecorator, addParameters } from '@storybook/polymer'; // eslint-disable-line import/first
-import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { withKnobs } from '@storybook/addon-knobs';
 import './components/focus-trap/focus-trap';
 import { CURRENT_THEME } from './addon-carbon-theme/shared';
-import DocsPage from './DocsPage';
 import theme from './theme';
 import containerStyles from './_container.scss'; // eslint-disable-line import/first
 
@@ -24,10 +22,6 @@ if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
 }
 
 addParameters({
-  docs: {
-    container: DocsContainer,
-    page: DocsPage,
-  },
   options: {
     theme: theme,
   },

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,7 @@
 const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
 const rtlcss = require('rtlcss');
+const createCompiler = require('@storybook/addon-docs/mdx-compiler-plugin');
 
 const useExperimentalFeatures = process.env.STORYBOOK_CARBON_USE_EXPERIMENTAL_FEATURES !== 'false';
 const useStyleSourceMap = process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_STYLE_SOURCEMAP === 'true';
@@ -135,6 +136,43 @@ module.exports = ({ config, mode }) => {
                 },
               ],
             ],
+          },
+        },
+      ],
+    },
+    {
+      test: /\.mdx$/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              '@babel/preset-react',
+              [
+                '@babel/preset-env',
+                {
+                  modules: false,
+                  targets: ['last 1 version', 'Firefox ESR', 'ie >= 11'],
+                },
+              ],
+            ],
+            plugins: [
+              // `version: '7.3.0'` ensures `@babel/plugin-transform-runtime` is applied to decorator helper
+              ['@babel/plugin-transform-runtime', { version: '7.3.0' }],
+              [
+                'babel-plugin-emotion',
+                {
+                  sourceMap: true,
+                  autoLabel: true,
+                },
+              ],
+            ],
+          },
+        },
+        {
+          loader: '@mdx-js/loader',
+          options: {
+            compilers: [createCompiler({})],
           },
         },
       ],

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@carbon/icons-vue": "^10.5.0",
     "@commitlint/cli": "^7.5.0",
     "@commitlint/config-conventional": "^7.5.0",
+    "@mdx-js/loader": "^1.5.0",
     "@open-wc/semantic-dom-diff": "^0.15.0",
     "@storybook/addon-actions": "^5.2.0",
     "@storybook/addon-docs": "^5.2.0",

--- a/src/components/accordion/accordion-story.mdx
+++ b/src/components/accordion/accordion-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Accordion
 
 The accordion component delivers large amounts of content in a small space through progressive disclosure.
@@ -8,3 +10,7 @@ Avoid “nested” accordions—that is, collapsible content within collapsible 
 The Carbon accordion allows for multiple sections to be expanded simultaneously.
 
 A chevron is used to indicate the “expand/collapse” action, though the entire header area is clickable for the same action.
+
+<Preview withToolbar>
+  <Story id="accordion--default-story" height="200px" />
+</Preview>

--- a/src/components/accordion/accordion-story.ts
+++ b/src/components/accordion/accordion-story.ts
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './accordion';
 import './accordion-item';
+import storyDocs from './accordion-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { open, titleText, disableToggle } = parameters?.props?.['bx-accordion'];
@@ -57,6 +58,7 @@ defaultStory.story = {
 export default {
   title: 'Accordion',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-accordion': () => ({
         open: boolean('Open the section (open)', false),

--- a/src/components/button/button-story.mdx
+++ b/src/components/button/button-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Button
 
 Buttons are used to initialize an action, either in the background or foreground of an experience.
@@ -11,3 +13,7 @@ There are several kinds of buttons:
 Small buttons may be used when there is not enough space for a regular sized button. This issue is most often found in tables. Small buttons should have three words or fewer.
 
 When words are not enough, icons can be used in buttons to better communicate what the button does. Icons are always paired with text.
+
+<Preview withToolbar>
+  <Story id="button--default-story" height="160px" />
+</Preview>

--- a/src/components/button/button-story.ts
+++ b/src/components/button/button-story.ts
@@ -13,6 +13,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import Add16 from '@carbon/icons/lib/add/16';
 import { BUTTON_KIND } from './button';
+import storyDocs from './button-story.mdx';
 
 const kinds = {
   [`Primary button (${BUTTON_KIND.PRIMARY})`]: BUTTON_KIND.PRIMARY,
@@ -59,6 +60,7 @@ textAndIcon.story = {
 export default {
   title: 'Button',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-btn': () => ({
         kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY),

--- a/src/components/checkbox/checkbox-story.mdx
+++ b/src/components/checkbox/checkbox-story.mdx
@@ -1,6 +1,12 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Check box
 
 Check box in `carbon-custom-elements` represents a combination of a check box and its label.
+
+<Preview withToolbar>
+  <Story id="checkbox--default-story" height="160px" />
+</Preview>
 
 ## Basic usage
 

--- a/src/components/checkbox/checkbox-story.ts
+++ b/src/components/checkbox/checkbox-story.ts
@@ -12,6 +12,7 @@ import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './checkbox';
+import storyDocs from './checkbox-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onInput } = parameters?.props?.['bx-checkbox'];
@@ -36,6 +37,7 @@ defaultStory.story = {
 export default {
   title: 'Checkbox',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-checkbox': () => ({
         checked: boolean('Checked (checked)', false),

--- a/src/components/code-snippet/README.md
+++ b/src/components/code-snippet/README.md
@@ -1,3 +1,0 @@
-# Code snippet
-
-Code snippets are small blocks of reusable code that can be inserted in a code file.

--- a/src/components/code-snippet/code-snippet-story.mdx
+++ b/src/components/code-snippet/code-snippet-story.mdx
@@ -1,0 +1,29 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Code snippet
+
+Code snippets are small blocks of reusable code that can be inserted in a code file.
+
+## Single line
+
+The Terminal style is for single-line.
+
+<Preview withToolbar>
+  <Story id="code-snippet--single-line" height="160px" />
+</Preview>
+
+## Multi line
+
+The Code style is for larger, multi-line code snippets.
+
+<Preview withToolbar>
+  <Story id="code-snippet--multi-line" height="320px" />
+</Preview>
+
+## Inline
+
+The Inline style is for code used within a block of text.
+
+<Preview withToolbar>
+  <Story id="code-snippet--inline" height="160px" />
+</Preview>

--- a/src/components/code-snippet/code-snippet-story.ts
+++ b/src/components/code-snippet/code-snippet-story.ts
@@ -12,6 +12,7 @@ import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { number, text } from '@storybook/addon-knobs';
 import './code-snippet';
+import storyDocs from './code-snippet-story.mdx';
 
 const defaultKnobs = {
   'bx-code-snippet': () => ({
@@ -47,11 +48,6 @@ export const singleLine = ({ parameters }) => {
 
 singleLine.story = {
   name: 'Single line',
-  parameters: {
-    docs: {
-      storyDescription: 'The Terminal style is for single-line.',
-    },
-  },
 };
 
 export const multiLine = ({ parameters }) => {
@@ -102,9 +98,6 @@ floating: 10000
 multiLine.story = {
   name: 'Multi line',
   parameters: {
-    docs: {
-      storyDescription: 'The Code style is for larger, multi-line code snippets.',
-    },
     knobs: {
       'bx-code-snippet': () => ({
         ...defaultKnobs['bx-code-snippet'](),
@@ -138,16 +131,12 @@ export const inline = ({ parameters }) => {
 
 inline.story = {
   name: 'Inline',
-  parameters: {
-    docs: {
-      storyDescription: 'The Inline style is for code used within a block of text.',
-    },
-  },
 };
 
 export default {
   title: 'Code snippet',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: defaultKnobs,
   },
 };

--- a/src/components/combo-box/combo-box-story.mdx
+++ b/src/components/combo-box/combo-box-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Combo box
 
 Combo box realizes a notion of "filterable dropdown".
@@ -6,3 +8,7 @@ The drawer opens on click (anywhere in the field) and the user can type to filte
 Once the user begins typing, the close (X) icon will appear to the right of the label.
 This will clear any user-inputted text.
 Selecting an item from the dropdown will close the drawer and the selected option will replace the default label.
+
+<Preview withToolbar>
+  <Story id="combo-box--default-story" height="240px" />
+</Preview>

--- a/src/components/combo-box/combo-box-story.ts
+++ b/src/components/combo-box/combo-box-story.ts
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './combo-box';
 import './combo-box-item';
+import storyDocs from './combo-box-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const {
@@ -63,6 +64,7 @@ defaultStory.story = {
 export default {
   title: 'Combo box',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-combo-box': () => ({
         open: boolean('Open (open)', false),

--- a/src/components/content-switcher/content-switcher-story.mdx
+++ b/src/components/content-switcher/content-switcher-story.mdx
@@ -1,0 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Content switcher
+
+Content switcher manipulates the content shown following an exclusive or “either/or” pattern. It is used to toggle between two or more content sections within the same space on screen. Only one section can be shown at a time.
+
+<Preview withToolbar>
+  <Story id="content-switcher--default-story" height="160px" />
+</Preview>

--- a/src/components/content-switcher/content-switcher-story.ts
+++ b/src/components/content-switcher/content-switcher-story.ts
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './content-switcher';
 import './content-switcher-item';
+import storyDocs from './content-switcher-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, value, disableSelection } = parameters?.props?.['bx-content-switcher'];
@@ -45,6 +46,7 @@ defaultStory.story = {
 export default {
   title: 'Content switcher',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-content-switcher': () => ({
         disabled: boolean('Disabled (disabled)', false),

--- a/src/components/data-table/data-table-story.mdx
+++ b/src/components/data-table/data-table-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Data table
 
 Data table in `carbon-custom-elements` focuses on primitives that constructs table UI, consisting of the following:
@@ -14,6 +16,10 @@ Data table in `carbon-custom-elements` focuses on primitives that constructs tab
 | `<bx-table-cell>`        | The header cell | `<td>`               |
 
 ## Basic usage
+
+<Preview withToolbar>
+  <Story id="data-table--default-story" height="280px" />
+</Preview>
 
 In the most basic case, you can simply put your table rows/cells in the same way as putting `<tr>`/`<td>` like below, and you'll get Carbon-styled table automatically:
 
@@ -167,6 +173,10 @@ html`
 ```
 
 ## Sorting
+
+<Preview withToolbar>
+  <Story id="data-table--sortable" height="320px" />
+</Preview>
 
 Adding `sort-direction` attribute to `<bx-table-header-cell>` shows the sorting UI in the table header cell.
 

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -33,6 +33,7 @@ import './table-toolbar-content';
 import './table-toolbar-search';
 import { rows as demoRows, rowsMany as demoRowsMany, columns as demoColumns, sortInfo as demoSortInfo } from './stories/data';
 import { TDemoTableColumn, TDemoTableRow, TDemoSortInfo } from './stories/types';
+import storyDocs from './data-table-story.mdx';
 
 /**
  * A class to manage table states, like selection and sorting.
@@ -619,4 +620,7 @@ sortableWithPagination.story = {
 
 export default {
   title: 'Data table',
+  parameters: {
+    docs: storyDocs.parameters.docs,
+  },
 };

--- a/src/components/date-picker/date-picker-story.mdx
+++ b/src/components/date-picker/date-picker-story.mdx
@@ -1,0 +1,29 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Date picker
+
+Date and time pickers allow users to select a single or a range of dates and times.
+
+## Simple date picker
+
+A simple Date Picker consists of an input field and no calendar.
+
+<Preview withToolbar>
+  <Story id="date-picker--default-story" height="160px" />
+</Preview>
+
+## Single date picker
+
+A single Date Picker consists of an input field and a calendar.
+
+<Preview withToolbar>
+  <Story id="date-picker--single-with-calendar" height="480px" />
+</Preview>
+
+## Range date picker
+
+A range Date Picker consists of two input fields and a calendar.
+
+<Preview withToolbar>
+  <Story id="date-picker--range-with-calendar" height="480px" />
+</Preview>

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -10,6 +10,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './date-picker';
 import './date-picker-input';
+import storyDocs from './date-picker-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, hideLabel, labelText, light, placeholder } = parameters?.props?.['bx-date-picker-input'];
@@ -29,11 +30,6 @@ export const defaultStory = ({ parameters }) => {
 
 defaultStory.story = {
   name: 'Default',
-  parameters: {
-    docs: {
-      storyDescription: 'A simple Date Picker consists of an input field and no calendar.',
-    },
-  },
 };
 
 export const singleWithCalendar = ({ parameters }) => {
@@ -65,9 +61,6 @@ export const singleWithCalendar = ({ parameters }) => {
 singleWithCalendar.story = {
   name: 'Single with calendar',
   parameters: {
-    docs: {
-      storyDescription: 'A single Date Picker consists of an input field and a calendar.',
-    },
     knobs: {
       'bx-date-picker': () => ({
         dateFormat: text('The date format (date-format)', 'm/d/Y'),
@@ -120,9 +113,6 @@ export const rangeWithCalendar = ({ parameters }) => {
 rangeWithCalendar.story = {
   name: 'Range with calendar',
   parameters: {
-    docs: {
-      storyDescription: 'A range Date Picker consists of two input fields and a calendar.',
-    },
     knobs: singleWithCalendar.story.parameters.knobs,
   },
 };
@@ -130,6 +120,7 @@ rangeWithCalendar.story = {
 export default {
   title: 'Date picker',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-date-picker-input': () => ({
         disabled: boolean('Disabled (disabled in <bx-date-picker-input>)', false),

--- a/src/components/dropdown/README.md
+++ b/src/components/dropdown/README.md
@@ -1,3 +1,0 @@
-# Dropdown
-
-Dropdown presents a list of options that can be used to filter or sort existing content.

--- a/src/components/dropdown/dropdown-story.mdx
+++ b/src/components/dropdown/dropdown-story.mdx
@@ -1,0 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Dropdown
+
+Dropdown presents a list of options that can be used to filter or sort existing content.
+
+<Preview withToolbar>
+  <Story id="dropdown--default-story" height="240px" />
+</Preview>

--- a/src/components/dropdown/dropdown-story.ts
+++ b/src/components/dropdown/dropdown-story.ts
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './dropdown';
 import './dropdown-item';
+import storyDocs from './dropdown-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { open, disabled, helperText, labelText, light, value, triggerContent, disableSelection } = parameters?.props?.[
@@ -52,6 +53,7 @@ defaultStory.story = {
 export default {
   title: 'Dropdown',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-dropdown': () => ({
         open: boolean('Open (open)', false),

--- a/src/components/inline-loading/inline-loading-story.mdx
+++ b/src/components/inline-loading/inline-loading-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Inline loading
 
 Inline loading spinners are used when performing actions.
@@ -8,3 +10,7 @@ Although it may not be obvious what is occurring on the back-end, we can communi
 It is best practice to use an Inline loading component for any Create, Update, or Delete actions.
 The component provides feedback to the user about the progress of the action they took.
 This could be in a table, after a primary or secondary button click, or even in a modal.
+
+<Preview withToolbar>
+  <Story id="inline-loading--default-story" height="160px" />
+</Preview>

--- a/src/components/inline-loading/inline-loading-story.ts
+++ b/src/components/inline-loading/inline-loading-story.ts
@@ -10,6 +10,7 @@
 import { html } from 'lit-element';
 import { select } from '@storybook/addon-knobs';
 import { INLINE_LOADING_STATE } from './inline-loading';
+import storyDocs from './inline-loading-story.mdx';
 
 const states = {
   [`Inactive (${INLINE_LOADING_STATE.INACTIVE})`]: INLINE_LOADING_STATE.INACTIVE,
@@ -32,6 +33,7 @@ defaultStory.story = {
 export default {
   title: 'Inline loading',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-inline-loading': () => ({
         status: select('Loading status (status)', states, INLINE_LOADING_STATE.ACTIVE),

--- a/src/components/input/input-story.mdx
+++ b/src/components/input/input-story.mdx
@@ -1,4 +1,10 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Input
 
 Text fields enable the user to interact with and input data.
 A single line field is used when the input anticipated by the user is a single line of text as opposed to a paragraph.
+
+<Preview withToolbar>
+  <Story id="input--default-story" height="160px" />
+</Preview>

--- a/src/components/input/input-story.ts
+++ b/src/components/input/input-story.ts
@@ -12,6 +12,7 @@ import * as knobs from '@storybook/addon-knobs';
 import './input';
 import '../form/form-item';
 import createProps from './stories/helpers';
+import storyDocs from './input-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, value, placeholder, invalid, type, onInput } = parameters?.props?.['bx-input'];
@@ -66,6 +67,7 @@ withoutFormItemWrapper.story = {
 export default {
   title: 'Input',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-input': () => createProps(knobs),
     },

--- a/src/components/loading/loading-story.mdx
+++ b/src/components/loading/loading-story.mdx
@@ -1,5 +1,11 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Loading
 
 Loading spinners are used when retrieving data or performing slow computations, and help to notify users that loading is underway.
 The waiting experience is a crucial design opportunity.
 Although it may not be obvious what is occurring on the back-end, we can communicate clearly to reassure the user that progress is happening.
+
+<Preview withToolbar>
+  <Story id="loading--default-story" height="320px" />
+</Preview>

--- a/src/components/loading/loading-story.ts
+++ b/src/components/loading/loading-story.ts
@@ -10,6 +10,7 @@
 import { html } from 'lit-element';
 import { boolean, select } from '@storybook/addon-knobs';
 import { LOADING_TYPE } from './loading';
+import storyDocs from './loading-story.mdx';
 
 const types = {
   [`Regular (${LOADING_TYPE.REGULAR})`]: LOADING_TYPE.REGULAR,
@@ -31,6 +32,7 @@ defaultStory.story = {
 export default {
   title: 'Loading',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-loading': () => ({
         inactive: boolean('Inactive (inactive)', false),

--- a/src/components/modal/modal-story.mdx
+++ b/src/components/modal/modal-story.mdx
@@ -1,5 +1,11 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Modal
 
 Modals interrupt user workflow by design.
 They are most effective when a task must be completed before a user can continue.
 While effective when used correctly, modals should be used sparingly to limit disruption to a user experience.
+
+<Preview withToolbar>
+  <Story id="modal--default-story" height="320px" />
+</Preview>

--- a/src/components/modal/modal-story.ts
+++ b/src/components/modal/modal-story.ts
@@ -18,6 +18,7 @@ import './modal-heading';
 import './modal-label';
 import './modal-body';
 import './modal-footer';
+import storyDocs from './modal-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { danger, open, disableClose } = parameters?.props?.['bx-modal'];
@@ -56,6 +57,7 @@ defaultStory.story = {
 export default {
   title: 'Modal',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-modal': () => ({
         open: boolean('Open (open)', true),

--- a/src/components/multi-select/multi-select-story.mdx
+++ b/src/components/multi-select/multi-select-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Multi select
 
 Multi select in `carbon-custom-elements` focuses on primitives consisting of the following:
@@ -6,6 +8,10 @@ Multi select in `carbon-custom-elements` focuses on primitives consisting of the
 | ------------------------ | --------------- |
 | `<bx-multi-select>`      | The container   |
 | `<bx-multi-select-item>` | The select item |
+
+<Preview withToolbar>
+  <Story id="multi-select--default-story" height="240px" />
+</Preview>
 
 ## Basic usage
 

--- a/src/components/multi-select/multi-select-story.ts
+++ b/src/components/multi-select/multi-select-story.ts
@@ -13,6 +13,7 @@ import { boolean, select, text } from '@storybook/addon-knobs';
 import { DROPDOWN_TYPE } from '../dropdown/dropdown';
 import './multi-select';
 import './multi-select-item';
+import storyDocs from './multi-select-story.mdx';
 
 const types = {
   [`Regular (${DROPDOWN_TYPE.REGULAR})`]: DROPDOWN_TYPE.REGULAR,
@@ -75,6 +76,7 @@ defaultStory.story = {
 export default {
   title: 'Multi select',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-multi-select': () => ({
         clearSelectionLabel: text('a11y label for the icon to clear selection (clear-selection-label)', ''),

--- a/src/components/notification/README.md
+++ b/src/components/notification/README.md
@@ -1,3 +1,0 @@
-# Notification
-
-Notifications are messages that communicate information to the user.

--- a/src/components/notification/notification-story.mdx
+++ b/src/components/notification/notification-story.mdx
@@ -1,0 +1,21 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Notification
+
+Notifications are messages that communicate information to the user.
+
+## Inline notification
+
+Inline notifications show up in task flows, to notify users of the status of an action. They usually appear at the top of the primary content area.
+
+<Preview withToolbar>
+  <Story id="notifications--inline" height="160px" />
+</Preview>
+
+## Toast notification
+
+Toasts are a non-modal, time-based window elements used to display short messages; they usually appear at the bottom of the screen and disappear after a few seconds.
+
+<Preview withToolbar>
+  <Story id="notifications--toast" height="240px" />
+</Preview>

--- a/src/components/notification/notification-story.ts
+++ b/src/components/notification/notification-story.ts
@@ -13,6 +13,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { NOTIFICATION_KIND } from './inline-notification';
 import './toast-notification';
+import storyDocs from './notification-story.mdx';
 
 const kinds = {
   [`Success (${NOTIFICATION_KIND.SUCCESS})`]: NOTIFICATION_KIND.SUCCESS,
@@ -51,12 +52,6 @@ export const inline = ({ parameters }) => {
 
 inline.story = {
   parameters: {
-    docs: {
-      storyDescription: `
-Inline notifications show up in task flows, to notify users of the status of an action.
-They usually appear at the top of the primary content area.
-    `,
-    },
     knobs: {
       'bx-inline-notification': () => ({
         kind: select('The notification kind (kind)', kinds, NOTIFICATION_KIND.INFO),
@@ -114,12 +109,6 @@ export const toast = ({ parameters }) => {
 
 toast.story = {
   parameters: {
-    docs: {
-      storyDescription: `
-Toasts are non-modal, time-based window elements used to display short messages;
-they usually appear at the bottom of the screen and disappear after a few seconds.
-    `,
-    },
     knobs: {
       'bx-toast-notification': () => ({
         ...inline.story.parameters.knobs['bx-inline-notification'](),
@@ -131,4 +120,7 @@ they usually appear at the bottom of the screen and disappear after a few second
 
 export default {
   title: 'Notifications',
+  parameters: {
+    docs: storyDocs.parameters.docs,
+  },
 };

--- a/src/components/number-input/number-input-story.mdx
+++ b/src/components/number-input/number-input-story.mdx
@@ -1,0 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Number input
+
+Number inputs are similar to text inputs, but contain controls used to increase or decrease an incremental value.
+
+<Preview withToolbar>
+  <Story id="number-input--default-story" height="160px" />
+</Preview>

--- a/src/components/number-input/number-input-story.ts
+++ b/src/components/number-input/number-input-story.ts
@@ -12,6 +12,7 @@ import * as knobs from '@storybook/addon-knobs';
 import './number-input';
 import '../form/form-item';
 import createProps from './stories/helpers';
+import storyDocs from './number-input-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, value, placeholder, invalid, mobile, min, max, step, light, onInput } = parameters?.props?.[
@@ -98,6 +99,7 @@ withoutFormItemWrapper.story = {
 export default {
   title: 'Number Input',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-number-input': () => createProps(knobs),
     },

--- a/src/components/overflow-menu/overflow-menu-story.mdx
+++ b/src/components/overflow-menu/overflow-menu-story.mdx
@@ -1,4 +1,10 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Overflow menu
 
 Overflow menu is used when additional options are available to the user and there is a space constraint.
 Create overflow menu item components for each option on the menu.
+
+<Preview withToolbar>
+  <Story id="overflow-menu--default-story" height="240px" />
+</Preview>

--- a/src/components/overflow-menu/overflow-menu-story.ts
+++ b/src/components/overflow-menu/overflow-menu-story.ts
@@ -13,6 +13,7 @@ import { FLOATING_MENU_DIRECTION } from '../floating-menu/floating-menu';
 import './overflow-menu';
 import './overflow-menu-body';
 import './overflow-menu-item';
+import storyDocs from './overflow-menu-story.mdx';
 
 const directions = {
   [`Bottom (${FLOATING_MENU_DIRECTION.BOTTOM})`]: FLOATING_MENU_DIRECTION.BOTTOM,
@@ -41,6 +42,7 @@ defaultStory.story = {
 export default {
   title: 'Overflow menu',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-overflow-menu': () => ({
         open: boolean('Open (open)', false),

--- a/src/components/pagination/pageination-story.ts
+++ b/src/components/pagination/pageination-story.ts
@@ -14,6 +14,7 @@ import ifNonNull from '../../globals/directives/if-non-null';
 import './pagination';
 import './page-sizes-select';
 import './pages-select';
+import storyDocs from './pagination-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { atLastPage, pageSize, start, total, onChangedCurrent, onChangedPageSizesSelect } = parameters?.props?.['bx-pagination'];
@@ -47,6 +48,7 @@ defaultStory.story = {
 export default {
   title: 'Pagination',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-pagination': () => ({
         atLastPage: boolean('Explicitly state that the user is at the last page (at-last-apge)', false),

--- a/src/components/pagination/pagination-story.mdx
+++ b/src/components/pagination/pagination-story.mdx
@@ -1,4 +1,10 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Pagination
 
 The pagination component is used to switch through multiple pages of items, when only a maxium number of items can be displayed per page.
 Can be used in combination with other components like data table.
+
+<Preview withToolbar>
+  <Story id="pagination--default-story" height="160px" />
+</Preview>

--- a/src/components/progress-indicator/progress-indicator-story.mdx
+++ b/src/components/progress-indicator/progress-indicator-story.mdx
@@ -1,0 +1,11 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Progress indicator
+
+Progress indicator is a visual representation of a users progress through a set of steps. They guide the user through a number of steps in order to complete a specified process.
+
+Use progress indicators to keep the user on track when completing a specific task. By dividing the end goal into smaller, sub-tasks, it increases the percentage of completeness as each task is completed.
+
+<Preview withToolbar>
+  <Story id="progress-indicator--default-story" height="160px" />
+</Preview>

--- a/src/components/progress-indicator/progress-indicator-story.ts
+++ b/src/components/progress-indicator/progress-indicator-story.ts
@@ -12,6 +12,7 @@ import { html } from 'lit-element';
 import { boolean, text } from '@storybook/addon-knobs';
 import './progress-indicator';
 import './progress-step';
+import storyDocs from './progress-indicator-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { vertical } = parameters?.props?.['bx-progress-indicator'];
@@ -58,6 +59,7 @@ defaultStory.story = {
 export default {
   title: 'Progress indicator',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-progress-indicator': () => ({
         vertical: boolean('Vertical (vertical)', false),

--- a/src/components/radio-button/radio-button-story.mdx
+++ b/src/components/radio-button/radio-button-story.mdx
@@ -1,0 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Radio button
+
+Radio buttons are used when a list of two or more options are mutually exclusive, meaning the user must select only one option.
+
+<Preview withToolbar>
+  <Story id="radio-button--default-story" height="160px" />
+</Preview>

--- a/src/components/radio-button/radio-button-story.ts
+++ b/src/components/radio-button/radio-button-story.ts
@@ -13,6 +13,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { RADIO_BUTTON_ORIENTATION } from './radio-button-group';
 import { RADIO_BUTTON_LABEL_POSITION } from './radio-button';
+import storyDocs from './radio-button-story.mdx';
 
 const orientations = {
   [`Horizontal (${RADIO_BUTTON_ORIENTATION.HORIZONTAL})`]: RADIO_BUTTON_ORIENTATION.HORIZONTAL,
@@ -50,6 +51,7 @@ defaultStory.story = {
 export default {
   title: 'Radio button',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-radio-button-group': () => ({
         disabled: boolean('Disabled (disabled)', false),

--- a/src/components/search/search-story.mdx
+++ b/src/components/search/search-story.mdx
@@ -1,4 +1,10 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Search
 
 Search enables users to specify a word or a phrase to find particular relevant pieces of content without the use of navigation.
 Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
+
+<Preview withToolbar>
+  <Story id="search--default-story" height="160px" />
+</Preview>

--- a/src/components/search/search-story.ts
+++ b/src/components/search/search-story.ts
@@ -12,6 +12,7 @@ import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { SEARCH_SIZE } from './search';
+import storyDocs from './search-story.mdx';
 
 const sizes = {
   [`Small size (${SEARCH_SIZE.SMALL})`]: SEARCH_SIZE.SMALL,
@@ -54,6 +55,7 @@ defaultStory.story = {
 export default {
   title: 'Search',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-search': () => ({
         closeButtonAssistiveText: text('The label text for the close button (close-button-assistive-text)', 'Clear search input'),

--- a/src/components/slider/slider-story.mdx
+++ b/src/components/slider/slider-story.mdx
@@ -1,3 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Slider
 
 Sliders provide a visual indication of adjustable content, where the user can move the handle along a horizontal track to increase or decrease the value.
+
+<Preview withToolbar>
+  <Story id="slider--default-story" height="160px" />
+</Preview>

--- a/src/components/slider/slider-story.ts
+++ b/src/components/slider/slider-story.ts
@@ -13,6 +13,7 @@ import { boolean, number, text } from '@storybook/addon-knobs';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './slider';
 import './slider-input';
+import storyDocs from './slider-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, labelText, max, min, name, step, value, onAfterChange } = parameters?.props?.['bx-slider'];
@@ -59,6 +60,7 @@ withInputBox.story = {
 export default {
   title: 'Slider',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-slider': () => ({
         disabled: boolean('Disabled (disabled)', false),

--- a/src/components/structured-list/README.md
+++ b/src/components/structured-list/README.md
@@ -1,3 +1,0 @@
-# Structured list
-
-Structured Lists group content that is similar or related, such as terms or definitions.

--- a/src/components/structured-list/structured-list-story.mdx
+++ b/src/components/structured-list/structured-list-story.mdx
@@ -1,0 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Structured list
+
+Structured Lists group content that is similar or related, such as terms or definitions.
+
+<Preview withToolbar>
+  <Story id="structured-list--default-story" />
+</Preview>

--- a/src/components/structured-list/structured-list-story.ts
+++ b/src/components/structured-list/structured-list-story.ts
@@ -15,6 +15,7 @@ import './structured-list-head';
 import './structured-list-header-row';
 import './structured-list-body';
 import './structured-list-row';
+import storyDocs from './structured-list-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { hasSelection } = parameters?.props?.['bx-structured-list'];
@@ -68,6 +69,7 @@ defaultStory.story = {
 export default {
   title: 'Structured list',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-structured-list': () => ({
         hasSelection: boolean('Supports selection feature (has-selection)', false),

--- a/src/components/tabs/tabs-story.mdx
+++ b/src/components/tabs/tabs-story.mdx
@@ -1,0 +1,9 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Tabs
+
+Tabs are used to quickly navigate between views within the same context.
+
+<Preview withToolbar>
+  <Story id="tabs--default-story" height="320px" />
+</Preview>

--- a/src/components/tabs/tabs-story.ts
+++ b/src/components/tabs/tabs-story.ts
@@ -13,6 +13,7 @@ import { boolean, text } from '@storybook/addon-knobs';
 import './tabs';
 import './tab';
 import styles from './tabs-story.scss';
+import storyDocs from './tabs-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, triggerContent, value, disableSelection } = parameters?.props?.['bx-tabs'];
@@ -87,6 +88,7 @@ defaultStory.story = {
 export default {
   title: 'Tabs',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-tabs': () => ({
         disabled: boolean('Disabled (disabled)', false),

--- a/src/components/tag/tag-story.mdx
+++ b/src/components/tag/tag-story.mdx
@@ -1,0 +1,19 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Tag
+
+Tags are used for items that need to be labeled, categorized, or organized using keywords that describe them.
+
+Multiple or single tags can be used to categorize items.
+
+Use tags when content is mapped to multiple categories, and the user needs a way to differentiate between them.
+
+<Preview withToolbar>
+  <Story id="tag--default-story" height="160px" />
+</Preview>
+
+## Filter tag
+
+<Preview withToolbar>
+  <Story id="tag--filter" height="160px" />
+</Preview>

--- a/src/components/tag/tag-story.ts
+++ b/src/components/tag/tag-story.ts
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
 import { TAG_TYPE } from './tag';
 import './filter-tag';
+import storyDocs from './tag-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { type, title, disabled } = parameters?.props?.['bx-tag'];
@@ -66,5 +67,8 @@ filter.story = {
 };
 
 export default {
+  parameters: {
+    docs: storyDocs.parameters.docs,
+  },
   title: 'Tag',
 };

--- a/src/components/textarea/textarea-story.mdx
+++ b/src/components/textarea/textarea-story.mdx
@@ -1,0 +1,11 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Textarea
+
+Text inputs enable the user to interact with and input content and data. This component can be used for long and short form entries.
+
+Textarea is a multi-line variant of text input.
+
+<Preview withToolbar>
+  <Story id="textarea--default-story" height="240px" />
+</Preview>

--- a/src/components/textarea/textarea-story.ts
+++ b/src/components/textarea/textarea-story.ts
@@ -12,6 +12,7 @@ import * as knobs from '@storybook/addon-knobs';
 import './textarea';
 import '../form/form-item';
 import createProps from './stories/helpers';
+import storyDocs from './textarea-story.mdx';
 
 export const defaultStory = () => {
   const { disabled, value, placeholder, invalid, onInput, rows, cols } = createProps(knobs);
@@ -86,6 +87,7 @@ withoutFormItemWrapper.story = {
 export default {
   title: 'Textarea',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-textarea': () => createProps(knobs),
     },

--- a/src/components/tile/README.md
+++ b/src/components/tile/README.md
@@ -1,9 +1,0 @@
-# Tile
-
-Tiles are a highly flexible component for displaying a wide variety of content, including informational, getting started, how-to, next steps, and more.
-
-Carbon ships a basic tile structure that responds to the grid.
-Tiles have no pre-set styles for the content within them. You can customize tiles to fit your specific use case.
-
-When using a call-to-action (CTA) within a tile, use a secondary button.
-Primary buttons should be reserved for the most important action a user can take on the page.

--- a/src/components/tile/tile-story.mdx
+++ b/src/components/tile/tile-story.mdx
@@ -1,0 +1,58 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Tile
+
+Tiles are a highly flexible component for displaying a wide variety of content, including informational, getting started, how-to, next steps, and more.
+
+Carbon ships a basic tile structure that responds to the grid.
+Tiles have no pre-set styles for the content within them. You can customize tiles to fit your specific use case.
+
+When using a call-to-action (CTA) within a tile, use a secondary button.
+Primary buttons should be reserved for the most important action a user can take on the page.
+
+# Read-only tile
+
+Read-only tiles are used to display information to the user, such as features or services offered.
+Read-only tiles are often seen on marketing pages to promote content.
+These tiles can have internal calls-to-action (CTAs), such as a button or a link.
+
+<Preview withToolbar>
+  <Story id="tile--default-story" height="160px" />
+</Preview>
+
+# Clickable tile
+
+Clickable tiles can be used as navigational items, where the entire tile is a clickable state,
+which redirects the user to a new page.
+Clickable tiles cannot contain separate internal CTAs.
+
+<Preview withToolbar>
+  <Story id="tile--clickable" height="160px" />
+</Preview>
+
+# Selectable tile
+
+Selectable tiles work like a radio button, where the entire tile is a click target.
+Selectable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
+Selectable tiles work well for presenting options to a user in a structured manner, such as a set of pricing plans.
+
+<Preview withToolbar>
+  <Story id="tile--single-selectable" height="320px" />
+</Preview>
+
+# Multi-selectable tile
+
+<Preview withToolbar>
+  <Story id="tile--multi-selectable" height="160px" />
+</Preview>
+
+# Expandable tile
+
+Expandable tiles are helpful for hiding/showing larger amounts of content to a user.
+They can only be stacked in a single column, and cannot live in a row or horizontal grid.
+When expanded, tiles push content down the page.
+Expandable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
+
+<Preview withToolbar>
+  <Story id="tile--expandable" />
+</Preview>

--- a/src/components/tile/tile-story.ts
+++ b/src/components/tile/tile-story.ts
@@ -16,6 +16,7 @@ import './clickable-tile';
 import './radio-tile';
 import './selectable-tile';
 import './expandable-tile';
+import storyDocs from './tile-story.mdx';
 
 export const defaultStory = () => html`
   <bx-tile>Default tile</bx-tile>
@@ -23,15 +24,6 @@ export const defaultStory = () => html`
 
 defaultStory.story = {
   name: 'Default',
-  parameters: {
-    docs: {
-      storyDescription: `
-Read-only tiles are used to display information to the user, such as features or services offered.
-Read-only tiles are often seen on marketing pages to promote content.
-These tiles can have internal calls-to-action (CTAs), such as a button or a link.
-    `,
-    },
-  },
 };
 
 export const clickable = ({ parameters }) => {
@@ -43,13 +35,6 @@ export const clickable = ({ parameters }) => {
 
 clickable.story = {
   parameters: {
-    docs: {
-      storyDescription: `
-Clickable tiles can be used as navigational items, where the entire tile is a clickable state,
-which redirects the user to a new page.
-Clickable tiles cannot contain separate internal CTAs.
-    `,
-    },
     knobs: {
       'bx-clickable-tile': () => ({
         href: text('Href for clickable UI (href)', ''),
@@ -94,13 +79,6 @@ export const singleSelectable = ({ parameters }) => {
 singleSelectable.story = {
   name: 'Single-selectable',
   parameters: {
-    docs: {
-      storyDescription: `
-Selectable tiles work like a radio button, where the entire tile is a click target.
-Selectable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
-Selectable tiles work well for presenting options to a user in a structured manner, such as a set of pricing plans.
-    `,
-    },
     knobs: {
       'bx-radio-tile': () => ({
         checkmarkLabel: text('Label text for the checkmark icon (checkmark-label)', ''),
@@ -166,14 +144,6 @@ export const expandable = ({ parameters }) => {
 
 expandable.story = {
   parameters: {
-    docs: {
-      storyDescription: `
-Expandable tiles are helpful for hiding/showing larger amounts of content to a user.
-They can only be stacked in a single column, and cannot live in a row or horizontal grid.
-When expanded, tiles push content down the page.
-Expandable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
-    `,
-    },
     knobs: {
       'bx-expandable-tile': () => ({
         expanded: boolean('Expanded (expanded)', false),
@@ -195,4 +165,7 @@ export default {
         <div>${story()}</div>
       `,
   ],
+  parameters: {
+    docs: storyDocs.parameters.docs,
+  },
 };

--- a/src/components/toggle/toggle-story.mdx
+++ b/src/components/toggle/toggle-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # Toggle
 
 Toggle is a control that is used to quickly switch between two possible states.
@@ -5,3 +7,7 @@ Toggles are only used for these binary actions that occur immediately after the 
 They are commonly used for “on/off” switches.
 
 Use `small` property/attribute to make it more compact in size, so they can be used in use cases such as data tables.
+
+<Preview withToolbar>
+  <Story id="toggle--default-story" height="160px" />
+</Preview>

--- a/src/components/toggle/toggle-story.ts
+++ b/src/components/toggle/toggle-story.ts
@@ -12,6 +12,7 @@ import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import './toggle';
+import storyDocs from './toggle-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onInput } = parameters?.props?.[
@@ -39,6 +40,7 @@ defaultStory.story = {
 export default {
   title: 'Toggle',
   parameters: {
+    docs: storyDocs.parameters.docs,
     knobs: {
       'bx-toggle': () => ({
         checked: boolean('Checked (checked)', false),

--- a/src/components/tooltip/README.md
+++ b/src/components/tooltip/README.md
@@ -1,5 +1,0 @@
-# Tooltip
-
-Tooltips provide additional information upon hover or focus.
-The information should be contextual, useful, and nonessential information.
-Keep tooltips short.

--- a/src/components/tooltip/tooltip-story.mdx
+++ b/src/components/tooltip/tooltip-story.mdx
@@ -1,0 +1,40 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
+# Tooltip
+
+Tooltips provide additional information upon hover or focus.
+The information should be contextual, useful, and nonessential information.
+Keep tooltips short.
+
+## Interactive tooltip
+
+Interactive tooltips may contain rich text and other interactive elements like buttons or links. In general, hiding interactive content in a tooltip is discouraged. Interactive tooltips are best used for onboarding experiences and product tours.
+
+* If a user may need to visit an external resource, like while using a form, include a link in your interactive tooltip
+* Don’t use without a label. Consider the context a user needs before clicking a link
+
+<Preview withToolbar>
+  <Story id="tooltip--default-story" height="320px" />
+</Preview>
+
+## Definition tooltip
+
+The definition tooltip provides additional help or defines an item or term. It may be used on the label of a UI element, or on a word embedded in a paragraph.
+
+* Should contain brief, read-only text
+* Use on proper nouns, technical terms, or acronyms with two letters or more
+* Do not use a definition tooltip on words with fewer than two letters
+
+<Preview withToolbar>
+  <Story id="tooltip--definition" height="200px" />
+</Preview>
+
+## Icon tooltip
+
+An icon tooltip is used to clarify the action or name of an interactive icon button.
+
+* The tooltip content should only contain one or two words.
+
+<Preview withToolbar>
+  <Story id="tooltip--icon" height="160px" />
+</Preview>

--- a/src/components/tooltip/tooltip-story.ts
+++ b/src/components/tooltip/tooltip-story.ts
@@ -18,6 +18,7 @@ import './tooltip-footer';
 import { TOOLTIP_ALIGNMENT, TOOLTIP_DIRECTION } from './tooltip-definition';
 import './tooltip-icon';
 import styles from './tooltip-story.scss';
+import storyDocs from './tooltip-story.mdx';
 
 const tooltipBodyDirections = {
   [`Bottom (${FLOATING_MENU_DIRECTION.BOTTOM})`]: FLOATING_MENU_DIRECTION.BOTTOM,
@@ -61,12 +62,6 @@ export const defaultStory = ({ parameters }) => {
 defaultStory.story = {
   name: 'Default',
   parameters: {
-    docs: {
-      storyDescription: `
-Interactive tooltip should be used if there are actions a user can take in the tooltip (e.g. a link or a button).
-For more regular use cases, e.g. giving the user more text information about something, use definition tooltip or icon tooltip.
-    `,
-    },
     knobs: {
       'bx-tooltip': () => ({
         open: boolean('Open (open)', false),
@@ -124,4 +119,7 @@ icon.story = {
 
 export default {
   title: 'Tooltip',
+  parameters: {
+    docs: storyDocs.parameters.docs,
+  },
 };

--- a/src/components/ui-shell/ui-shell-story.mdx
+++ b/src/components/ui-shell/ui-shell-story.mdx
@@ -1,3 +1,5 @@
+import { Preview, Story } from '@storybook/addon-docs/blocks';
+
 # UI Shell
 
 UI Shell in Carbon Design System consists of several component groups.
@@ -13,6 +15,10 @@ Side nav in UI Shell consists of the following components:
 | `<side-nav-link>`      | Nav item, working as a link                      |
 | `<side-nav-menu>`      | Nav item, working as a container of sub-items    |
 | `<side-nav-menu-item>` | Nav item, working as as a sub-item and as a link |
+
+<Preview withToolbar>
+  <Story id="ui-shell--side-nav" />
+</Preview>
 
 ### Expanding/collapsing
 
@@ -37,3 +43,7 @@ Header nav in UI Shell consists of the following components:
 | `<bx-header-menu-item>`   | Nav item, working as as a sub-item            |
 | `<bx-header-menu-button>` | The expando button for side nav               |
 | `<bx-header-name>`        | The UI to show product name                   |
+
+<Preview withToolbar>
+  <Story id="ui-shell--header" />
+</Preview>

--- a/src/components/ui-shell/ui-shell-story.ts
+++ b/src/components/ui-shell/ui-shell-story.ts
@@ -23,6 +23,7 @@ import './header-menu';
 import './header-menu-item';
 import './header-menu-button';
 import './header-name';
+import storyDocs from './ui-shell-story.mdx';
 
 const StoryContent = () => html`
   <style type="text/css">
@@ -231,4 +232,7 @@ header.story = {
 
 export default {
   title: 'UI Shell',
+  parameters: {
+    docs: storyDocs.parameters.docs,
+  },
 };

--- a/src/typings/resources.d.ts
+++ b/src/typings/resources.d.ts
@@ -8,3 +8,15 @@
  */
 
 declare module '*.scss';
+
+declare module '*.mdx' {
+  let MDXComponent: (props: any) => JSX.Element;
+  export default {
+    parameters: {
+      docs: {
+        container: JSX.Element,
+        page: MDXComponent,
+      },
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,7 +2066,7 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mdx-js/loader@^1.1.0":
+"@mdx-js/loader@^1.1.0", "@mdx-js/loader@^1.5.0":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.5.1.tgz#d66a00b757345540c1530f750459de39b0fb7b96"
   integrity sha512-g7BGfMdJY5ZnDjUEdGz4cfMs9Je0hGZAItGZ1rCBHtJt6SCKMy5N8qml6FJYo3pxNxWkbOCQbX85F6qsetwlAA==


### PR DESCRIPTION
This change merges DocsPage feature of Storybook with the README contents, by using MDX feature in Storybook. This allows us to create documentation pages in more flexible manner, paving cowpath toward `web-component-analyzer` integration.

Fixes #226.