### PR TITLE
chore(components): rename eventAfterSomething

### DIFF
--- a/src/components/accordion/accordion-item.ts
+++ b/src/components/accordion/accordion-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,7 +35,7 @@ class BXAccordionItem extends FocusMixin(LitElement) {
     };
     if (this.dispatchEvent(new CustomEvent((this.constructor as typeof BXAccordionItem).eventBeforeToggle, init))) {
       this.open = open;
-      this.dispatchEvent(new CustomEvent((this.constructor as typeof BXAccordionItem).eventAfterToggle, init));
+      this.dispatchEvent(new CustomEvent((this.constructor as typeof BXAccordionItem).eventToggle, init));
     }
   }
 
@@ -122,7 +122,7 @@ class BXAccordionItem extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after this accordion item is toggled upon a user gesture.
    */
-  static get eventAfterToggle() {
+  static get eventToggle() {
     return `${prefix}-accordion-item-toggled`;
   }
 

--- a/src/components/accordion/accordion-story-angular.ts
+++ b/src/components/accordion/accordion-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ export const defaultStory = ({ parameters }) => ({
       </bx-accordion-item>
     </bx-accordion>
   `,
-  props: (({ disableToggle, onBeforeToggle, onAfterToggle, ...rest }) => ({
+  props: (({ disableToggle, onBeforeToggle, onToggle, ...rest }) => ({
     ...rest,
     handleBeforeToggle: (event: CustomEvent) => {
       onBeforeToggle(event);
@@ -46,7 +46,7 @@ export const defaultStory = ({ parameters }) => ({
         event.preventDefault();
       }
     },
-    handleToggle: onAfterToggle,
+    handleToggle: onToggle,
   }))(parameters?.props?.['bx-accordion']),
   moduleMetadata: {
     schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/src/components/accordion/accordion-story-react.tsx
+++ b/src/components/accordion/accordion-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import { defaultStory as baseDefaultStory } from './accordion-story';
 export { default } from './accordion-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { open, titleText, disableToggle, onBeforeToggle, onAfterToggle } = parameters?.props?.['bx-accordion'];
+  const { open, titleText, disableToggle, onBeforeToggle, onToggle } = parameters?.props?.['bx-accordion'];
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
     if (disableToggle) {
@@ -28,19 +28,19 @@ export const defaultStory = ({ parameters }) => {
   };
   return (
     <BXAccordion>
-      <BXAccordionItem open={open} titleText={titleText} onBeforeToggle={handleBeforeToggle} onAfterToggle={onAfterToggle}>
+      <BXAccordionItem open={open} titleText={titleText} onBeforeToggle={handleBeforeToggle} onToggle={onToggle}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
       </BXAccordionItem>
-      <BXAccordionItem open={open} titleText={titleText} onBeforeToggle={handleBeforeToggle} onAfterToggle={onAfterToggle}>
+      <BXAccordionItem open={open} titleText={titleText} onBeforeToggle={handleBeforeToggle} onToggle={onToggle}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
         </p>
       </BXAccordionItem>
-      <BXAccordionItem open={open} onBeforeToggle={handleBeforeToggle} onAfterToggle={onAfterToggle}>
+      <BXAccordionItem open={open} onBeforeToggle={handleBeforeToggle} onToggle={onToggle}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
           aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/src/components/accordion/accordion-story-vue.ts
+++ b/src/components/accordion/accordion-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -40,7 +40,7 @@ export const defaultStory = ({ parameters }) => ({
     </bx-accordion>
   `,
   ...createVueBindingsFromProps(
-    (({ disableToggle, onBeforeToggle, onAfterToggle, ...rest }) => ({
+    (({ disableToggle, onBeforeToggle, onToggle, ...rest }) => ({
       ...rest,
       handleBeforeToggle: (event: CustomEvent) => {
         onBeforeToggle(event);
@@ -48,7 +48,7 @@ export const defaultStory = ({ parameters }) => ({
           event.preventDefault();
         }
       },
-      handleToggle: onAfterToggle,
+      handleToggle: onToggle,
     }))(parameters?.props?.['bx-accordion'])
   ),
 });

--- a/src/components/accordion/accordion-story.ts
+++ b/src/components/accordion/accordion-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,8 +17,7 @@ import storyDocs from './accordion-story.mdx';
 const noop = () => {};
 
 export const defaultStory = ({ parameters }) => {
-  const { open, titleText, disableToggle, onBeforeToggle = noop, onAfterToggle = noop } =
-    parameters?.props?.['bx-accordion'] ?? {};
+  const { open, titleText, disableToggle, onBeforeToggle = noop, onToggle = noop } = parameters?.props?.['bx-accordion'] ?? {};
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
     if (disableToggle) {
@@ -26,7 +25,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return html`
-    <bx-accordion @bx-accordion-item-beingtoggled="${handleBeforeToggle}" @bx-accordion-item-toggled="${onAfterToggle}">
+    <bx-accordion @bx-accordion-item-beingtoggled="${handleBeforeToggle}" @bx-accordion-item-toggled="${onToggle}">
       <bx-accordion-item ?open="${open}" title-text=${titleText}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
@@ -69,7 +68,7 @@ export default {
           false
         ),
         onBeforeToggle: action('bx-accordion-item-beingtoggled'),
-        onAfterToggle: action('bx-accordion-item-toggled'),
+        onToggle: action('bx-accordion-item-toggled'),
       }),
     },
   },

--- a/src/components/checkbox/checkbox-story-angular.ts
+++ b/src/components/checkbox/checkbox-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,7 +21,7 @@ export const defaultStory = ({ parameters }) => ({
       [labelText]="labelText"
       [name]="name"
       [value]="value"
-      (bx-checkbox-changed)="onAfterChange($event)"
+      (bx-checkbox-changed)="onChange($event)"
     ></bx-checkbox>
   `,
   props: parameters?.props?.['bx-checkbox'],

--- a/src/components/checkbox/checkbox-story-react.tsx
+++ b/src/components/checkbox/checkbox-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,9 +17,7 @@ import { defaultStory as baseDefaultStory } from './checkbox-story';
 export { default } from './checkbox-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onAfterChange } = parameters?.props?.[
-    'bx-checkbox'
-  ];
+  const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onChange } = parameters?.props?.['bx-checkbox'];
   return (
     <BXCheckbox
       checked={checked}
@@ -29,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
       labelText={labelText}
       name={name || undefined}
       value={value || undefined}
-      onAfterChange={onAfterChange}
+      onChange={onChange}
     />
   );
 };

--- a/src/components/checkbox/checkbox-story-vue.ts
+++ b/src/components/checkbox/checkbox-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ export const defaultStory = ({ parameters }) => ({
       :label-text="labelText"
       :name="name"
       :value="value"
-      @bx-checkbox-changed="onAfterChange"
+      @bx-checkbox-changed="onChange"
     ></bx-checkbox>
   `,
   ...createVueBindingsFromProps(parameters?.props?.['bx-checkbox']),

--- a/src/components/checkbox/checkbox-story.ts
+++ b/src/components/checkbox/checkbox-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,7 +16,7 @@ import './checkbox';
 import storyDocs from './checkbox-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
-  const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onAfterChange } =
+  const { checked, disabled, hideLabel, indeterminate, labelText, name, value, onChange } =
     parameters?.props?.['bx-checkbox'] ?? {};
   return html`
     <bx-checkbox
@@ -27,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
       label-text="${ifNonNull(labelText)}"
       name="${ifNonNull(name)}"
       value="${ifNonNull(value)}"
-      @bx-checkbox-changed="${onAfterChange}"
+      @bx-checkbox-changed="${onChange}"
     ></bx-checkbox>
   `;
 };
@@ -51,7 +51,7 @@ export default {
         labelText: textNullable('Label text (label-text)', 'Checkbox'),
         name: textNullable('Name (name)', ''),
         value: textNullable('Value (value)', ''),
-        onAfterChange: action('bx-checkbox-changed'),
+        onChange: action('bx-checkbox-changed'),
       }),
     },
   },

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -32,9 +32,9 @@ class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
     const { checked, indeterminate } = this._checkboxNode;
     this.checked = checked;
     this.indeterminate = indeterminate;
-    const { eventAfterChange } = this.constructor as typeof BXCheckbox;
+    const { eventChange } = this.constructor as typeof BXCheckbox;
     this.dispatchEvent(
-      new CustomEvent(eventAfterChange, {
+      new CustomEvent(eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -124,7 +124,7 @@ class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
   /**
    * The name of the custom event fired after this changebox changes its checked state.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-checkbox-changed`;
   }
 

--- a/src/components/combo-box/combo-box-story-angular.ts
+++ b/src/components/combo-box/combo-box-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,7 +33,7 @@ export const defaultStory = ({ parameters }) => ({
       <bx-combo-box-item value="router">Option 5</bx-combo-box-item>
     </bx-combo-box>
   `,
-  props: (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => {
+  props: (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => {
     const handleBeforeSelect = (event: CustomEvent) => {
       onBeforeSelect(event);
       if (disableSelection) {
@@ -43,7 +43,7 @@ export const defaultStory = ({ parameters }) => ({
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-combo-box']),
 });

--- a/src/components/combo-box/combo-box-story-react.tsx
+++ b/src/components/combo-box/combo-box-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ export const defaultStory = ({ parameters }) => {
     triggerContent,
     disableSelection,
     onBeforeSelect,
-    onAfterSelect,
+    onSelect,
   } = parameters?.props?.['bx-combo-box'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -51,7 +51,7 @@ export const defaultStory = ({ parameters }) => {
       value={value}
       triggerContent={triggerContent}
       onBeforeSelect={handleBeforeSelected}
-      onAfterSelect={onAfterSelect}>
+      onSelect={onSelect}>
       <BXComboBoxItem value="all">Option 1</BXComboBoxItem>
       <BXComboBoxItem value="cloudFoundry">Option 2</BXComboBoxItem>
       <BXComboBoxItem value="staging">Option 3</BXComboBoxItem>

--- a/src/components/combo-box/combo-box-story-vue.ts
+++ b/src/components/combo-box/combo-box-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,7 +35,7 @@ export const defaultStory = ({ parameters }) => ({
     </bx-combo-box>
   `,
   ...createVueBindingsFromProps(
-    (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => {
+    (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => {
       const handleBeforeSelect = (event: CustomEvent) => {
         onBeforeSelect(event);
         if (disableSelection) {
@@ -45,7 +45,7 @@ export const defaultStory = ({ parameters }) => ({
       return {
         ...rest,
         handleBeforeSelect,
-        handleAfterSelect: onAfterSelect,
+        handleAfterSelect: onSelect,
       };
     })(parameters?.props?.['bx-combo-box'])
   ),

--- a/src/components/combo-box/combo-box-story.ts
+++ b/src/components/combo-box/combo-box-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
     validityMessage,
     disableSelection,
     onBeforeSelect,
-    onAfterSelect,
+    onSelect,
   } = parameters?.props?.['bx-combo-box'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     if (onBeforeSelect) {
@@ -49,7 +49,7 @@ export const defaultStory = ({ parameters }) => {
       value=${value}
       trigger-content=${triggerContent}
       @bx-combo-box-beingselected=${handleBeforeSelected}
-      @bx-combo-box-selected=${onAfterSelect}
+      @bx-combo-box-selected=${onSelect}
     >
       <bx-combo-box-item value="all">Option 1</bx-combo-box-item>
       <bx-combo-box-item value="cloudFoundry">Option 2</bx-combo-box-item>
@@ -86,7 +86,7 @@ export default {
           false
         ),
         onBeforeSelect: action('bx-combo-box-beingselected'),
-        onAfterSelect: action('bx-combo-box-selected'),
+        onSelect: action('bx-combo-box-selected'),
       }),
     },
   },

--- a/src/components/combo-box/combo-box.ts
+++ b/src/components/combo-box/combo-box.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -222,7 +222,7 @@ class BXComboBox extends BXDropdown {
   /**
    * The name of the custom event fired after a a combo box item is selected upon a user gesture.
    */
-  static get eventAfterSelect() {
+  static get eventSelect() {
     return `${prefix}-combo-box-selected`;
   }
 

--- a/src/components/content-switcher/content-switcher-story-angular.ts
+++ b/src/components/content-switcher/content-switcher-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -26,7 +26,7 @@ export const defaultStory = ({ parameters }) => ({
       <bx-content-switcher-item value="router">Option 5</bx-content-switcher-item>
     </bx-content-switcher>
   `,
-  props: (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => {
+  props: (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => {
     const handleBeforeSelect = (event: CustomEvent) => {
       onBeforeSelect(event);
       if (disableSelection) {
@@ -36,7 +36,7 @@ export const defaultStory = ({ parameters }) => ({
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-content-switcher']),
 });

--- a/src/components/content-switcher/content-switcher-story-react.tsx
+++ b/src/components/content-switcher/content-switcher-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import { defaultStory as baseDefaultStory } from './content-switcher-story';
 export { default } from './content-switcher-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, value, disableSelection, onBeforeSelect, onAfterSelect } = parameters?.props?.['bx-content-switcher'];
+  const { disabled, value, disableSelection, onBeforeSelect, onSelect } = parameters?.props?.['bx-content-switcher'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -27,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return (
-    <BXContentSwitcher disabled={disabled} value={value} onBeforeSelect={handleBeforeSelected} onAfterSelect={onAfterSelect}>
+    <BXContentSwitcher disabled={disabled} value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect}>
       <BXContentSwitcherItem value="all">Option 1</BXContentSwitcherItem>
       <BXContentSwitcherItem value="cloudFoundry" disabled>
         Option 2

--- a/src/components/content-switcher/content-switcher-story-vue.ts
+++ b/src/components/content-switcher/content-switcher-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,7 +13,7 @@ import { defaultStory as baseDefaultStory } from './content-switcher-story';
 export { default } from './content-switcher-story';
 
 export const defaultStory = ({ parameters }) => {
-  const props = (({ onBeforeSelect, onAfterSelect, ...rest }) => {
+  const props = (({ onBeforeSelect, onSelect, ...rest }) => {
     function handleBeforeSelect(this: any, event: CustomEvent) {
       onBeforeSelect(event);
       // NOTE: Using class property ref instead of closure ref (from `original`)
@@ -25,7 +25,7 @@ export const defaultStory = ({ parameters }) => {
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-content-switcher']);
   return {

--- a/src/components/content-switcher/content-switcher-story.ts
+++ b/src/components/content-switcher/content-switcher-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import storyDocs from './content-switcher-story.mdx';
 const noop = () => {};
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, value, disableSelection, onBeforeSelect = noop, onAfterSelect = noop } =
+  const { disabled, value, disableSelection, onBeforeSelect = noop, onSelect = noop } =
     parameters?.props?.['bx-content-switcher'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -32,7 +32,7 @@ export const defaultStory = ({ parameters }) => {
       ?disabled="${disabled}"
       value="${ifNonNull(value)}"
       @bx-content-switcher-beingselected="${handleBeforeSelected}"
-      @bx-content-switcher-selected="${onAfterSelect}"
+      @bx-content-switcher-selected="${onSelect}"
     >
       <bx-content-switcher-item value="all">Option 1</bx-content-switcher-item>
       <bx-content-switcher-item value="cloudFoundry" disabled>Option 2</bx-content-switcher-item>
@@ -62,7 +62,7 @@ export default {
           false
         ),
         onBeforeSelect: action('bx-content-switcher-beingselected'),
-        onAfterSelect: action('bx-content-switcher-selected'),
+        onSelect: action('bx-content-switcher-selected'),
       }),
     },
   },

--- a/src/components/content-switcher/content-switcher.ts
+++ b/src/components/content-switcher/content-switcher.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -111,7 +111,7 @@ class BXContentSwitcher extends LitElement {
       });
       if (this.dispatchEvent(beforeSelectEvent)) {
         this._selectionDidChange(item);
-        const afterSelectEvent = new CustomEvent(constructor.eventAfterSelect, init);
+        const afterSelectEvent = new CustomEvent(constructor.eventSelect, init);
         this.dispatchEvent(afterSelectEvent);
       }
     }
@@ -194,7 +194,7 @@ class BXContentSwitcher extends LitElement {
   /**
    * The name of the custom event fired after a a content switcher item is selected upon a user gesture.
    */
-  static get eventAfterSelect() {
+  static get eventSelect() {
     return `${prefix}-content-switcher-selected`;
   }
 

--- a/src/components/data-table/data-table-story-react.tsx
+++ b/src/components/data-table/data-table-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -262,12 +262,8 @@ const BXCEDemoDataTable = ({
     typeof pageSize === 'undefined' ? (
       undefined
     ) : (
-      <BXPagination
-        page-size={pageSize}
-        start={adjustedStart}
-        total={filteredRows.length}
-        onAfterChangeCurrent={handleChangeStart}>
-        <BXPageSizesSelect slot="page-sizes-select" onAfterChange={handleChangePageSize}>
+      <BXPagination page-size={pageSize} start={adjustedStart} total={filteredRows.length} onChangeCurrent={handleChangeStart}>
+        <BXPageSizesSelect slot="page-sizes-select" onChange={handleChangePageSize}>
           <option value="5">5</option>
           <option value="10">10</option>
           <option value="15">15</option>
@@ -283,7 +279,7 @@ const BXCEDemoDataTable = ({
         <BXTableBatchActions
           active={hasBatchActions}
           selectedRowsCount={selectedRowsCountInFiltered}
-          onAfterClickCancel={handleCancelSelection}>
+          onClickCancel={handleCancelSelection}>
           <BXBtn onClick={handleDeleteRows}>
             Delete <Delete16 slot="icon" />
           </BXBtn>
@@ -292,7 +288,7 @@ const BXCEDemoDataTable = ({
           </BXBtn>
         </BXTableBatchActions>
         <BXTableToolbarContent hasBatchActions={hasBatchActions}>
-          <BXTableToolbarSearch onAfterInput={handleChangeSearchString}></BXTableToolbarSearch>
+          <BXTableToolbarSearch onInput={handleChangeSearchString}></BXTableToolbarSearch>
           <BXOverflowMenu>
             <Settings16 slot="icon" />
             <BXOverflowMenuBody>

--- a/src/components/data-table/table-batch-actions.ts
+++ b/src/components/data-table/table-batch-actions.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,8 +22,8 @@ class BXTableBatchActions extends LitElement {
    * Handles `click` event on the Cancel button.
    */
   private _handleCancel() {
-    const { eventAfterClickCancel } = this.constructor as typeof BXTableBatchActions;
-    this.dispatchEvent(new CustomEvent(eventAfterClickCancel, { bubbles: true, composed: true }));
+    const { eventClickCancel } = this.constructor as typeof BXTableBatchActions;
+    this.dispatchEvent(new CustomEvent(eventClickCancel, { bubbles: true, composed: true }));
   }
 
   /**
@@ -70,7 +70,7 @@ class BXTableBatchActions extends LitElement {
   /**
    * The name of the custom event fired after the Cancel button is clicked.
    */
-  static get eventAfterClickCancel() {
+  static get eventClickCancel() {
     return `${prefix}-table-batch-actions-cancel-clicked`;
   }
 

--- a/src/components/data-table/table-toolbar-search.ts
+++ b/src/components/data-table/table-toolbar-search.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -102,7 +102,7 @@ class BXTableToolbarSearch extends HostListenerMixin(BXSearch) {
   /**
    * The name of the custom event fired after the search content is changed upon a user gesture.
    */
-  static get eventAfterInput() {
+  static get eventInput() {
     // The code uses on in `<bx-search>`, but definition is done also here for React event generation
     return `${prefix}-search-input`;
   }

--- a/src/components/date-picker/date-picker-story-angular.ts
+++ b/src/components/date-picker/date-picker-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -45,7 +45,7 @@ export const singleWithCalendar = ({ parameters }) => ({
     [enabledRange]="enabledRange"
     [open]="open"
     [value]="value"
-    (bx-date-picker-changed)="onAfterChanged($event)"
+    (bx-date-picker-changed)="onChanged($event)"
     (bx-date-picker-flatpickr-error)="onFlatpickrError($event)"
   >
     <bx-date-picker-input
@@ -77,7 +77,7 @@ export const rangeWithCalendar = ({ parameters }) => ({
     [enabledRange]="enabledRange"
     [open]="open"
     [value]="value"
-    (bx-date-picker-changed)="onAfterChanged($event)"
+    (bx-date-picker-changed)="onChanged($event)"
     (bx-date-picker-flatpickr-error)="onFlatpickrError($event)"
   >
     <bx-date-picker-input

--- a/src/components/date-picker/date-picker-story-react.tsx
+++ b/src/components/date-picker/date-picker-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -44,7 +44,7 @@ export const defaultStory = ({ parameters }) => {
 defaultStory.story = baseDefaultStory.story;
 
 export const singleWithCalendar = ({ parameters }) => {
-  const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
+  const { dateFormat, enabledRange, open, value, onChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
   const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } = parameters?.props?.[
     'bx-date-picker-input'
   ];
@@ -54,7 +54,7 @@ export const singleWithCalendar = ({ parameters }) => {
       enabledRange={enabledRange}
       open={open}
       value={value}
-      onAfterChanged={onAfterChanged}
+      onChanged={onChanged}
       onFlatpickrError={onFlatpickrError}>
       <BXDatePickerInput
         disabled={disabled}
@@ -74,7 +74,7 @@ export const singleWithCalendar = ({ parameters }) => {
 singleWithCalendar.story = baseSingleWithCalendar.story;
 
 export const rangeWithCalendar = ({ parameters }) => {
-  const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
+  const { dateFormat, enabledRange, open, value, onChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'];
   const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } = parameters?.props?.[
     'bx-date-picker-input'
   ];
@@ -84,7 +84,7 @@ export const rangeWithCalendar = ({ parameters }) => {
       enabledRange={enabledRange}
       open={open}
       value={value}
-      onAfterChanged={onAfterChanged}
+      onChanged={onChanged}
       onFlatpickrError={onFlatpickrError}>
       <BXDatePickerInput
         disabled={disabled}

--- a/src/components/date-picker/date-picker-story-vue.ts
+++ b/src/components/date-picker/date-picker-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -43,7 +43,7 @@ export const singleWithCalendar = ({ parameters }) => ({
       :enabled-range="enabledRange"
       :open="open"
       :value="value"
-      @bx-date-picker-changed="onAfterChanged"
+      @bx-date-picker-changed="onChanged"
       @bx-date-picker-flatpickr-error="onFlatpickrError"
     >
       <bx-date-picker-input
@@ -72,7 +72,7 @@ export const rangeWithCalendar = ({ parameters }) => ({
       :enabled-range="enabledRange"
       :open="open"
       :value="value"
-      @bx-date-picker-changed="onAfterChanged"
+      @bx-date-picker-changed="onChanged"
       @bx-date-picker-flatpickr-error="onFlatpickrError"
     >
       <bx-date-picker-input

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2016, 2018
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ defaultStory.story = {
 };
 
 export const singleWithCalendar = ({ parameters }) => {
-  const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'] ?? {};
+  const { dateFormat, enabledRange, open, value, onChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'] ?? {};
   const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } =
     parameters?.props?.['bx-date-picker-input'] ?? {};
   return html`
@@ -47,7 +47,7 @@ export const singleWithCalendar = ({ parameters }) => {
       enabled-range="${ifNonNull(enabledRange)}"
       ?open="${open}"
       value="${ifNonNull(value)}"
-      @bx-date-picker-changed="${onAfterChanged}"
+      @bx-date-picker-changed="${onChanged}"
       @bx-date-picker-flatpickr-error="${onFlatpickrError}"
     >
       <bx-date-picker-input
@@ -75,7 +75,7 @@ singleWithCalendar.story = {
         enabledRange: textNullable('Minimum/maximum dates in ISO8601 date format, separated by `/` (enabled-range)', ''),
         open: boolean('Open (open)', false),
         value: textNullable('Value in ISO8601 date format, separated by `/` (value)', ''),
-        onAfterChanged: action('bx-date-picker-changed'),
+        onChanged: action('bx-date-picker-changed'),
         onFlatpickrError: action('bx-date-picker-flatpickr-error'),
       }),
     },
@@ -83,7 +83,7 @@ singleWithCalendar.story = {
 };
 
 export const rangeWithCalendar = ({ parameters }) => {
-  const { dateFormat, enabledRange, open, value, onAfterChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'] ?? {};
+  const { dateFormat, enabledRange, open, value, onChanged, onFlatpickrError } = parameters?.props?.['bx-date-picker'] ?? {};
   const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage, onInput } =
     parameters?.props?.['bx-date-picker-input'] ?? {};
   return html`
@@ -92,7 +92,7 @@ export const rangeWithCalendar = ({ parameters }) => {
       enabled-range="${ifNonNull(enabledRange)}"
       ?open="${open}"
       value="${ifNonNull(value)}"
-      @bx-date-picker-changed="${onAfterChanged}"
+      @bx-date-picker-changed="${onChanged}"
       @bx-date-picker-flatpickr-error="${onFlatpickrError}"
     >
       <bx-date-picker-input

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -301,11 +301,7 @@ class BXDatePicker extends LitElement {
     super.connectedCallback();
     this._instantiateDatePicker();
     // Manually hooks the event listeners on the host element to make the event names configurable
-    this._hAfterChange = on(
-      this,
-      (this.constructor as typeof BXDatePicker).eventAfterChange,
-      this._handleChange as EventListener
-    );
+    this._hAfterChange = on(this, (this.constructor as typeof BXDatePicker).eventChange, this._handleChange as EventListener);
   }
 
   disconnectedCallback() {
@@ -521,7 +517,7 @@ class BXDatePicker extends LitElement {
   /**
    * The name of the custom event fired on this element when Flatpickr updates its value.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-date-picker-changed`;
   }
 

--- a/src/components/date-picker/state-handshake-plugin.ts
+++ b/src/components/date-picker/state-handshake-plugin.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,9 +35,9 @@ export default (datePicker: BXDatePicker): Plugin => (fp: FlatpickrInstance) => 
    * @param selectedDates The latest selected dates.
    */
   const handleChange = (selectedDates: Date[]) => {
-    const { eventAfterChange } = datePicker.constructor as typeof BXDatePicker;
+    const { eventChange } = datePicker.constructor as typeof BXDatePicker;
     datePicker.dispatchEvent(
-      new CustomEvent(eventAfterChange, {
+      new CustomEvent(eventChange, {
         bubbles: true,
         cancelable: true,
         composed: true,

--- a/src/components/dropdown/dropdown-story-angular.ts
+++ b/src/components/dropdown/dropdown-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ export const defaultStory = ({ parameters }) => ({
       <bx-dropdown-item value="router">Option 5</bx-dropdown-item>
     </bx-dropdown>
   `,
-  props: (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => {
+  props: (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => {
     const handleBeforeSelect = (event: CustomEvent) => {
       onBeforeSelect(event);
       if (disableSelection) {
@@ -41,7 +41,7 @@ export const defaultStory = ({ parameters }) => ({
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-dropdown']),
 });

--- a/src/components/dropdown/dropdown-story-react.tsx
+++ b/src/components/dropdown/dropdown-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ export const defaultStory = ({ parameters }) => {
     value,
     disableSelection,
     onBeforeSelect,
-    onAfterSelect,
+    onSelect,
   } = parameters?.props?.['bx-dropdown'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -51,7 +51,7 @@ export const defaultStory = ({ parameters }) => {
       triggerContent={triggerContent}
       value={value}
       onBeforeSelect={handleBeforeSelected}
-      onAfterSelect={onAfterSelect}>
+      onSelect={onSelect}>
       <BXDropdownItem value="all">Option 1</BXDropdownItem>
       <BXDropdownItem value="cloudFoundry">Option 2</BXDropdownItem>
       <BXDropdownItem value="staging">Option 3</BXDropdownItem>

--- a/src/components/dropdown/dropdown-story-vue.ts
+++ b/src/components/dropdown/dropdown-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,7 +13,7 @@ import { defaultStory as baseDefaultStory } from './dropdown-story';
 export { default } from './dropdown-story';
 
 export const defaultStory = ({ parameters }) => {
-  const props = (({ onBeforeSelect, onAfterSelect, ...rest }) => {
+  const props = (({ onBeforeSelect, onSelect, ...rest }) => {
     function handleBeforeSelect(this: any, event: CustomEvent) {
       onBeforeSelect(event);
       // NOTE: Using class property ref instead of closure ref (from `original`)
@@ -25,7 +25,7 @@ export const defaultStory = ({ parameters }) => {
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-dropdown']);
   return {

--- a/src/components/dropdown/dropdown-story.ts
+++ b/src/components/dropdown/dropdown-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,7 +33,7 @@ export const defaultStory = ({ parameters }) => {
     triggerContent,
     disableSelection,
     onBeforeSelect,
-    onAfterSelect,
+    onSelect,
   } = parameters?.props?.['bx-dropdown'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     if (onBeforeSelect) {
@@ -54,7 +54,7 @@ export const defaultStory = ({ parameters }) => {
       value=${ifNonNull(value)}
       trigger-content=${ifNonNull(triggerContent)}
       @bx-dropdown-beingselected=${handleBeforeSelected}
-      @bx-dropdown-selected=${onAfterSelect}
+      @bx-dropdown-selected=${onSelect}
     >
       <bx-dropdown-item value="all">Option 1</bx-dropdown-item>
       <bx-dropdown-item value="cloudFoundry">Option 2</bx-dropdown-item>
@@ -90,7 +90,7 @@ export default {
           false
         ),
         onBeforeSelect: action('bx-dropdown-beingselected'),
-        onAfterSelect: action('bx-dropdown-selected'),
+        onSelect: action('bx-dropdown-selected'),
       }),
     },
   },

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -256,7 +256,7 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
       });
       if (this.dispatchEvent(beforeSelectEvent)) {
         this._selectionDidChange(item);
-        const afterSelectEvent = new CustomEvent(constructor.eventAfterSelect, init);
+        const afterSelectEvent = new CustomEvent(constructor.eventSelect, init);
         this.dispatchEvent(afterSelectEvent);
       }
     }
@@ -625,7 +625,7 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
   /**
    * The name of the custom event fired after a a dropdown item is selected upon a user gesture.
    */
-  static get eventAfterSelect() {
+  static get eventSelect() {
     return `${prefix}-dropdown-selected`;
   }
 

--- a/src/components/modal/modal-story-angular.ts
+++ b/src/components/modal/modal-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ export const defaultStory = ({ parameters }) => ({
       </bx-modal-footer>
     </bx-modal>
   `,
-  props: (({ disableClose, onBeforeClose, onAfterClose, ...rest }) => ({
+  props: (({ disableClose, onBeforeClose, onClose, ...rest }) => ({
     ...rest,
     handleBeforeClose: (event: CustomEvent) => {
       onBeforeClose(event);
@@ -39,7 +39,7 @@ export const defaultStory = ({ parameters }) => ({
         event.preventDefault();
       }
     },
-    handleClose: onAfterClose,
+    handleClose: onClose,
   }))(parameters?.props?.['bx-modal']),
 });
 

--- a/src/components/modal/modal-story-react.tsx
+++ b/src/components/modal/modal-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -32,7 +32,7 @@ import { defaultStory as baseDefaultStory } from './modal-story';
 export { default } from './modal-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { danger, open, disableClose, onBeforeClose, onAfterClose } = parameters?.props?.['bx-modal'];
+  const { danger, open, disableClose, onBeforeClose, onClose } = parameters?.props?.['bx-modal'];
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -40,7 +40,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return (
-    <BXModal danger={danger} open={open} onBeforeClose={handleBeforeClose} onAfterClose={onAfterClose}>
+    <BXModal danger={danger} open={open} onBeforeClose={handleBeforeClose} onClose={onClose}>
       <BXModalHeader>
         <BXModalCloseButton />
         <BXModalLabel>Label (Optional)</BXModalLabel>

--- a/src/components/modal/modal-story-vue.ts
+++ b/src/components/modal/modal-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -33,7 +33,7 @@ export const defaultStory = ({ parameters }) => ({
     </bx-modal>
   `,
   ...createVueBindingsFromProps(
-    (({ disableClose, onBeforeClose, onAfterClose, ...rest }) => ({
+    (({ disableClose, onBeforeClose, onClose, ...rest }) => ({
       ...rest,
       handleBeforeClose: (event: CustomEvent) => {
         onBeforeClose(event);
@@ -41,7 +41,7 @@ export const defaultStory = ({ parameters }) => ({
           event.preventDefault();
         }
       },
-      handleClose: onAfterClose,
+      handleClose: onClose,
     }))(parameters?.props?.['bx-modal'])
   ),
 });

--- a/src/components/modal/modal-story.ts
+++ b/src/components/modal/modal-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,7 +21,7 @@ import './modal-footer';
 import storyDocs from './modal-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
-  const { danger, open, disableClose, onBeforeClose, onAfterClose } = parameters?.props?.['bx-modal'] ?? {};
+  const { danger, open, disableClose, onBeforeClose, onClose } = parameters?.props?.['bx-modal'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -29,7 +29,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return html`
-    <bx-modal ?danger="${danger}" ?open="${open}" @bx-modal-beingclosed=${handleBeforeClose} @bx-modal-closed=${onAfterClose}>
+    <bx-modal ?danger="${danger}" ?open="${open}" @bx-modal-beingclosed=${handleBeforeClose} @bx-modal-closed=${onClose}>
       <bx-modal-header>
         <bx-modal-close-button></bx-modal-close-button>
         <bx-modal-label>Label (Optional)</bx-modal-label>
@@ -63,7 +63,7 @@ export default {
           false
         ),
         onBeforeClose: action('bx-modal-beingclosed'),
-        onAfterClose: action('bx-modal-closed'),
+        onClose: action('bx-modal-closed'),
       }),
     },
   },

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -132,7 +132,7 @@ class BXModal extends HostListenerMixin(LitElement) {
       };
       if (this.dispatchEvent(new CustomEvent((this.constructor as typeof BXModal).eventBeforeClose, init))) {
         this.open = false;
-        this.dispatchEvent(new CustomEvent((this.constructor as typeof BXModal).eventAfterClose, init));
+        this.dispatchEvent(new CustomEvent((this.constructor as typeof BXModal).eventClose, init));
       }
     }
   }
@@ -230,7 +230,7 @@ class BXModal extends HostListenerMixin(LitElement) {
   /**
    * The name of the custom event fired after this modal is closed upon a user gesture.
    */
-  static get eventAfterClose() {
+  static get eventClose() {
     return `${prefix}-modal-closed`;
   }
 

--- a/src/components/multi-select/multi-select-story-angular.ts
+++ b/src/components/multi-select/multi-select-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ export const defaultStory = ({ parameters }) => ({
       <bx-multi-select-item value="router">Option 5</bx-multi-select-item>
     </bx-multi-select>
   `,
-  props: (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => ({
+  props: (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => ({
     ...rest,
     handleBeforeSelected: (event: CustomEvent) => {
       onBeforeSelect(event);
@@ -44,7 +44,7 @@ export const defaultStory = ({ parameters }) => ({
         event.preventDefault();
       }
     },
-    handleSelected: onAfterSelect,
+    handleSelected: onSelect,
   }))(parameters?.props?.['bx-multi-select']),
 });
 

--- a/src/components/multi-select/multi-select-story-react.tsx
+++ b/src/components/multi-select/multi-select-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -34,7 +34,7 @@ export const defaultStory = ({ parameters }) => {
     validityMessage,
     disableSelection,
     onBeforeSelect,
-    onAfterSelect,
+    onSelect,
   } = parameters?.props?.['bx-multi-select'];
   const handleBeforeSelect = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -57,7 +57,7 @@ export const defaultStory = ({ parameters }) => {
       type={type}
       validityMessage={validityMessage}
       onBeforeSelect={handleBeforeSelect}
-      onAfterSelect={onAfterSelect}>
+      onSelect={onSelect}>
       <BXMultiSelectItem value="all">Option 1</BXMultiSelectItem>
       <BXMultiSelectItem value="cloudFoundry">Option 2</BXMultiSelectItem>
       <BXMultiSelectItem value="staging">Option 3</BXMultiSelectItem>

--- a/src/components/multi-select/multi-select-story-vue.ts
+++ b/src/components/multi-select/multi-select-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ export const defaultStory = ({ parameters }) => ({
     </bx-multi-select>
   `,
   ...createVueBindingsFromProps(
-    (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => ({
+    (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => ({
       ...rest,
       handleBeforeSelected: (event: CustomEvent) => {
         onBeforeSelect(event);
@@ -46,7 +46,7 @@ export const defaultStory = ({ parameters }) => ({
           event.preventDefault();
         }
       },
-      handleSelected: onAfterSelect,
+      handleSelected: onSelect,
     }))(parameters?.props?.['bx-multi-select'])
   ),
 });

--- a/src/components/multi-select/multi-select-story.ts
+++ b/src/components/multi-select/multi-select-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ export const defaultStory = ({ parameters }) => {
     validityMessage,
     disableSelection,
     onBeforeSelect,
-    onAfterSelect,
+    onSelect,
   } = parameters?.props?.['bx-multi-select'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -61,7 +61,7 @@ export const defaultStory = ({ parameters }) => {
       type=${ifNonNull(type)}
       validity-message=${ifNonNull(validityMessage)}
       @bx-multi-select-beingselected=${handleBeforeSelected}
-      @bx-multi-select-selected=${onAfterSelect}
+      @bx-multi-select-selected=${onSelect}
     >
       <bx-multi-select-item value="all">Option 1</bx-multi-select-item>
       <bx-multi-select-item value="cloudFoundry">Option 2</bx-multi-select-item>
@@ -101,7 +101,7 @@ export default {
           false
         ),
         onBeforeSelect: action('bx-multi-select-beingselected'),
-        onAfterSelect: action('bx-multi-select-selected'),
+        onSelect: action('bx-multi-select-selected'),
       }),
     },
   },

--- a/src/components/multi-select/multi-select.ts
+++ b/src/components/multi-select/multi-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -180,7 +180,7 @@ class BXMultiSelect extends BXDropdown {
   /**
    * The name of the custom event fired after a a multi select item is selected upon a user gesture.
    */
-  static get eventAfterSelect() {
+  static get eventSelect() {
     return `${prefix}-multi-select-selected`;
   }
 

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -105,7 +105,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
       };
       if (this.dispatchEvent(new CustomEvent((this.constructor as typeof BXInlineNotification).eventBeforeClose, init))) {
         this.open = false;
-        this.dispatchEvent(new CustomEvent((this.constructor as typeof BXInlineNotification).eventAfterClose, init));
+        this.dispatchEvent(new CustomEvent((this.constructor as typeof BXInlineNotification).eventClose, init));
       }
     }
   }
@@ -232,7 +232,7 @@ class BXInlineNotification extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after this notification is closed upon a user gesture.
    */
-  static get eventAfterClose() {
+  static get eventClose() {
     return `${prefix}-notification-closed`;
   }
 

--- a/src/components/notification/notification-story-angular.ts
+++ b/src/components/notification/notification-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ export const inline = ({ parameters }) => ({
     >
     </bx-inline-notification>
   `,
-  props: (({ disableClose, onBeforeClose, onAfterClose, ...rest }) => ({
+  props: (({ disableClose, onBeforeClose, onClose, ...rest }) => ({
     ...rest,
     handleBeforeClose: (event: CustomEvent) => {
       onBeforeClose(event);
@@ -35,7 +35,7 @@ export const inline = ({ parameters }) => ({
         event.preventDefault();
       }
     },
-    handleClose: onAfterClose,
+    handleClose: onClose,
   }))(parameters?.props?.['bx-inline-notification']),
   moduleMetadata: {
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -61,7 +61,7 @@ export const toast = ({ parameters }) => ({
     >
     </bx-toast-notification>
   `,
-  props: (({ disableClose, onBeforeClose, onAfterClose, ...rest }) => ({
+  props: (({ disableClose, onBeforeClose, onClose, ...rest }) => ({
     ...rest,
     handleBeforeClose: (event: CustomEvent) => {
       onBeforeClose(event);
@@ -69,7 +69,7 @@ export const toast = ({ parameters }) => ({
         event.preventDefault();
       }
     },
-    handleClose: onAfterClose,
+    handleClose: onClose,
   }))(parameters?.props?.['bx-toast-notification']),
   moduleMetadata: {
     schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/src/components/notification/notification-story-react.tsx
+++ b/src/components/notification/notification-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ export const inline = ({ parameters }) => {
     open,
     disableClose,
     onBeforeClose,
-    onAfterClose,
+    onClose,
   } = parameters?.props?.['bx-inline-notification'];
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
@@ -50,7 +50,7 @@ export const inline = ({ parameters }) => {
       iconLabel={iconLabel}
       open={open}
       onBeforeClose={handleBeforeClose}
-      onClose={onAfterClose}
+      onClose={onClose}
     />
   );
 };
@@ -69,7 +69,7 @@ export const toast = ({ parameters }) => {
     open,
     disableClose,
     onBeforeClose,
-    onAfterClose,
+    onClose,
   } = parameters?.props?.['bx-toast-notification'];
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
@@ -89,7 +89,7 @@ export const toast = ({ parameters }) => {
       iconLabel={iconLabel}
       open={open}
       onBeforeClose={handleBeforeClose}
-      onClose={onAfterClose}
+      onClose={onClose}
     />
   );
 };

--- a/src/components/notification/notification-story-vue.ts
+++ b/src/components/notification/notification-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,7 +29,7 @@ export const inline = ({ parameters }) => ({
     </bx-inline-notification>
   `,
   ...createVueBindingsFromProps(
-    (({ disableClose, onBeforeClose, onAfterClose, ...rest }) => ({
+    (({ disableClose, onBeforeClose, onClose, ...rest }) => ({
       ...rest,
       handleBeforeClose: (event: CustomEvent) => {
         onBeforeClose(event);
@@ -37,7 +37,7 @@ export const inline = ({ parameters }) => ({
           event.preventDefault();
         }
       },
-      handleClose: onAfterClose,
+      handleClose: onClose,
     }))(parameters?.props?.['bx-inline-notification'])
   ),
 });
@@ -62,7 +62,7 @@ export const toast = ({ parameters }) => ({
     </bx-toast-notification>
   `,
   ...createVueBindingsFromProps(
-    (({ disableClose, onBeforeClose, onAfterClose, ...rest }) => ({
+    (({ disableClose, onBeforeClose, onClose, ...rest }) => ({
       ...rest,
       handleBeforeClose: (event: CustomEvent) => {
         onBeforeClose(event);
@@ -70,7 +70,7 @@ export const toast = ({ parameters }) => ({
           event.preventDefault();
         }
       },
-      handleClose: onAfterClose,
+      handleClose: onClose,
     }))(parameters?.props?.['bx-toast-notification'])
   ),
 });

--- a/src/components/notification/notification-story.ts
+++ b/src/components/notification/notification-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ export const inline = ({ parameters }) => {
     open,
     disableClose,
     onBeforeClose = noop,
-    onAfterClose = noop,
+    onClose = noop,
   } = parameters?.props?.['bx-inline-notification'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
@@ -55,7 +55,7 @@ export const inline = ({ parameters }) => {
       icon-label="${ifNonNull(iconLabel)}"
       ?open="${open}"
       @bx-notification-beingclosed="${handleBeforeClose}"
-      @bx-notification-closed="${onAfterClose}"
+      @bx-notification-closed="${onClose}"
     >
     </bx-inline-notification>
   `;
@@ -77,7 +77,7 @@ inline.story = {
           false
         ),
         onBeforeClose: action('bx-notification-beingclosed'),
-        onAfterClose: action('bx-notification-closed'),
+        onClose: action('bx-notification-closed'),
       }),
     },
   },
@@ -95,7 +95,7 @@ export const toast = ({ parameters }) => {
     open,
     disableClose,
     onBeforeClose = noop,
-    onAfterClose = noop,
+    onClose = noop,
   } = parameters?.props?.['bx-toast-notification'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
@@ -115,7 +115,7 @@ export const toast = ({ parameters }) => {
       icon-label="${ifNonNull(iconLabel)}"
       ?open="${open}"
       @bx-notification-beingclosed="${handleBeforeClose}"
-      @bx-notification-closed="${onAfterClose}"
+      @bx-notification-closed="${onClose}"
     >
     </bx-toast-notification>
   `;

--- a/src/components/pagination/page-sizes-select.ts
+++ b/src/components/pagination/page-sizes-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -29,7 +29,7 @@ class BXPageSizesSelect extends FocusMixin(LitElement) {
   private _handleChange({ target }: Event) {
     const value = Number((target as HTMLSelectElement).value);
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXPageSizesSelect).eventAfterChange, {
+      new CustomEvent((this.constructor as typeof BXPageSizesSelect).eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -85,7 +85,7 @@ class BXPageSizesSelect extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after the page size is changed.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-page-sizes-select-changed`;
   }
 

--- a/src/components/pagination/pages-select.ts
+++ b/src/components/pagination/pages-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -26,7 +26,7 @@ class BXPagesSelect extends FocusMixin(LitElement) {
   protected _handleChange({ target }: Event) {
     const value = Number((target as HTMLSelectElement).value);
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXPagesSelect).eventAfterChange, {
+      new CustomEvent((this.constructor as typeof BXPagesSelect).eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -91,7 +91,7 @@ class BXPagesSelect extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after the page is changed.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-pages-select-changed`;
   }
 

--- a/src/components/pagination/pagination.ts
+++ b/src/components/pagination/pagination.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -57,7 +57,7 @@ class BXPagination extends FocusMixin(LitElement) {
   private _handleUserInitiatedChangeStart(start: number) {
     this.start = start;
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXPagination).eventAfterChangeCurrent, {
+      new CustomEvent((this.constructor as typeof BXPagination).eventChangeCurrent, {
         bubbles: true,
         composed: true,
         detail: {
@@ -170,12 +170,12 @@ class BXPagination extends FocusMixin(LitElement) {
     // Manually hooks the event listeners on the host element to make the event names configurable
     this._hChangePage = on(
       this,
-      (this.constructor as typeof BXPagination).eventAfterChangePage,
+      (this.constructor as typeof BXPagination).eventChangePage,
       this._handleChangePage as EventListener
     );
     this._hChangePageSize = on(
       this,
-      (this.constructor as typeof BXPagination).eventAfterChangePageSize,
+      (this.constructor as typeof BXPagination).eventChangePageSize,
       this._handleChangePageSize as EventListener
     );
   }
@@ -282,21 +282,21 @@ class BXPagination extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after the current row number is changed.
    */
-  static get eventAfterChangeCurrent() {
+  static get eventChangeCurrent() {
     return `${prefix}-pagination-changed-current`;
   }
 
   /**
    * The name of the custom event fired after the current page is changed from `<bx-pages-select>`.
    */
-  static get eventAfterChangePage() {
+  static get eventChangePage() {
     return `${prefix}-pages-select-changed`;
   }
 
   /**
    * The name of the custom event fired after the number of rows per page is changed from `<bx-page-sizes-select>`.
    */
-  static get eventAfterChangePageSize() {
+  static get eventChangePageSize() {
     return `${prefix}-page-sizes-select-changed`;
   }
 

--- a/src/components/radio-button/radio-button-group.ts
+++ b/src/components/radio-button/radio-button-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -52,9 +52,9 @@ class BXRadioButtonGroup extends FormMixin(LitElement) {
     const oldValue = this.value;
     this.value = selected && selected.value;
     if (oldValue !== this.value) {
-      const { eventAfterChange } = this.constructor as typeof BXRadioButtonGroup;
+      const { eventChange } = this.constructor as typeof BXRadioButtonGroup;
       this.dispatchEvent(
-        new CustomEvent(eventAfterChange, {
+        new CustomEvent(eventChange, {
           bubbles: true,
           composed: true,
           detail: {
@@ -108,7 +108,7 @@ class BXRadioButtonGroup extends FormMixin(LitElement) {
     // Manually hooks the event listeners on the host element to make the event names configurable
     this._hAfterChangeRadioButton = on(
       this,
-      (this.constructor as typeof BXRadioButtonGroup).eventAfterChangeRadioButton,
+      (this.constructor as typeof BXRadioButtonGroup).eventChangeRadioButton,
       this._handleAfterChangeRadioButton as EventListener
     );
   }
@@ -155,14 +155,14 @@ class BXRadioButtonGroup extends FormMixin(LitElement) {
   /**
    * The name of the custom event fired after this radio button group changes its selected item.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-radio-button-group-changed`;
   }
 
   /**
    * The name of the custom event fired after a radio button changes its checked state.
    */
-  static get eventAfterChangeRadioButton() {
+  static get eventChangeRadioButton() {
     return `${prefix}-radio-button-changed`;
   }
 

--- a/src/components/radio-button/radio-button-story-angular.ts
+++ b/src/components/radio-button/radio-button-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ export const defaultStory = ({ parameters }) => ({
       [orientation]="orientation"
       [name]="name"
       [value]="value"
-      (bx-radio-button-group-changed)="onAfterChange($event)"
+      (bx-radio-button-group-changed)="onChange($event)"
     >
       <bx-radio-button [hideLabel]="hideLabel" [labelText]="labelText" value="all"></bx-radio-button>
       <bx-radio-button [hideLabel]="hideLabel" [labelText]="labelText" value="cloudFoundry"></bx-radio-button>

--- a/src/components/radio-button/radio-button-story-react.tsx
+++ b/src/components/radio-button/radio-button-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import { defaultStory as baseDefaultStory } from './radio-button-story';
 export { default } from './radio-button-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, labelPosition, orientation, name, value, onAfterChange } = parameters?.props?.['bx-radio-button-group'];
+  const { disabled, labelPosition, orientation, name, value, onChange } = parameters?.props?.['bx-radio-button-group'];
   const { hideLabel, labelText } = parameters?.props?.['bx-radio-button'];
   return (
     <BXRadioButtonGroup
@@ -28,7 +28,7 @@ export const defaultStory = ({ parameters }) => {
       orientation={orientation}
       name={name}
       value={value}
-      onAfterChange={onAfterChange}>
+      onChange={onChange}>
       <BXRadioButton hideLabel={hideLabel} labelText={labelText} value="all" />
       <BXRadioButton hideLabel={hideLabel} labelText={labelText} value="cloudFoundry" />
       <BXRadioButton hideLabel={hideLabel} labelText={labelText} value="staging" />

--- a/src/components/radio-button/radio-button-story-vue.ts
+++ b/src/components/radio-button/radio-button-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ export const defaultStory = ({ parameters }) => ({
       :orientation="orientation"
       :name="name"
       :value="value"
-      @bx-radio-button-group-changed="onAfterChange"
+      @bx-radio-button-group-changed="onChange"
     >
       <bx-radio-button :hide-label="hideLabel" :label-text="labelText" value="all"></bx-radio-button>
       <bx-radio-button :hide-label="hideLabel" :label-text="labelText" value="cloudFoundry"></bx-radio-button>

--- a/src/components/radio-button/radio-button-story.ts
+++ b/src/components/radio-button/radio-button-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ const labelPositions = {
 };
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, labelPosition, orientation, name, value, onAfterChange } = parameters?.props?.['bx-radio-button-group'] ?? {};
+  const { disabled, labelPosition, orientation, name, value, onChange } = parameters?.props?.['bx-radio-button-group'] ?? {};
   const { hideLabel, labelText } = parameters?.props?.['bx-radio-button'] ?? {};
   return html`
     <bx-radio-button-group
@@ -36,7 +36,7 @@ export const defaultStory = ({ parameters }) => {
       orientation="${ifNonNull(orientation)}"
       name="${ifNonNull(name)}"
       value="${ifNonNull(value)}"
-      @bx-radio-button-group-changed="${onAfterChange}"
+      @bx-radio-button-group-changed="${onChange}"
     >
       <bx-radio-button ?hide-label="${hideLabel}" label-text="${ifNonNull(labelText)}" value="all"></bx-radio-button>
       <bx-radio-button ?hide-label="${hideLabel}" label-text="${ifNonNull(labelText)}" value="cloudFoundry"></bx-radio-button>
@@ -62,7 +62,7 @@ export default {
         orientation: select('Orientation (orientation)', orientations, RADIO_BUTTON_ORIENTATION.HORIZONTAL),
         name: textNullable('Name (name)', 'radio-group'),
         value: textNullable('Value (value)', ''),
-        onAfterChange: action('bx-radio-button-group-changed'),
+        onChange: action('bx-radio-button-group-changed'),
       }),
       'bx-radio-button': () => ({
         hideLabel: boolean('Hide label (hide-label)', false),

--- a/src/components/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -74,11 +74,11 @@ class RadioButtonDelegate implements ManagedRadioButtonDelegate {
 
   set checked(checked) {
     const { host } = this._radio.getRootNode() as ShadowRoot;
-    const { eventAfterChange } = host.constructor as typeof BXRadioButton; // eslint-disable-line no-use-before-define
+    const { eventChange } = host.constructor as typeof BXRadioButton; // eslint-disable-line no-use-before-define
     (host as BXRadioButton).checked = checked;
     this._radio.tabIndex = checked ? 0 : -1;
     host.dispatchEvent(
-      new CustomEvent(eventAfterChange, {
+      new CustomEvent(eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -272,7 +272,7 @@ class BXRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
   /**
    * The name of the custom event fired after this radio button changes its checked state.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-radio-button-changed`;
   }
 

--- a/src/components/search/search-story-angular.ts
+++ b/src/components/search/search-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ export const defaultStory = ({ parameters }) => ({
       [size]="size"
       [type]="type"
       [value]="value"
-      (bx-search-input)="onAfterInput($event)"
+      (bx-search-input)="onInput($event)"
     ></bx-search>
   `,
   props: parameters?.props?.['bx-search'],

--- a/src/components/search/search-story-react.tsx
+++ b/src/components/search/search-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
     size,
     type,
     value,
-    onAfterInput,
+    onInput,
   } = parameters?.props?.['bx-search'];
   return (
     <BXSearch
@@ -40,7 +40,7 @@ export const defaultStory = ({ parameters }) => {
       size={size}
       type={type}
       value={value}
-      onAfterInput={onAfterInput}
+      onInput={onInput}
     />
   );
 };

--- a/src/components/search/search-story-vue.ts
+++ b/src/components/search/search-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,7 +24,7 @@ export const defaultStory = ({ parameters }) => ({
       :size="size"
       :type="type"
       :value="value"
-      @bx-search-input="onAfterInput"
+      @bx-search-input="onInput"
     ></bx-search>
   `,
   ...createVueBindingsFromProps(parameters?.props?.['bx-search']),

--- a/src/components/search/search-story.ts
+++ b/src/components/search/search-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,7 +21,7 @@ const sizes = {
 };
 
 export const defaultStory = ({ parameters }) => {
-  const { closeButtonAssistiveText, disabled, light, labelText, name, placeholder, size, type, value, onAfterInput } =
+  const { closeButtonAssistiveText, disabled, light, labelText, name, placeholder, size, type, value, onInput } =
     parameters?.props?.['bx-search'] ?? {};
   return html`
     <bx-search
@@ -34,7 +34,7 @@ export const defaultStory = ({ parameters }) => {
       size="${ifNonNull(size)}"
       type="${ifNonNull(type)}"
       value="${ifNonNull(value)}"
-      @bx-search-input="${onAfterInput}"
+      @bx-search-input="${onInput}"
     ></bx-search>
   `;
 };
@@ -63,7 +63,7 @@ export default {
         size: select('Searh size (size)', sizes, null),
         type: textNullable('The type of the <input> (type)', ''),
         value: textNullable('Value (value)', ''),
-        onAfterInput: action('bx-search-input'),
+        onInput: action('bx-search-input'),
       }),
     },
   },

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -46,7 +46,7 @@ class BXSearch extends FocusMixin(LitElement) {
     const { target } = event;
     const { value } = target as HTMLInputElement;
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXSearch).eventAfterInput, {
+      new CustomEvent((this.constructor as typeof BXSearch).eventInput, {
         bubbles: true,
         composed: true,
         cancelable: false,
@@ -64,7 +64,7 @@ class BXSearch extends FocusMixin(LitElement) {
   private _handleClearInputButtonClick() {
     if (this.value) {
       this.dispatchEvent(
-        new CustomEvent((this.constructor as typeof BXSearch).eventAfterInput, {
+        new CustomEvent((this.constructor as typeof BXSearch).eventInput, {
           bubbles: true,
           composed: true,
           cancelable: false,
@@ -188,7 +188,7 @@ class BXSearch extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after the search content is changed upon a user gesture.
    */
-  static get eventAfterInput() {
+  static get eventInput() {
     return `${prefix}-search-input`;
   }
 

--- a/src/components/slider/slider-input.ts
+++ b/src/components/slider/slider-input.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -26,7 +26,7 @@ class BXSliderInput extends FocusMixin(LitElement) {
    */
   private _handleChange({ target }: Event) {
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXSliderInput).eventAfterChange, {
+      new CustomEvent((this.constructor as typeof BXSliderInput).eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -41,7 +41,7 @@ class BXSliderInput extends FocusMixin(LitElement) {
    */
   private _handleInput({ target }: Event) {
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXSliderInput).eventAfterChange, {
+      new CustomEvent((this.constructor as typeof BXSliderInput).eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -113,7 +113,7 @@ class BXSliderInput extends FocusMixin(LitElement) {
   /**
    * The name of the custom event fired after the value is changed by user gesture.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-slider-input-changed`;
   }
 

--- a/src/components/slider/slider-story-angular.ts
+++ b/src/components/slider/slider-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,7 +21,7 @@ export const defaultStory = ({ parameters }) => ({
       [name]="name"
       [step]="step"
       [value]="value"
-      (bx-slider-changed)="onAfterChange($event)"
+      (bx-slider-changed)="onChange($event)"
     ></bx-slider>
   `,
   props: parameters?.props?.['bx-slider'],
@@ -39,7 +39,7 @@ export const withInputBox = ({ parameters }) => ({
       [name]="name"
       [step]="step"
       [value]="value"
-      (bx-slider-changed)="onAfterChange($event)"
+      (bx-slider-changed)="onChange($event)"
     >
       <bx-slider-input aria-label="Slider value" type="number"></bx-slider-input>
     </bx-slider>

--- a/src/components/slider/slider-story-react.tsx
+++ b/src/components/slider/slider-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,7 @@ import { defaultStory as baseDefaultStory, withInputBox as baseWithInputBox } fr
 export { default } from './slider-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, labelText, max, min, name, step, value, onAfterChange } = parameters?.props?.['bx-slider'];
+  const { disabled, labelText, max, min, name, step, value, onChange } = parameters?.props?.['bx-slider'];
   return (
     <BXSlider
       disabled={disabled}
@@ -29,7 +29,7 @@ export const defaultStory = ({ parameters }) => {
       name={name}
       step={step}
       value={value}
-      onAfterChange={onAfterChange}
+      onChange={onChange}
     />
   );
 };
@@ -37,7 +37,7 @@ export const defaultStory = ({ parameters }) => {
 defaultStory.story = baseDefaultStory;
 
 export const withInputBox = ({ parameters }) => {
-  const { disabled, labelText, max, min, name, step, value, onAfterChange } = parameters?.props?.['bx-slider'];
+  const { disabled, labelText, max, min, name, step, value, onChange } = parameters?.props?.['bx-slider'];
   return (
     <BXSlider
       disabled={disabled}
@@ -47,7 +47,7 @@ export const withInputBox = ({ parameters }) => {
       name={name}
       step={step}
       value={value}
-      onAfterChange={onAfterChange}>
+      onChange={onChange}>
       <BXSliderInput aria-label="Slider value" type="number" />
     </BXSlider>
   );

--- a/src/components/slider/slider-story-vue.ts
+++ b/src/components/slider/slider-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ export const defaultStory = ({ parameters }) => ({
       :name="name"
       :step="step"
       :value="value"
-      @bx-slider-changed="onAfterChange"
+      @bx-slider-changed="onChange"
     ></bx-slider>
   `,
   ...createVueBindingsFromProps(parameters?.props?.['bx-slider']),
@@ -40,7 +40,7 @@ export const withInputBox = ({ parameters }) => ({
       :name="name"
       :step="step"
       :value="value"
-      @bx-slider-changed="onAfterChange"
+      @bx-slider-changed="onChange"
     >
       <bx-slider-input aria-label="Slider value" type="number"></bx-slider-input>
     </bx-slider>

--- a/src/components/slider/slider-story.ts
+++ b/src/components/slider/slider-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,7 +16,7 @@ import './slider-input';
 import storyDocs from './slider-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, labelText, max, min, name, step, value, onAfterChange } = parameters?.props?.['bx-slider'] || {};
+  const { disabled, labelText, max, min, name, step, value, onChange } = parameters?.props?.['bx-slider'] || {};
   return html`
     <bx-slider
       ?disabled="${disabled}"
@@ -26,7 +26,7 @@ export const defaultStory = ({ parameters }) => {
       name="${ifNonNull(name)}"
       step="${ifNonNull(step)}"
       value="${ifNonNull(value)}"
-      @bx-slider-changed="${onAfterChange}"
+      @bx-slider-changed="${onChange}"
     ></bx-slider>
   `;
 };
@@ -36,7 +36,7 @@ defaultStory.story = {
 };
 
 export const withInputBox = ({ parameters }) => {
-  const { disabled, labelText, max, min, name, step, value, onAfterChange } = parameters?.props?.['bx-slider'] || {};
+  const { disabled, labelText, max, min, name, step, value, onChange } = parameters?.props?.['bx-slider'] || {};
   return html`
     <bx-slider
       ?disabled="${disabled}"
@@ -46,7 +46,7 @@ export const withInputBox = ({ parameters }) => {
       name="${ifNonNull(name)}"
       step="${ifNonNull(step)}"
       value="${ifNonNull(value)}"
-      @bx-slider-changed="${onAfterChange}"
+      @bx-slider-changed="${onChange}"
     >
       <bx-slider-input aria-label="Slider value" type="number"></bx-slider-input>
     </bx-slider>
@@ -72,7 +72,7 @@ export default {
         min: number('The minimum value (min)', 0),
         step: number('The step (step)', 1),
         value: number('Value (value)', 50),
-        onAfterChange: action('bx-slider-changed'),
+        onChange: action('bx-slider-changed'),
       }),
     },
   },

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -133,7 +133,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
         const { max, min, step, stepRatio } = this;
         this.value += (!shiftKey ? Number(step) : (Number(max) - Number(min)) / Number(stepRatio)) * THUMB_DIRECTION[key];
         this.dispatchEvent(
-          new CustomEvent((this.constructor as typeof BXSlider).eventAfterChange, {
+          new CustomEvent((this.constructor as typeof BXSlider).eventChange, {
             bubbles: true,
             composed: true,
             detail: {
@@ -164,7 +164,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
       const { left: trackLeft, width: trackWidth } = trackNode.getBoundingClientRect();
       this._rate = (isRtl ? trackLeft + trackWidth - thumbPosition : thumbPosition - trackLeft) / trackWidth;
       this.dispatchEvent(
-        new CustomEvent((this.constructor as typeof BXSlider).eventAfterChange, {
+        new CustomEvent((this.constructor as typeof BXSlider).eventChange, {
           bubbles: true,
           composed: true,
           detail: {
@@ -200,7 +200,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
       const { left: trackLeft, width: trackWidth } = this._trackNode.getBoundingClientRect();
       this._rate = (isRtl ? trackLeft + trackWidth - thumbPosition : thumbPosition - trackLeft) / trackWidth;
       this.dispatchEvent(
-        new CustomEvent((this.constructor as typeof BXSlider).eventAfterChange, {
+        new CustomEvent((this.constructor as typeof BXSlider).eventChange, {
           bubbles: true,
           composed: true,
           detail: {
@@ -220,7 +220,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   private _handleMouseup = () => {
     if (this._dragging) {
       this.dispatchEvent(
-        new CustomEvent((this.constructor as typeof BXSlider).eventAfterChange, {
+        new CustomEvent((this.constructor as typeof BXSlider).eventChange, {
           bubbles: true,
           composed: true,
           detail: {
@@ -239,7 +239,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
     const { intermediate, value } = detail;
     this.value = value;
     this.dispatchEvent(
-      new CustomEvent((this.constructor as typeof BXSlider).eventAfterChange, {
+      new CustomEvent((this.constructor as typeof BXSlider).eventChange, {
         bubbles: true,
         composed: true,
         detail: {
@@ -358,7 +358,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
     // Manually hooks the event listeners on the host element to make the event names configurable
     this._hChangeInput = on(
       this,
-      (this.constructor as typeof BXSlider).eventAfterChangeInput,
+      (this.constructor as typeof BXSlider).eventChangeInput,
       this._handleChangeInput as EventListener
     );
   }
@@ -470,14 +470,14 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   /**
    * The name of the custom event fired after the value is changed by user gesture.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-slider-changed`;
   }
 
   /**
    * The name of the custom event fired after the value is changed in `<bx-slider-input>` by user gesture.
    */
-  static get eventAfterChangeInput() {
+  static get eventChangeInput() {
     return `${prefix}-slider-input-changed`;
   }
 

--- a/src/components/tabs/tabs-story-angular.ts
+++ b/src/components/tabs/tabs-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -28,7 +28,7 @@ export const defaultStory = ({ parameters }) => ({
     </bx-tabs>
     <!-- TODO: Figure out how to style the tab panels demo -->
   `,
-  props: (({ disableSelection, onBeforeSelect, onAfterSelect, ...rest }) => {
+  props: (({ disableSelection, onBeforeSelect, onSelect, ...rest }) => {
     const handleBeforeSelect = (event: CustomEvent) => {
       onBeforeSelect(event);
       if (disableSelection) {
@@ -38,7 +38,7 @@ export const defaultStory = ({ parameters }) => ({
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-tabs']),
 });

--- a/src/components/tabs/tabs-story-react.tsx
+++ b/src/components/tabs/tabs-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ import styles from './tabs-story.scss';
 export { default } from './tabs-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, triggerContent, value, disableSelection, onBeforeSelect, onAfterSelect } = parameters?.props?.['bx-tabs'];
+  const { disabled, triggerContent, value, disableSelection, onBeforeSelect, onSelect } = parameters?.props?.['bx-tabs'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -35,7 +35,7 @@ export const defaultStory = ({ parameters }) => {
         triggerContent={triggerContent}
         value={value}
         onBeforeSelect={handleBeforeSelected}
-        onAfterSelect={onAfterSelect}>
+        onSelect={onSelect}>
         <BXTab id="tab-all" target="panel-all" value="all">
           Option 1
         </BXTab>

--- a/src/components/tabs/tabs-story-vue.ts
+++ b/src/components/tabs/tabs-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,7 +13,7 @@ import { defaultStory as baseDefaultStory } from './tabs-story';
 export { default } from './tabs-story';
 
 export const defaultStory = ({ parameters }) => {
-  const props = (({ onBeforeSelect, onAfterSelect, ...rest }) => {
+  const props = (({ onBeforeSelect, onSelect, ...rest }) => {
     function handleBeforeSelect(this: any, event: CustomEvent) {
       onBeforeSelect(event);
       // NOTE: Using class property ref instead of closure ref (from `original`)
@@ -25,7 +25,7 @@ export const defaultStory = ({ parameters }) => {
     return {
       ...rest,
       handleBeforeSelect,
-      handleAfterSelect: onAfterSelect,
+      handleAfterSelect: onSelect,
     };
   })(parameters?.props?.['bx-tabs']);
   return {

--- a/src/components/tabs/tabs-story.ts
+++ b/src/components/tabs/tabs-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,7 +20,7 @@ import storyDocs from './tabs-story.mdx';
 const noop = () => {};
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, triggerContent, value, disableSelection, onBeforeSelect = noop, onAfterSelect = noop } =
+  const { disabled, triggerContent, value, disableSelection, onBeforeSelect = noop, onSelect = noop } =
     parameters?.props?.['bx-tabs'] || {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -37,7 +37,7 @@ export const defaultStory = ({ parameters }) => {
       trigger-content="${ifNonNull(triggerContent)}"
       value="${ifNonNull(value)}"
       @bx-tabs-beingselected="${handleBeforeSelected}"
-      @bx-tabs-selected="${onAfterSelect}"
+      @bx-tabs-selected="${onSelect}"
     >
       <bx-tab id="tab-all" target="panel-all" value="all">Option 1</bx-tab>
       <bx-tab id="tab-cloudFoundry" target="panel-cloudFoundry" disabled value="cloudFoundry">Option 2</bx-tab>
@@ -108,7 +108,7 @@ export default {
           false
         ),
         onBeforeSelect: action('bx-tabs-beingselected'),
-        onAfterSelect: action('bx-tabs-selected'),
+        onSelect: action('bx-tabs-selected'),
       }),
     },
   },

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -385,7 +385,7 @@ class BXTabs extends HostListenerMixin(BXContentSwitcher) {
   /**
    * The name of the custom event fired after a a tab is selected upon a user gesture.
    */
-  static get eventAfterSelect() {
+  static get eventSelect() {
     return `${prefix}-tabs-selected`;
   }
 

--- a/src/components/tile/expandable-tile.ts
+++ b/src/components/tile/expandable-tile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -40,7 +40,7 @@ class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
     });
     if (this.dispatchEvent(beforeChangeEvent)) {
       this.expanded = expanded;
-      const afterChangeEvent = new CustomEvent(constructor.eventAfterChange, init);
+      const afterChangeEvent = new CustomEvent(constructor.eventChange, init);
       this.dispatchEvent(afterChangeEvent);
     }
   };
@@ -124,7 +124,7 @@ class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
   /**
    * The name of the custom event fired after a the expanded state is changed upon a user gesture.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-expandable-tile-changed`;
   }
 

--- a/src/components/tile/tile-story-angular.ts
+++ b/src/components/tile/tile-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -101,7 +101,7 @@ export const expandable = ({ parameters }) => ({
       </bx-tile-below-the-fold-content>
     </bx-expandable-tile>
   `,
-  props: (({ disableChange, onBeforeChange, onAfterChange, ...rest }) => {
+  props: (({ disableChange, onBeforeChange, onChange, ...rest }) => {
     const handleBeforeChange = (event: CustomEvent) => {
       onBeforeChange(event);
       if (disableChange) {
@@ -111,7 +111,7 @@ export const expandable = ({ parameters }) => ({
     return {
       ...rest,
       handleBeforeChange,
-      handleAfterChange: onAfterChange,
+      handleAfterChange: onChange,
     };
   })(parameters?.props?.['bx-expandable-tile']),
 });

--- a/src/components/tile/tile-story-react.tsx
+++ b/src/components/tile/tile-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -76,7 +76,7 @@ export const multiSelectable = ({ parameters }) => {
 multiSelectable.story = baseMultiSelectable.story;
 
 export const expandable = ({ parameters }) => {
-  const { expanded, disableChange, onBeforeChange, onAfterChange } =
+  const { expanded, disableChange, onBeforeChange, onChange } =
     (parameters.props && parameters.props['bx-expandable-tile']) || ({} as typeof parameters.props['bx-expandable-tile']);
   const handleBeforeChanged = (event: CustomEvent) => {
     onBeforeChange(event);
@@ -85,7 +85,7 @@ export const expandable = ({ parameters }) => {
     }
   };
   return (
-    <BXExpandableTile expanded={expanded} onBeforeChange={handleBeforeChanged} onAfterChange={onAfterChange}>
+    <BXExpandableTile expanded={expanded} onBeforeChange={handleBeforeChanged} onChange={onChange}>
       <BXTileAboveTheFoldContent style={{ height: '200px' }}>Above the fold content here</BXTileAboveTheFoldContent>
       <BXTileBelowTheFoldContent style={{ height: '300px' }}>Below the fold content here</BXTileBelowTheFoldContent>
     </BXExpandableTile>

--- a/src/components/tile/tile-story-vue.ts
+++ b/src/components/tile/tile-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -86,7 +86,7 @@ export const multiSelectable = ({ parameters }) => ({
 multiSelectable.story = baseMultiSelectable.story;
 
 export const expandable = ({ parameters }) => {
-  const props = (({ disableChange, onBeforeChange, onAfterChange, ...rest }) => {
+  const props = (({ disableChange, onBeforeChange, onChange, ...rest }) => {
     const handleBeforeChange = (event: CustomEvent) => {
       onBeforeChange(event);
       if (disableChange) {
@@ -96,7 +96,7 @@ export const expandable = ({ parameters }) => {
     return {
       ...rest,
       handleBeforeChange,
-      handleAfterChange: onAfterChange,
+      handleAfterChange: onChange,
     };
   })(parameters?.props?.['bx-expandable-tile']);
   return {

--- a/src/components/tile/tile-story.ts
+++ b/src/components/tile/tile-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -119,7 +119,7 @@ multiSelectable.story = {
 };
 
 export const expandable = ({ parameters }) => {
-  const { expanded, disableChange, onBeforeChange, onAfterChange } = parameters?.props?.['bx-expandable-tile'] ?? {};
+  const { expanded, disableChange, onBeforeChange, onChange } = parameters?.props?.['bx-expandable-tile'] ?? {};
   const handleBeforeChanged = (event: CustomEvent) => {
     onBeforeChange(event);
     if (disableChange) {
@@ -130,7 +130,7 @@ export const expandable = ({ parameters }) => {
     <bx-expandable-tile
       ?expanded="${expanded}"
       @bx-expandable-tile-beingchanged=${handleBeforeChanged}
-      @bx-expandable-tile-changed=${onAfterChange}
+      @bx-expandable-tile-changed=${onChange}
     >
       <bx-tile-above-the-fold-content style="height: 200px">
         Above the fold content here
@@ -153,7 +153,7 @@ expandable.story = {
           false
         ),
         onBeforeChange: action('bx-expandable-tile-beingchanged'),
-        onAfterChange: action('bx-expandable-tile-changed'),
+        onChange: action('bx-expandable-tile-changed'),
       }),
     },
   },

--- a/src/components/toggle/toggle-story-angular.ts
+++ b/src/components/toggle/toggle-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,7 +22,7 @@ export const defaultStory = ({ parameters }) => ({
       [small]="small"
       [uncheckedText]="uncheckedText"
       [value]="value"
-      (bx-toggle-changed)="onAfterChange($event)"
+      (bx-toggle-changed)="onChange($event)"
     ></bx-toggle>
   `,
   props: parameters?.props?.['bx-toggle'],

--- a/src/components/toggle/toggle-story-react.tsx
+++ b/src/components/toggle/toggle-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@ import { defaultStory as baseDefaultStory } from './toggle-story';
 export { default } from './toggle-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onAfterChange } = parameters?.props?.[
+  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onChange } = parameters?.props?.[
     'bx-toggle'
   ];
   return (
@@ -30,7 +30,7 @@ export const defaultStory = ({ parameters }) => {
       small={small}
       uncheckedText={uncheckedText}
       value={value}
-      onAfterChange={onAfterChange}
+      onChange={onChange}
     />
   );
 };

--- a/src/components/toggle/toggle-story-vue.ts
+++ b/src/components/toggle/toggle-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,7 +23,7 @@ export const defaultStory = ({ parameters }) => ({
       :small="small"
       :unchecked-text="uncheckedText"
       :value="value"
-      @bx-toggle-changed="onAfterChange"
+      @bx-toggle-changed="onChange"
     ></bx-toggle>
   `,
   ...createVueBindingsFromProps(parameters?.props?.['bx-toggle']),

--- a/src/components/toggle/toggle-story.ts
+++ b/src/components/toggle/toggle-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,7 +16,7 @@ import './toggle';
 import storyDocs from './toggle-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
-  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onAfterChange } =
+  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onChange } =
     parameters?.props?.['bx-toggle'] ?? {};
   return html`
     <bx-toggle
@@ -28,7 +28,7 @@ export const defaultStory = ({ parameters }) => {
       ?small="${small}"
       unchecked-text="${ifNonNull(uncheckedText)}"
       value="${ifNonNull(value)}"
-      @bx-toggle-changed="${onAfterChange}"
+      @bx-toggle-changed="${onChange}"
     ></bx-toggle>
   `;
 };
@@ -53,7 +53,7 @@ export default {
         small: boolean('Use small variant (small)', false),
         uncheckedText: textNullable('Text for unchecked state (unchecked-text)', 'Off'),
         value: textNullable('Value (value)', ''),
-        onAfterChange: action('bx-toggle-changed'),
+        onChange: action('bx-toggle-changed'),
       }),
     },
   },

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -86,7 +86,7 @@ class BXToggle extends BXCheckbox {
   /**
    * The name of the custom event fired after this changebox changes its checked state.
    */
-  static get eventAfterChange() {
+  static get eventChange() {
     return `${prefix}-toggle-changed`;
   }
 

--- a/src/directives-angular/checkbox.ts
+++ b/src/directives-angular/checkbox.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@ const host = {
   '(blur)': 'onTouched()',
 };
 
-// NOTE: Referring `BXCheckbox.eventAfterChange` seems to cause ng-packagr to package up `src/components/checkbox.ts` code,
+// NOTE: Referring `BXCheckbox.eventChange` seems to cause ng-packagr to package up `src/components/checkbox.ts` code,
 // Which is not desirable
 host[`(${prefix}-checkbox-changed)`] = 'onChange($event.target.checked)';
 

--- a/src/directives-angular/slider.ts
+++ b/src/directives-angular/slider.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@ const host = {
   '(blur)': 'onTouched()',
 };
 
-// NOTE: Referring `BXSlider.eventAfterChange` seems to cause ng-packagr to package up `src/components/slider.ts` code,
+// NOTE: Referring `BXSlider.eventChange` seems to cause ng-packagr to package up `src/components/slider.ts` code,
 // Which is not desirable
 host[`(${prefix}-slider-changed)`] = 'onChange($event.detail.value)';
 

--- a/src/directives-angular/toggle.ts
+++ b/src/directives-angular/toggle.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,7 +17,7 @@ const host = {
   '(blur)': 'onTouched()',
 };
 
-// NOTE: Referring `BXCheckbox.eventAfterChange` seems to cause ng-packagr to package up `src/components/checkbox.ts` code,
+// NOTE: Referring `BXCheckbox.eventChange` seems to cause ng-packagr to package up `src/components/checkbox.ts` code,
 // Which is not desirable
 host[`(${prefix}-toggle-changed)`] = 'onChange($event.target.checked)';
 


### PR DESCRIPTION
To `eventSomething`, so we better align to native event's `onbeforeinput`/`oninput` combination.

The auto-generated React components also will have `onSomething` instead of `onAfterSomething`.