### PR TITLE
chore(components): track change in properties

### DIFF
--- a/src/components/data-table/table.ts
+++ b/src/components/data-table/table.ts
@@ -63,14 +63,13 @@ class BXTable extends LitElement {
     super.connectedCallback();
   }
 
-  attributeChangedCallback(name, old, current) {
-    if (name === 'size') {
+  updated(changedProperties) {
+    if (changedProperties.has('size')) {
       // Propagate `size` attribute to descendants until `:host-context()` gets supported in all major browsers
       forEach(this.querySelectorAll((this.constructor as typeof BXTable).selectorRowsWithHeader), elem => {
-        elem.setAttribute('size', current);
+        elem.setAttribute('size', this.size);
       });
     }
-    super.attributeChangedCallback(name, old, current);
   }
 
   render() {

--- a/src/components/floating-menu/floating-menu.ts
+++ b/src/components/floating-menu/floating-menu.ts
@@ -276,35 +276,33 @@ abstract class BXFloatingMenu extends LitElement {
     }
   }
 
-  attributeChangedCallback(name, old, current) {
-    if (old !== current) {
-      const { container, open } = this;
-      if ((name === 'open' || name === 'direction' || name === 'alignment') && open) {
-        if (!this.parent) {
-          this.parent = this.parentElement as BXFloatingMenuTrigger;
-          container.appendChild(this);
-        }
-        const { direction, start, top } = this.position;
-        this.style[direction !== FLOATING_MENU_POSITION_DIRECTION.RTL ? 'left' : 'right'] = `${start}px`;
-        this.style.top = `${top}px`;
+  updated(changedProperties) {
+    const { container, open, parent } = this;
+    if ((changedProperties.has('alignment') || changedProperties.has('direction') || changedProperties.has('open')) && open) {
+      if (!parent) {
+        this.parent = this.parentElement as BXFloatingMenuTrigger;
+        container.appendChild(this);
       }
-      if (name === 'open') {
-        if (this._hObserveResizeContainer) {
-          this._hObserveResizeContainer = this._hObserveResizeContainer.release();
-        }
-        if (this._hObserveResizeParent) {
-          this._hObserveResizeParent = this._hObserveResizeParent.release();
-        }
-        if (open) {
-          const { parentElement } = this.parent ?? {};
-          this._hObserveResizeContainer = observeResize(this._resizeObserver, container);
-          if (parentElement) {
-            this._hObserveResizeParent = observeResize(this._resizeObserver, parentElement);
-          }
+      // Note: `this.position` cannot be referenced until `this.parent` is set
+      const { direction, start, top } = this.position;
+      this.style[direction !== FLOATING_MENU_POSITION_DIRECTION.RTL ? 'left' : 'right'] = `${start}px`;
+      this.style.top = `${top}px`;
+    }
+    if (changedProperties.has('open')) {
+      if (this._hObserveResizeContainer) {
+        this._hObserveResizeContainer = this._hObserveResizeContainer.release();
+      }
+      if (this._hObserveResizeParent) {
+        this._hObserveResizeParent = this._hObserveResizeParent.release();
+      }
+      if (open) {
+        const { parentElement } = this.parent ?? {};
+        this._hObserveResizeContainer = observeResize(this._resizeObserver, container);
+        if (parentElement) {
+          this._hObserveResizeParent = observeResize(this._resizeObserver, parentElement);
         }
       }
     }
-    super.attributeChangedCallback(name, old, current);
   }
 
   /**

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -174,29 +174,32 @@ class BXModal extends HostListenerMixin(LitElement) {
     super.connectedCallback();
   }
 
-  attributeChangedCallback(name, old, current) {
-    super.attributeChangedCallback(name, old, current);
-    if (name === 'open') {
-      if (old == null && current != null) {
+  async updated(changedProperties) {
+    if (changedProperties.has('open')) {
+      if (this.open) {
         this._launcher = this.ownerDocument!.activeElement;
         const primaryFocusNode = this.querySelector((this.constructor as typeof BXModal).selectorPrimaryFocus);
         if (primaryFocusNode) {
+          // For cases where a `carbon-custom-elements` component (e.g. `<bx-btn>`) being `primaryFocusNode`,
+          // where its first update/render cycle that makes it focusable happens after `<bx-modal>`'s first update/render cycle
+          await 0;
           (primaryFocusNode as HTMLElement).focus();
         } else {
           const tabbable = find(this.querySelectorAll((this.constructor as typeof BXModal).selectorTabbable), elem =>
             Boolean((elem as HTMLElement).offsetParent)
           );
           if (tabbable) {
+            // For cases where a `carbon-custom-elements` component (e.g. `<bx-btn>`) being `tabbable`,
+            // where its first update/render cycle that makes it focusable happens after `<bx-modal>`'s first update/render cycle
+            await 0;
             (tabbable as HTMLElement).focus();
           } else {
             this.focus();
           }
         }
-      } else if (old != null && current == null) {
-        if (this._launcher && typeof (this._launcher as HTMLElement).focus === 'function') {
-          (this._launcher as HTMLElement).focus();
-          this._launcher = null;
-        }
+      } else if (this._launcher && typeof (this._launcher as HTMLElement).focus === 'function') {
+        (this._launcher as HTMLElement).focus();
+        this._launcher = null;
       }
     }
   }

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -81,9 +81,9 @@ class BXTooltip extends HostListenerMixin(LitElement) implements BXFloatingMenuT
     super.connectedCallback();
   }
 
-  attributeChangedCallback(name, old, current) {
-    if (old !== current) {
-      if (name === 'open' && !this._menuBody) {
+  updated(changedProperties) {
+    if (changedProperties.has('open')) {
+      if (!this._menuBody) {
         this._menuBody = find(this.childNodes, elem => (elem.constructor as typeof BXFloatingMenu).FLOATING_MENU);
       }
       if (this._menuBody) {
@@ -91,7 +91,6 @@ class BXTooltip extends HostListenerMixin(LitElement) implements BXFloatingMenuT
       }
       this.setAttribute('aria-expanded', String(Boolean(this.open)));
     }
-    super.attributeChangedCallback(name, old, current);
   }
 
   render() {

--- a/tests/spec/.eslintrc
+++ b/tests/spec/.eslintrc
@@ -11,7 +11,8 @@
     "it": true,
     "expect": true,
     "jasmine": true,
-    "spyOn": true
+    "spyOn": true,
+    "spyOnProperty": true
   },
   "rules": {
     "func-names": 0,

--- a/tests/spec/modal_spec.ts
+++ b/tests/spec/modal_spec.ts
@@ -33,7 +33,8 @@ describe('bx-modal', function() {
       const input = elem!.querySelector('input');
       spyOn(input!, 'focus');
       ((elem as unknown) as BXModal).open = true;
-      await Promise.resolve();
+      await Promise.resolve(); // For triggering the update cycle of `<bx-modal>`
+      await Promise.resolve(); // `update()` in `<bx-modal>` waits for child nodes' update cycles to run
       expect(input!.focus).not.toHaveBeenCalled();
     });
 
@@ -42,7 +43,8 @@ describe('bx-modal', function() {
       const input = elem!.querySelector('input');
       spyOn(input!, 'focus');
       ((elem as unknown) as BXModal).open = true;
-      await Promise.resolve();
+      await Promise.resolve(); // For triggering the update cycle of `<bx-modal>`
+      await Promise.resolve(); // `update()` in `<bx-modal>` waits for child nodes' update cycles to run
       expect(input!.focus).toHaveBeenCalled();
     });
 
@@ -53,7 +55,8 @@ describe('bx-modal', function() {
       spyOn(input!, 'focus');
       spyOn(button!, 'focus');
       ((elem as unknown) as BXModal).open = true;
-      await Promise.resolve();
+      await Promise.resolve(); // For triggering the update cycle of `<bx-modal>`
+      await Promise.resolve(); // `update()` in `<bx-modal>` waits for child nodes' update cycles to run
       expect(input!.focus).not.toHaveBeenCalled();
       expect(button!.focus).toHaveBeenCalled();
     });
@@ -65,7 +68,8 @@ describe('bx-modal', function() {
       spyOn(input!, 'focus');
       spyOn(button as HTMLButtonElement, 'focus');
       ((elem as unknown) as BXModal).open = true;
-      await Promise.resolve();
+      await Promise.resolve(); // For triggering the update cycle of `<bx-modal>`
+      await Promise.resolve(); // `update()` in `<bx-modal>` waits for child nodes' update cycles to run
       expect(input!.focus).not.toHaveBeenCalled();
       expect((button as HTMLButtonElement).focus).toHaveBeenCalled();
     });
@@ -91,6 +95,20 @@ describe('bx-modal', function() {
       await Promise.resolve();
       expect(spyBeforeClosed).toHaveBeenCalled();
       expect(spyAfterClosed).toHaveBeenCalled();
+    });
+
+    it('Should focus on the launcher button upon hiding', async function() {
+      elem = document.body.appendChild(document.createElement('div'));
+      const button = elem.appendChild(document.createElement('button'));
+      button.focus();
+      spyOn(button, 'focus');
+      const modal = elem.appendChild(document.createElement('bx-modal'));
+      await Promise.resolve(); // Wait for initial render
+      (modal as BXModal).open = true;
+      await Promise.resolve();
+      (modal as BXModal).open = false;
+      await Promise.resolve();
+      expect(button.focus).toHaveBeenCalled();
     });
 
     it('Should support preventing modal from being closed upon user gesture', async function() {

--- a/tests/spec/tooltip_spec.ts
+++ b/tests/spec/tooltip_spec.ts
@@ -11,6 +11,7 @@ import { html, render, TemplateResult } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import Filter16 from '@carbon/icons/lib/filter/16';
 
+import ResizeObserver from 'resize-observer-polyfill';
 // Just importing the default export does not seem to run `customElements.define()`
 /* eslint-disable import/no-duplicates */
 import '../../src/components/tooltip/tooltip';
@@ -26,9 +27,12 @@ const bodyTemplate = () => html`
 `;
 const contentTemplate = ({ hasBody = true }: { hasBody?: boolean } = {}) => html`
   <div data-floating-menu-container style="position:relative">
-    <bx-tooltip>
-      ${!hasBody ? undefined : bodyTemplate()}
-    </bx-tooltip>
+    <!-- <div> for resize testing, distinguishing the parent node of <bx-tooltip> vs. the floating menu container -->
+    <div>
+      <bx-tooltip>
+        ${!hasBody ? undefined : bodyTemplate()}
+      </bx-tooltip>
+    </div>
   </div>
 `;
 const template = ({ hasContent = true, hasBody = true }: { hasContent?: boolean; hasBody?: boolean } = {}) =>
@@ -117,11 +121,56 @@ describe('bx-tooltip', function() {
       await Promise.resolve();
       expect(trigger!.open).toBe(true);
       expect(body!.open).toBe(true);
+      expect(trigger?.getAttribute('aria-expanded')).toBe('true');
 
       trigger!.shadowRoot!.firstElementChild!.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
       await Promise.resolve();
       expect(trigger!.open).toBe(false);
       expect(body!.open).toBe(false);
+      expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('Should start observing element resizes when tooltip gets open', async function() {
+      spyOn(ResizeObserver.prototype, 'observe');
+      spyOn(ResizeObserver.prototype, 'unobserve');
+      trigger!.shadowRoot!.firstElementChild!.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
+      await Promise.resolve(); // Calls `update()` of `<bx-tooltip>`
+      await Promise.resolve(); // Calls `update()` of `<bx-tooltip-body>`
+      const floatingMenuContainer = document.body.querySelector('div[data-floating-menu-container]');
+      expect(ResizeObserver.prototype.observe).toHaveBeenCalledWith(floatingMenuContainer);
+      expect(ResizeObserver.prototype.observe).toHaveBeenCalledWith(trigger?.parentElement);
+      trigger!.shadowRoot!.firstElementChild!.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
+      await Promise.resolve(); // Calls `update()` of `<bx-tooltip>`
+      await Promise.resolve(); // Calls `update()` of `<bx-tooltip-body>`
+      expect(ResizeObserver.prototype.unobserve).toHaveBeenCalledWith(trigger?.parentElement);
+      expect(ResizeObserver.prototype.unobserve).toHaveBeenCalledWith(floatingMenuContainer);
+    });
+  });
+
+  describe('Placing', function() {
+    let trigger: BXTooltip | null;
+    let body: BXTooltipBody | null;
+
+    beforeEach(async function() {
+      render(template(), document.body);
+      await Promise.resolve();
+      trigger = document.body.querySelector('bx-tooltip');
+      body = document.body.querySelector('bx-tooltip-body');
+    });
+
+    it('Should place and position', async function() {
+      // TODO: Figure out why `spyOnProperty()` with a property name that actually exists causes a TS error
+      // @ts-ignore
+      spyOnProperty(body, 'position').and.returnValue({
+        start: 1,
+        top: 2,
+      });
+      trigger!.shadowRoot!.firstElementChild!.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
+      await Promise.resolve(); // Calls `update()` of `<bx-tooltip>`
+      await Promise.resolve(); // Calls `update()` of `<bx-tooltip-body>`
+      expect(body!.parentElement).toBe(document.body.querySelector('div[data-floating-menu-container]') as HTMLElement);
+      expect(body!.style.left).toBe('1px');
+      expect(body!.style.top).toBe('2px');
     });
   });
 


### PR DESCRIPTION
Instead of change in attributes. Given we have several properties that are not reflected back to attributes and tracking changes only in attributes loses track of those properties.