### PR TITLE
chore(dependencies): reduce peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ To install `carbon-custom-elements` in your project, you will need to run the
 following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S carbon-custom-elements carbon-components lit-html lit-element lodash-es resize-observer-polyfill @babel/runtime
+npm install -S carbon-custom-elements carbon-components lit-html lit-element
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add carbon-custom-elements carbon-components lit-html lit-element lodash-es resize-observer-polyfill @babel/runtime
+yarn add carbon-custom-elements carbon-components lit-html lit-element
 ```
 
 ### Basic usage

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
     "babel-plugin-transform-vue-jsx": "^4.0.0",
     "prettier": "^1.19.0"
   },
+  "dependencies": {
+    "@babel/runtime": "^7.8.0",
+    "lodash-es": "^4.17.0",
+    "resize-observer-polyfill": "^1.5.0"
+  },
   "devDependencies": {
     "@angular-devkit/core": "^8.0.0",
     "@angular/common": "^8.0.0",
@@ -166,7 +171,6 @@
     "lint-staged": "^8.1.0",
     "lit-element": "^2.2.0",
     "lit-html": "^1.1.0",
-    "lodash-es": "^4.17.0",
     "mini-css-extract-plugin": "^0.5.0",
     "mkdirp": "^0.5.0",
     "morgan": "^1.8.0",
@@ -183,7 +187,6 @@
     "react-dom": "^16.8.0",
     "replace-ext": "^1.0.0",
     "rtlcss": "^2.4.0",
-    "resize-observer-polyfill": "^1.5.0",
     "rxjs": "^6.4.0",
     "sass-loader": "^7.1.0",
     "strip-comments": "^1.0.0",
@@ -203,13 +206,10 @@
     "zone.js": "^0.8.0"
   },
   "peerDependencies": {
-    "@babel/runtime": "^7.8.0",
     "carbon-components": "~10.9.0",
     "flatpickr": "4.6.1",
     "lit-element": "^2.2.0",
-    "lit-html": "^1.1.0",
-    "lodash-es": "^4.17.0",
-    "resize-observer-polyfill": "^1.5.0"
+    "lit-html": "^1.1.0"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Moving some of `peerDependencies` to `dependencies` for misc dependencies. This reduces some workload when setting up an application using `carbon-custom-elements` library.

Fixes #224.