### PR TITLE
chore(devenv): support Props doc block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+custom-elements.json
 docs/js
 es
 node_modules

--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,12 +10,15 @@
 import '../src/polyfills';
 import { html } from 'lit-html'; // eslint-disable-line import/first
 import addons from '@storybook/addons';
-import { configure, addDecorator, addParameters } from '@storybook/web-components'; // eslint-disable-line import/first
+import { configure, addDecorator, addParameters, setCustomElements } from '@storybook/web-components'; // eslint-disable-line import/first
 import { withKnobs } from '@storybook/addon-knobs';
 import './components/focus-trap/focus-trap';
+import customElementsMetadata from '../custom-elements.json';
 import { CURRENT_THEME } from './addon-carbon-theme/shared';
 import theme from './theme';
 import containerStyles from './_container.scss'; // eslint-disable-line import/first
+
+setCustomElements(customElementsMetadata);
 
 if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
   document.documentElement.setAttribute('dir', 'rtl');

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Vue users can use our components in the same manner as native HTML tags, without
 
 1. Fork this repository and clone it
 2. `yarn install`
-3. `yarn storybook`
+3. `yarn wca && yarn storybook`
 
 ## Running React/Angular/Vue Storybook demo
 
@@ -168,8 +168,9 @@ Vue users can use our components in the same manner as native HTML tags, without
 
 View available web components at: https://carbon-custom-elements.netlify.com/. You can see usage information in several ways:
 
-1. Clicking the **KNOBS** tab at the bottom and changing values there. Most knobs are shown as something like `Button kind (kind)`, where `kind` is the attribute name
-2. Clicking the **ACTION LOGGER** tab at the bottom and interacting with the selected component. You may see something like `bx-modal-closed` which typically indicates that an event with such event type is fired. You can also expand the twistie to see the details of the event
+1. Going to Docs tab, where it shows the usage and available attributes, properties and custom events.
+2. Clicking the **KNOBS** tab at the bottom and changing values there. Most knobs are shown as something like `Button kind (kind)`, where `kind` is the attribute name
+3. Clicking the **ACTION LOGGER** tab at the bottom and interacting with the selected component. You may see something like `bx-modal-closed` which typically indicates that an event with such event type is fired. You can also expand the twistie to see the details of the event
 
 ## Browser support
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "bugs": "https://github.com/carbon-design-system/carbon-custom-elements/issues",
   "files": [
     "es/**/*",
-    "scss/**/*"
+    "scss/**/*",
+    "custom-elements.json"
   ],
   "keywords": [
     "carbon",
@@ -22,11 +23,11 @@
     "web components"
   ],
   "scripts": {
-    "build": "gulp build && yarn build:ngc",
+    "build": "gulp build && yarn build:ngc && yarn wca",
     "build:ngc": "yarn build:ngc:esm2015 && yarn build:ngc:esm5",
     "build:ngc:esm2015": "ngc -p tsconfig-angular-esm2015.json",
     "build:ngc:esm5": "ngc -p tsconfig-angular-esm5.json",
-    "ci-check": "yarn format:diff && yarn lint:src && yarn typecheck && yarn build && yarn test && yarn lint:dist",
+    "ci-check": "yarn wca && yarn format:diff && yarn lint:src && yarn typecheck && yarn build && yarn test && yarn lint:dist",
     "clean": "gulp clean",
     "format": "prettier --write \"**/*.{css,js,md,scss}\"",
     "format:diff": "prettier --check \"**/*.{css,js,md,scss}\"",
@@ -47,7 +48,8 @@
     "storybook": "start-storybook -p 9000",
     "storybook:angular": "start-storybook -p 9001 -c .storybook/angular",
     "storybook:react": "start-storybook -p 9002 -c .storybook/react",
-    "storybook:vue": "node node_modules/@storybook/vue/bin/index.js -p 9003 -c .storybook/vue"
+    "storybook:vue": "node node_modules/@storybook/vue/bin/index.js -p 9003 -c .storybook/vue",
+    "wca": "web-component-analyzer analyze src --outFile custom-elements.json"
   },
   "resolutions": {
     "babel-plugin-transform-vue-jsx": "^4.0.0",
@@ -202,6 +204,7 @@
     "vue-eslint-parser": "^6.0.0",
     "vue-loader": "^15.7.0",
     "vue-template-compiler": "^2.6.0",
+    "web-component-analyzer": "^1.0.0",
     "webpack": "^4.28.0",
     "zone.js": "^0.8.0"
   },

--- a/src/components/accordion/accordion-item.ts
+++ b/src/components/accordion/accordion-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,11 @@ const { prefix } = settings;
 
 /**
  * Accordion item.
+ * @element bx-accordion-item
+ * @fires bx-accordion-item-beingtoggled
+ *   The custom event fired before this accordion item is being toggled upon a user gesture.
+ *   Cancellation of this event stops the user-initiated action of toggling this accordion item.
+ * @fires bx-accordion-item-toggled - The custom event fired after this accordion item is toggled upon a user gesture.
  */
 @customElement(`${prefix}-accordion-item`)
 class BXAccordionItem extends FocusMixin(LitElement) {
@@ -56,19 +61,19 @@ class BXAccordionItem extends FocusMixin(LitElement) {
   };
 
   /**
-   * The assistive text for the expando button. Corresponds to `expando-assistive-text` attribute.
+   * The assistive text for the expando button.
    */
   @property({ attribute: 'expando-assistive-text' })
   expandoAssistiveText = 'Expand/Collapse';
 
   /**
-   * `true` if the check box should be open. Corresponds to the attribute with the same name.
+   * `true` if the check box should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;
 
   /**
-   * The title text. Corresponds to `title-text` attribute.
+   * The title text.
    */
   @property({ attribute: 'title-text' })
   titleText = '';

--- a/src/components/accordion/accordion-story.mdx
+++ b/src/components/accordion/accordion-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Accordion
 
@@ -14,3 +14,9 @@ A chevron is used to indicate the “expand/collapse” action, though the entir
 <Preview withToolbar>
   <Story id="accordion--default-story" height="200px" />
 </Preview>
+
+## `<bx-accordion-item>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-accordion-item open>`) and `false` means not setting the attribute (e.g. `<bx-accordion-item>` without `open` attribute).
+
+<Props of="bx-accordion-item" />

--- a/src/components/accordion/accordion.ts
+++ b/src/components/accordion/accordion.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Accordion container.
+ * @element bx-accordion
  */
 @customElement(`${prefix}-accordion`)
 class BXAccordion extends LitElement {

--- a/src/components/breadcrumb/breadcrumb-item.ts
+++ b/src/components/breadcrumb/breadcrumb-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Breadcrumb item.
+ * @element bx-breadcrumb-item
  */
 @customElement(`${prefix}-breadcrumb-item`)
 class BXBreadcrumbItem extends LitElement {

--- a/src/components/breadcrumb/breadcrumb-link.ts
+++ b/src/components/breadcrumb/breadcrumb-link.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,7 @@ const { prefix } = settings;
 
 /**
  * Link in breadcrumb.
+ * @element bx-breadcrumb-link
  */
 @customElement(`${prefix}-breadcrumb-link`)
 class BXBreadcrumbLink extends BXLink {

--- a/src/components/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Breadcrumb.
+ * @element bx-breadcrumb
  */
 @customElement(`${prefix}-breadcrumb`)
 class BXBreadcrumb extends LitElement {

--- a/src/components/button/button-story.mdx
+++ b/src/components/button/button-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Button
 
@@ -17,3 +17,9 @@ When words are not enough, icons can be used in buttons to better communicate wh
 <Preview withToolbar>
   <Story id="button--default-story" height="160px" />
 </Preview>
+
+## `<bx-btn>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-btn autofocus>`) and `false` means not setting the attribute (e.g. `<bx-btn>` without `autofocus` attribute).
+
+<Props of="bx-btn" />

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -43,6 +43,7 @@ export enum BUTTON_KIND {
 
 /**
  * Button.
+ * @element bx-btn
  */
 @customElement(`${prefix}-btn`)
 class BXButton extends FocusMixin(LitElement) {
@@ -80,70 +81,68 @@ class BXButton extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if the button should have input focus when the page loads. Corresponds to the attribute with the same name.
+   * `true` if the button should have input focus when the page loads.
    */
   @property({ type: Boolean, reflect: true })
   autofocus = false;
 
   /**
-   * `true` if the button should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the button should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The default file name, used if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The default file name, used if this button is rendered as `<a>`.
    */
   @property()
   download!: string;
 
   /**
-   * Link `href`. Corresponds to the attribute with the same name. If present, this button is rendered as `<a>`.
-   * Corresponds to the attribute with the same name.
+   * Link `href`. If present, this button is rendered as `<a>`.
    */
   @property()
   href!: string;
 
   /**
-   * The language of what `href` points to, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The language of what `href` points to, if this button is rendered as `<a>`.
    * @type {[type]}
    */
   @property()
   hreflang!: string;
 
   /**
-   * Button kind. Corresponds to the attribute with the same name.
+   * Button kind.
    */
   @property({ reflect: true })
   kind = BUTTON_KIND.PRIMARY;
 
   /**
-   * URLs to ping, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * URLs to ping, if this button is rendered as `<a>`.
    */
   @property()
   ping!: string;
 
   /**
-   * The link type, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The link type, if this button is rendered as `<a>`.
    */
   @property()
   rel!: string;
 
   /**
-   * `true` if the button should be a small variant. Corresponds to the attribute with the same name.
+   * `true` if the button should be a small variant.
    */
   @property({ type: Boolean, reflect: true })
   small = false;
 
   /**
-   * The link target, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The link target, if this button is rendered as `<a>`.
    */
   @property()
   target!: string;
 
   /**
    * The default behavior if the button is rendered as `<button>`. MIME type of the `target`if this button is rendered as `<a>`.
-   * Corresponds to the attribute with the same name.
    */
   @property()
   type!: string;

--- a/src/components/checkbox/checkbox-story.mdx
+++ b/src/components/checkbox/checkbox-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Check box
 
@@ -22,10 +22,10 @@ Indeterminate state:
 <bx-checkbox indeterminate label-text="Checkbox" />
 ```
 
-## Available attributes
+## `<bx-checkbox>` attributes, properties and events
 
-Please refer to Knobs tab at the bottom at: https://carbon-custom-elements.netlify.com/?path=/story/checkbox--default
+Unlike regular checkbox, `<bx-checkbox>` does _not_ fire `change` event. Please use `bx-checkbox-changed` event instead.
 
-## Event
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-checkbox checked>`) and `false` means not setting the attribute (e.g. `<bx-checkbox>` without `checked` attribute).
 
-Unlike regular checkbox, `<bx-checkbox>` does _not_ fire `change` event. Please use `input` event instead.
+<Props of="bx-checkbox" />

--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,8 @@ const { prefix } = settings;
 
 /**
  * Check box.
+ * @element bx-checkbox
+ * @fires bx-checkbox-changed - The custom event fired after this changebox changes its checked state.
  */
 @customElement(`${prefix}-checkbox`)
 class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
@@ -53,43 +55,43 @@ class BXCheckbox extends FocusMixin(FormMixin(LitElement)) {
   }
 
   /**
-   * `true` if the check box should be checked. Corresponds to the attribute with the same name.
+   * `true` if the check box should be checked.
    */
   @property({ type: Boolean, reflect: true })
   checked = false;
 
   /**
-   * `true` if the check box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the check box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * `true` if the label should be hidden. Corresponds to the attribute with the same name.
+   * `true` if the label should be hidden.
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-label' })
   hideLabel = false;
 
   /**
-   * `true` if the check box should show its UI of the indeterminate state. Corresponds to the attribute with the same name.
+   * `true` if the check box should show its UI of the indeterminate state.
    */
   @property({ type: Boolean, reflect: true })
   indeterminate = false;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
 
   /**
-   * The form name. Corresponds to the attribute with the same name.
+   * The form name.
    */
   @property()
   name!: string;
 
   /**
-   * The value. Corresponds to the attribute with the same name.
+   * The value.
    */
   @property()
   value!: string;

--- a/src/components/code-snippet/code-snippet-story.mdx
+++ b/src/components/code-snippet/code-snippet-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Code snippet
 
@@ -27,3 +27,7 @@ The Inline style is for code used within a block of text.
 <Preview withToolbar>
   <Story id="code-snippet--inline" height="160px" />
 </Preview>
+
+## `<bx-code-snippet>` attributes and properties
+
+<Props of="bx-code-snippet" />

--- a/src/components/code-snippet/code-snippet.ts
+++ b/src/components/code-snippet/code-snippet.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -93,6 +93,7 @@ const renderCode = ({
 
 /**
  * Basic code snippet.
+ * @element bx-code-snippet
  */
 @customElement(`${prefix}-code-snippet`)
 class BXCodeSnippet extends FocusMixin(LitElement) {
@@ -172,45 +173,43 @@ class BXCodeSnippet extends FocusMixin(LitElement) {
   private _preNode!: HTMLPreElement;
 
   /**
-   * An assistive text for screen reader to advice a DOM node is for code snippet. Corresponds to `code-assistive-text` attribute.
+   * An assistive text for screen reader to advice a DOM node is for code snippet.
    */
   @property({ attribute: 'code-assistive-text' })
   codeAssistiveText = 'code-snippet';
 
   /**
-   * The context content for the collapse button. Corresponds to `collapse-button-text` attribute.
+   * The context content for the collapse button.
    */
   @property({ attribute: 'collapse-button-text' })
   collapseButtonText = 'Show less';
 
   /**
    * An assistive text for screen reader to announce, telling that the button copies the content to the clipboard.
-   * Corresponds to `copy-button-assistive-text` attribute.
    */
   @property({ attribute: 'copy-button-assistive-text' })
   copyButtonAssistiveText = 'Copy to clipboard';
 
   /**
-   * The feedback text for the copy button. Corresponds to `copy-button-feedback-text` attribute.
+   * The feedback text for the copy button.
    */
   @property({ attribute: 'copy-button-feedback-text' })
   copyButtonFeedbackText = 'Copied!';
 
   /**
    * The number in milliseconds to determine how long the tooltip for the copy button should remain.
-   * Corresponds to `copy-button-feedback-timeout` attribute.
    */
   @property({ type: Number, attribute: 'copy-button-feedback-timeout' })
   copyButtonFeedbackTimeout = 2000;
 
   /**
-   * The context content for the expand button. Corresponds to `expand-button-text` attribute.
+   * The context content for the expand button.
    */
   @property({ attribute: 'expand-button-text' })
   expandButtonText = 'Show more';
 
   /**
-   * The type of code snippet. Corresponds to the attribute with the same name.
+   * The type of code snippet.
    */
   @property({ reflect: true })
   type = CODE_SNIPPET_TYPE.SINGLE;

--- a/src/components/combo-box/combo-box-item.ts
+++ b/src/components/combo-box/combo-box-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,7 @@ const { prefix } = settings;
 
 /**
  * Combo box item.
+ * @element bx-combo-box-item
  */
 @customElement(`${prefix}-combo-box-item`)
 class BXComboBoxItem extends BXDropdownItem {

--- a/src/components/combo-box/combo-box-story.mdx
+++ b/src/components/combo-box/combo-box-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Combo box
 
@@ -12,3 +12,15 @@ Selecting an item from the dropdown will close the drawer and the selected optio
 <Preview withToolbar>
   <Story id="combo-box--default-story" height="240px" />
 </Preview>
+
+## `<bx-combo-box>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-combo-box open>`) and `false` means not setting the attribute (e.g. `<bx-combo-box>` without `open` attribute).
+
+<Props of="bx-combo-box" />
+
+## `<bx-combo-box-item>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-combo-box-item disabled>`) and `false` means not setting the attribute (e.g. `<bx-combo-box-item>` without `disabled` attribute).
+
+<Props of="bx-combo-box-item" />

--- a/src/components/combo-box/combo-box.ts
+++ b/src/components/combo-box/combo-box.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,6 +20,11 @@ const { prefix } = settings;
 
 /**
  * Combo box.
+ * @element bx-combo-box
+ * @fires bx-combo-box-beingselected
+ *   The custom event fired before a combo box item is selected upon a user gesture.
+ *   Cancellation of this event stops changing the user-initiated selection.
+ * @fires bx-combo-box-selected - The custom event fired after a a combo box item is selected upon a user gesture.
  */
 @customElement(`${prefix}-combo-box`)
 class BXComboBox extends BXDropdown {
@@ -154,13 +159,13 @@ class BXComboBox extends BXDropdown {
   }
 
   /**
-   * The `aria-label` attribute for the icon to clear selection. Corresponds to `clear-selection-label` attribute.
+   * The `aria-label` attribute for the icon to clear selection.
    */
   @property({ attribute: 'clear-selection-label' })
   clearSelectionLabel = '';
 
   /**
-   * The `aria-label` attribute for the `<input>` for filtering. Corresponds to `input-label` attribute.
+   * The `aria-label` attribute for the `<input>` for filtering.
    */
   @property({ attribute: 'input-label' })
   inputLabel = '';

--- a/src/components/content-switcher/content-switcher-item.ts
+++ b/src/components/content-switcher/content-switcher-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,36 +18,38 @@ const { prefix } = settings;
 
 /**
  * Content switcher button.
+ * @element bx-content-switcher-item
  */
 @customElement(`${prefix}-content-switcher-item`)
 class BXContentSwitcherItem extends FocusMixin(LitElement) {
   /**
-   * `true` if this content switcher item should be disabled. Corresponds to the attribute with the same name.
+   * `true` if this content switcher item should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * `true` to hide the divider at the left. Corresponds to `hide-divider` attribute.
+   * `true` to hide the divider at the left.
+   * @private
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-divider' })
   hideDivider = false;
 
   /**
-   * `true` if the content switcher button should be selected. Corresponds to the attribute with the same name.
+   * `true` if the content switcher button should be selected.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   selected = false;
 
   /**
-   * The element ID of target panel. Corresponds to the attribute with the same name.
+   * The element ID of target panel.
    */
   @property()
   target!: string;
 
   /**
    * The `value` attribute that is set to the parent `<bx-content-switcher>` when this content switcher item is selected.
-   * Corresponds to the attribute with the same name.
    */
   @property()
   value = '';

--- a/src/components/content-switcher/content-switcher-story.mdx
+++ b/src/components/content-switcher/content-switcher-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Content switcher
 
@@ -7,3 +7,11 @@ Content switcher manipulates the content shown following an exclusive or “eith
 <Preview withToolbar>
   <Story id="content-switcher--default-story" height="160px" />
 </Preview>
+
+## `<bx-content-switcher>` attributes, properties and events
+
+<Props of="bx-content-switcher" />
+
+## `<bx-content-switcher-item>` attributes and properties
+
+<Props of="bx-content-switcher-item" />

--- a/src/components/content-switcher/content-switcher.ts
+++ b/src/components/content-switcher/content-switcher.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -42,6 +42,11 @@ export const NAVIGATION_DIRECTION = {
 
 /**
  * Content switcher.
+ * @element bx-content-switcher
+ * @fires bx-content-switcher-beingselected
+ *   The custom event fired before a content switcher item is selected upon a user gesture.
+ *   Cancellation of this event stops changing the user-initiated selection.
+ * @fires bx-content-switcher-selected - The custom event fired after a a content switcher item is selected upon a user gesture.
  */
 @customElement(`${prefix}-content-switcher`)
 class BXContentSwitcher extends LitElement {
@@ -147,7 +152,7 @@ class BXContentSwitcher extends LitElement {
   }
 
   /**
-   * The value of the selected item. Corresponds to the attribute with the same name.
+   * The value of the selected item.
    */
   @property({ reflect: true })
   value = '';

--- a/src/components/copy-button/copy-button-story.mdx
+++ b/src/components/copy-button/copy-button-story.mdx
@@ -1,0 +1,14 @@
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
+
+# Copy button
+
+Copy button provides the interface of copy button and its feedback tooltip.
+No actual copy is performed, but application can listen to `click` event of `<bx-copy-button>` and interact with the clipboard.
+
+<Preview withToolbar>
+  <Story id="copy-button--default-story" height="120px" />
+</Preview>
+
+## `<bx-copy-button>` attributes and properties
+
+<Props of="bx-copy-button" />

--- a/src/components/copy-button/copy-button-story.ts
+++ b/src/components/copy-button/copy-button-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,6 +13,7 @@ import { number } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './copy-button';
+import storyDocs from './copy-button-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { buttonAssistiveText, feedbackText, feedbackTimeout, onClick } = parameters?.props?.['bx-copy-button'] ?? {};
@@ -33,6 +34,9 @@ defaultStory.story = {
 export default {
   title: 'Copy button',
   parameters: {
+    docs: {
+      page: storyDocs,
+    },
     knobs: {
       'bx-copy-button': () => ({
         buttonAssistiveText: textNullable('Assistive text for the button (button-assistive-text)', ''),

--- a/src/components/copy-button/copy-button.ts
+++ b/src/components/copy-button/copy-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -75,6 +75,7 @@ export const _renderButton = ({
 
 /**
  * Copy button.
+ * @element bx-copy-button
  */
 @customElement(`${prefix}-copy-button`)
 class BXCopyButton extends FocusMixin(LitElement) {
@@ -100,19 +101,18 @@ class BXCopyButton extends FocusMixin(LitElement) {
 
   /**
    * An assistive text for screen reader to announce, telling that the button copies the content to the clipboard.
-   * Corresponds to `button-assistive-text` attribute.
    */
   @property({ attribute: 'button-assistive-text' })
   buttonAssistiveText = 'Copy to clipboard';
 
   /**
-   * The feedback text. Corresponds to `feedback-text` attribute.
+   * The feedback text.
    */
   @property({ attribute: 'feedback-text' })
   feedbackText = 'Copied!';
 
   /**
-   * The number in milliseconds to determine how long the tooltip should remain. Corresponds to `feedback-timeout` attribute.
+   * The number in milliseconds to determine how long the tooltip should remain.
    */
   @property({ type: Number, attribute: 'feedback-timeout' })
   feedbackTimeout = 2000;

--- a/src/components/data-table/data-table-story.mdx
+++ b/src/components/data-table/data-table-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Data table
 
@@ -248,3 +248,39 @@ html`
   </bx-data-table>
 `;
 ```
+
+## Attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-table sort>`) and `false` means not setting the attribute (e.g. `<bx-table>` without `sort` attribute).
+
+### `<bx-table>`
+
+<Props of="bx-table" />
+
+### `<bx-table-header-row>`
+
+<Props of="bx-table-header-row" />
+
+### `<bx-table-header-cell>`
+
+<Props of="bx-table-header-cell" />
+
+### `<bx-table-body>`
+
+<Props of="bx-table-body" />
+
+### `<bx-table-row>`
+
+<Props of="bx-table-row" />
+
+### `<bx-table-batch-actions>`
+
+<Props of="bx-table-batch-actions" />
+
+### `<bx-table-toolbar-content>`
+
+<Props of="bx-table-toolbar-content" />
+
+### `<bx-table-toolbar-search>`
+
+<Props of="bx-table-toolbar-search" />

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -270,31 +270,31 @@ class BXCEDemoDataTable extends LitElement {
   sortInfo?: TDemoSortInfo;
 
   /**
-   * `true` if the the table should support selection UI. Corresponds to `has-selection` attribute.
+   * `true` if the the table should support selection UI.
    */
   @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
   hasSelection = false;
 
   /**
-   * Number of items per page. Corresponds to `page-size` attribute.
+   * Number of items per page.
    */
   @property({ type: Number, attribute: 'page-size' })
   pageSize!: number;
 
   /**
-   * The table size. Corresponds to the attribute with the same name.
+   * The table size.
    */
   @property({ reflect: true })
   size = TABLE_SIZE.REGULAR;
 
   /**
-   * `true` if the zebra stripe should be shown. Corresponds to the attribute with the same name.
+   * `true` if the zebra stripe should be shown.
    */
   @property({ type: Boolean, reflect: true })
   zebra = false;
 
   /**
-   * The row number where current page start with, index that starts with zero. Corresponds to the attribute with the same name.
+   * The row number where current page start with, index that starts with zero.
    */
   @property({ type: Number })
   start = 0;
@@ -477,7 +477,9 @@ const defineDemoDataTable = (() => {
   return () => {
     if (!hasDemoDataTableDefined) {
       hasDemoDataTableDefined = true;
-      customElements.define('bx-ce-demo-data-table', BXCEDemoDataTable);
+      const ce = customElements;
+      // Prevents `web-component-analyzer` from harvesting `<bx-ce-demo-data-table>`
+      ce.define('bx-ce-demo-data-table', BXCEDemoDataTable);
     }
   };
 })();

--- a/src/components/data-table/table-batch-actions.ts
+++ b/src/components/data-table/table-batch-actions.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,8 @@ const { prefix } = settings;
 
 /**
  * Table batch actions.
+ * @element bx-table-batch-actions
+ * @fires bx-table-batch-actions-cancel-clicked - The custom event fired after the Cancel button is clicked.
  */
 @customElement(`${prefix}-table-batch-actions`)
 class BXTableBatchActions extends LitElement {
@@ -27,7 +29,7 @@ class BXTableBatchActions extends LitElement {
   }
 
   /**
-   * `true` if this batch actions bar should be active. Corresponds to the attribute with the same name.
+   * `true` if this batch actions bar should be active.
    */
   @property({ type: Boolean, reflect: true })
   active = false;
@@ -41,7 +43,6 @@ class BXTableBatchActions extends LitElement {
   /**
    * Numeric representation of the total number of items selected in a table.
    * This number is used to derive the selection message.
-   * Corresponds to `selected-rows-count` attribute.
    */
   @property({ type: Number, attribute: 'selected-rows-count' })
   selectedRowsCount = 0;

--- a/src/components/data-table/table-body.ts
+++ b/src/components/data-table/table-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,7 @@ const { prefix } = settings;
 
 /**
  * Data table body.
+ * @element bx-table-body
  */
 @customElement(`${prefix}-table-body`)
 class BXTableBody extends LitElement {
@@ -47,7 +48,7 @@ class BXTableBody extends LitElement {
   };
 
   /**
-   * `true` if the zebra stripe should be shown. Corresponds to the attribute with the same name.
+   * `true` if the zebra stripe should be shown.
    */
   @property({ type: Boolean, reflect: true })
   zebra = false;

--- a/src/components/data-table/table-cell-skeleton.ts
+++ b/src/components/data-table/table-cell-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Data table cell with skeleton content.
+ * @element bx-table-cell-skeleton
  */
 @customElement(`${prefix}-table-cell-skeleton`)
 class BXTableCellSkeleton extends BXTableCell {

--- a/src/components/data-table/table-cell.ts
+++ b/src/components/data-table/table-cell.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Data table cell.
+ * @element bx-table-cell
  */
 @customElement(`${prefix}-table-cell`)
 class BXTableCell extends LitElement {

--- a/src/components/data-table/table-head.ts
+++ b/src/components/data-table/table-head.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Data table header.
+ * @element bx-table-head
  */
 @customElement(`${prefix}-table-head`)
 class BXTableHead extends LitElement {

--- a/src/components/data-table/table-header-cell-skeleton.ts
+++ b/src/components/data-table/table-header-cell-skeleton.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Data table header cell with skeleton content.
+ * @element bx-table-header-cell-skeleton
  */
 @customElement(`${prefix}-table-header-cell-skeleton`)
 class BXTableHeaderCellSkeleton extends BXTableCell {}

--- a/src/components/data-table/table-header-cell.ts
+++ b/src/components/data-table/table-header-cell.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -66,6 +66,10 @@ export const TABLE_SORT_CYCLES = {
 
 /**
  * Data table header cell.
+ * @element bx-table-header-cell
+ * @fires bx-table-header-cell-sort
+ *   The custom event fired before a new sort direction is set upon a user gesture.
+ *   Cancellation of this event stops the user-initiated change in sort direction.
  */
 @customElement(`${prefix}-table-header-cell`)
 class BXTableHeaderCell extends FocusMixin(LitElement) {
@@ -123,19 +127,19 @@ class BXTableHeaderCell extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if this table header cell is of a primary sorting column. Corresponds to `sort-active` attribute.
+   * `true` if this table header cell is of a primary sorting column.
    */
   @property({ type: Boolean, reflect: true, attribute: 'sort-active' })
   sortActive = false;
 
   /**
-   * The table sort cycle in use. Corresponds to `sort-cycle` attribute.
+   * The table sort cycle in use.
    */
   @property({ reflect: true, attribute: 'sort-cycle' })
   sortCycle?: TABLE_SORT_CYCLE;
 
   /**
-   * The table sort direction. Corresponds to `sort-direction` attribute.
+   * The table sort direction.
    * If present, this table header cell will have a sorting UI.
    */
   @property({ reflect: true, attribute: 'sort-direction' })

--- a/src/components/data-table/table-header-row.ts
+++ b/src/components/data-table/table-header-row.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Data table header row.
+ * @element bx-table-header-row
  */
 @customElement(`${prefix}-table-header-row`)
 class BXTableHeaderRow extends BXTableRow {

--- a/src/components/data-table/table-row.ts
+++ b/src/components/data-table/table-row.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,10 @@ const { prefix } = settings;
 
 /**
  * Data table row.
+ * @element bx-table-row
+ * @fires bx-table-row-change-selection
+ *   The custom event fired before this row is selected/unselected upon a user gesture.
+ *   Cancellation of this event stops the user-initiated change in selection.
  */
 @customElement(`${prefix}-table-row`)
 class BXTableRow extends FocusMixin(LitElement) {
@@ -42,7 +46,7 @@ class BXTableRow extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if this table row should be disabled. Corresponds to the attribute with the same name.
+   * `true` if this table row should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -50,7 +54,7 @@ class BXTableRow extends FocusMixin(LitElement) {
   /**
    * `true` if this table row is placed at an even position in parent `<bx-table-body>`.
    * `<bx-table-body>` sets this property, _only_ in zebra stripe mode.
-   * Corresponds to the attribute with the same name.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   even = false;
@@ -58,38 +62,38 @@ class BXTableRow extends FocusMixin(LitElement) {
   /**
    * `true` if this table row is placed at an odd position in parent `<bx-table-body>`.
    * `<bx-table-body>` sets this property, _only_ in zebra stripe mode.
-   * Corresponds to the attribute with the same name.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   odd = false;
 
   /**
-   * `true` if this table row should work as an expando. Corresponds to the attribute with the same name.
+   * `true` if this table row should work as an expando.
    */
   @property({ type: Boolean, reflect: true })
   section = false;
 
   /**
-   * `true` if this table row should be selected. Corresponds to the attribute with the same name.
+   * `true` if this table row should be selected.
    */
   @property({ type: Boolean, reflect: true })
   selected = false;
 
   /**
-   * The `aria-label` attribute for the `<label>` for selection. Corresponds to `selection-label` attribute.
+   * The `aria-label` attribute for the `<label>` for selection.
    */
   @property({ attribute: 'selection-label' })
   selectionLabel = '';
 
   /**
-   * The `name` attribute for the `<input>` for selection. Corresponds to `selection-name` attribute.
+   * The `name` attribute for the `<input>` for selection.
    * If present, this table row will be a selectable one.
    */
   @property({ attribute: 'selection-name' })
   selectionName = '';
 
   /**
-   * The `value` attribute for the `<input>` for selection. Corresponds to `selection-value` attribute.
+   * The `value` attribute for the `<input>` for selection.
    */
   @property({ attribute: 'selection-value' })
   selectionValue = '';

--- a/src/components/data-table/table-toolbar-content.ts
+++ b/src/components/data-table/table-toolbar-content.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,11 +15,12 @@ const { prefix } = settings;
 
 /**
  * Table toolbar content.
+ * @element bx-table-toolbar-content
  */
 @customElement(`${prefix}-table-toolbar-content`)
 class BXTableToolbarContent extends LitElement {
   /**
-   * `true` if this batch actions bar is active. Corresponds to the attribute with the same name.
+   * `true` if this batch actions bar is active.
    */
   @property({ type: Boolean, reflect: true, attribute: 'has-batch-actions' })
   hasBatchActions = false;

--- a/src/components/data-table/table-toolbar-search.ts
+++ b/src/components/data-table/table-toolbar-search.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,8 @@ const { prefix } = settings;
 
 /**
  * Table toolbar search.
+ * @element bx-table-toolbar-search
+ * @fires bx-search-input - The custom event fired after the search content is changed upon a user gesture.
  */
 @customElement(`${prefix}-table-toolbar-search`)
 class BXTableToolbarSearch extends HostListenerMixin(BXSearch) {
@@ -64,13 +66,13 @@ class BXTableToolbarSearch extends HostListenerMixin(BXSearch) {
   }
 
   /**
-   * `true` if the search box should be expanded. Corresponds to the attribute with the same name.
+   * `true` if the search box should be expanded.
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
   /**
-   * The search box size. Corresponds to the attribute with the same name.
+   * The search box size.
    */
   @property({ reflect: true })
   size = SEARCH_SIZE.SMALL;

--- a/src/components/data-table/table-toolbar.ts
+++ b/src/components/data-table/table-toolbar.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Table toolbar.
+ * @element bx-table-toolbar
  */
 @customElement(`${prefix}-table-toolbar`)
 class BXTableToolbar extends LitElement {

--- a/src/components/data-table/table.ts
+++ b/src/components/data-table/table.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -41,17 +41,18 @@ export enum TABLE_SIZE {
 
 /**
  * Data table.
+ * @element bx-table
  */
 @customElement(`${prefix}-table`)
 class BXTable extends LitElement {
   /**
-   * The table size. Corresponds to the attribute with the same name.
+   * The table size.
    */
   @property({ reflect: true })
   size = TABLE_SIZE.REGULAR;
 
   /**
-   * `true` if this table should support sorting. Corresponds to the attribute with the same name.
+   * `true` if this table should support sorting.
    */
   @property({ type: Boolean, reflect: true })
   sort = false;

--- a/src/components/date-picker/date-picker-input.ts
+++ b/src/components/date-picker/date-picker-input.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -44,6 +44,7 @@ export enum DATE_PICKER_INPUT_KIND {
 
 /**
  * The input box for date picker.
+ * @element bx-date-picker-input
  */
 @customElement(`${prefix}-date-picker-input`)
 class BXDatePickerInput extends FocusMixin(LitElement) {
@@ -117,50 +118,49 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
   input!: HTMLInputElement;
 
   /**
-   * `true` if the check box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the check box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * `true` if the label should be hidden. Corresponds to the attribute with the same name.
+   * `true` if the label should be hidden.
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-label' })
   hideLabel = false;
 
   /**
    * Controls the invalid state and visibility of the `validityMessage`.
-   * Corresponds to the attribute with the same name.
    */
   @property({ type: Boolean, reflect: true })
   invalid = false;
 
   /**
-   * Date picker input kind. Corresponds to the attribute with the same name.
+   * Date picker input kind.
    */
   @property({ reflect: true })
   kind = DATE_PICKER_INPUT_KIND.SIMPLE;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText!: string;
 
   /**
-   * `true` if this date picker input should use the light UI variant. Corresponds to the attribute with the same name.
+   * `true` if this date picker input should use the light UI variant.
    */
   @property({ type: Boolean, reflect: true })
   light = false;
 
   /**
-   * The `pattern` attribute for the `<input>` in the shadow DOM. Corresponds to the attribute with the same name.
+   * The `pattern` attribute for the `<input>` in the shadow DOM.
    */
   @property()
   pattern!: string;
 
   /**
-   * The placeholder text. Corresponds to the attribute with the same name.
+   * The placeholder text.
    */
   @property()
   placeholder!: string;
@@ -168,26 +168,25 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
   /**
    * `true` if this date picker input should use the short UI variant.
    * Effective only when `kind` property is `DATE_PICKER_INPUT_KIND.SIMPLE`.
-   * Corresponds to the attribute with the same name.
    */
   @property({ type: Boolean, reflect: true })
   short = false;
 
   /**
-   * The `type` attribute for the `<input>` in the shadow DOM. Corresponds to the attribute with the same name.
+   * The `type` attribute for the `<input>` in the shadow DOM.
    */
   @property()
   type!: string;
 
   /**
-   * The validity message. Corresponds to `validity-message` attribute.
+   * The validity message.
    * If present and non-empty, this date picker input shows the UI of its invalid state.
    */
   @property({ attribute: 'validity-message' })
   validityMessage = '';
 
   /**
-   * The value. Corresponds to the attribute with the same name.
+   * The value.
    */
   @property()
   value!: string;

--- a/src/components/date-picker/date-picker-story.mdx
+++ b/src/components/date-picker/date-picker-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Date picker
 
@@ -27,3 +27,15 @@ A range Date Picker consists of two input fields and a calendar.
 <Preview withToolbar>
   <Story id="date-picker--range-with-calendar" height="480px" />
 </Preview>
+
+## `<bx-date-picker>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-date-picker open>`) and `false` means not setting the attribute (e.g. `<bx-date-picker>` without `open` attribute).
+
+<Props of="bx-date-picker" />
+
+## `<bx-date-picker-input>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-date-picker-input light>`) and `false` means not setting the attribute (e.g. `<bx-date-picker-input>` without `light` attribute).
+
+<Props of="bx-date-picker-input" />

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -52,6 +52,8 @@ enum DATE_PICKER_MODE {
 
 /**
  * Date picker.
+ * @element bx-date-picker
+ * @fires bx-date-picker-changed - The custom event fired on this element when Flatpickr updates its value.
  */
 @customElement(`${prefix}-date-picker`)
 class BXDatePicker extends LitElement {
@@ -259,7 +261,7 @@ class BXDatePicker extends LitElement {
   calendar: FlatpickrInstance | null = null;
 
   /**
-   * The date format to let Flatpickr use. Corresponds to `date-format` attribute.
+   * The date format to let Flatpickr use.
    */
   @property({ attribute: 'date-format' })
   dateFormat!: string;
@@ -271,20 +273,19 @@ class BXDatePicker extends LitElement {
   locale!: FlatpickrLocale;
 
   /**
-   * The date range that a user can pick in calendar dropdown. Corresponds to `enabled-range` attribute.
+   * The date range that a user can pick in calendar dropdown.
    */
   @property({ attribute: 'enabled-range' })
   enabledRange!: string;
 
   /**
-   * `true` if the date picker should be open. Corresponds to the attribute with the same name.
+   * `true` if the date picker should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;
 
   /**
    * The date(s) in ISO8601 format (date portion only), for range mode, '/' is used for separate start/end dates.
-   * Corresponds to the attribute with the same name.
    */
   @property()
   get value() {
@@ -509,13 +510,6 @@ class BXDatePicker extends LitElement {
    */
   static get eventFlatpickrError() {
     return `${prefix}-date-picker-flatpickr-error`;
-  }
-
-  /**
-   * The name of the custom event fired once the shadow DOM content if `<bx-date-picker-input>` is ready.
-   */
-  static get eventInputContentLoaded() {
-    return `${prefix}-date-picker-input-content-loaded`;
   }
 
   /**

--- a/src/components/dropdown/dropdown-item.ts
+++ b/src/components/dropdown/dropdown-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,31 +15,33 @@ const { prefix } = settings;
 
 /**
  * Dropdown item.
+ * @element bx-dropdown-item
  */
 @customElement(`${prefix}-dropdown-item`)
 class BXDropdownItem extends LitElement {
   /**
-   * `true` if this dropdown item should be disabled. Corresponds to the attribute with the same name.
+   * `true` if this dropdown item should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * `true` if this dropdown item should be highlighted. Corresponds to the attribute with the same name.
+   * `true` if this dropdown item should be highlighted.
    * If `true`, parent `<dropdown>` selects/deselects this dropdown item upon keyboard interaction.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   highlighted = false;
 
   /**
-   * `true` if this dropdown item should be selected. Corresponds to the attribute with the same name.
+   * `true` if this dropdown item should be selected.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   selected = false;
 
   /**
    * The `value` attribute that is set to the parent `<bx-dropdown>` when this dropdown item is selected.
-   * Corresponds to the attribute with the same name.
    */
   @property()
   value = '';

--- a/src/components/dropdown/dropdown-story.mdx
+++ b/src/components/dropdown/dropdown-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Dropdown
 
@@ -7,3 +7,15 @@ Dropdown presents a list of options that can be used to filter or sort existing 
 <Preview withToolbar>
   <Story id="dropdown--default-story" height="240px" />
 </Preview>
+
+## `<bx-dropdown>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-dropdown open>`) and `false` means not setting the attribute (e.g. `<bx-dropdown>` without `open` attribute).
+
+<Props of="bx-dropdown" />
+
+## `<bx-dropdown-item>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-dropdown-item disabled>`) and `false` means not setting the attribute (e.g. `<bx-dropdown-item>` without `disabled` attribute).
+
+<Props of="bx-dropdown-item" />

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -75,6 +75,11 @@ export enum DROPDOWN_TYPE {
 
 /**
  * Dropdown.
+ * @element bx-dropdown
+ * @fires bx-dropdown-beingselected
+ *   The custom event fired before a dropdown item is selected upon a user gesture.
+ *   Cancellation of this event stops changing the user-initiated selection.
+ * @fires bx-dropdown-selected - The custom event fired after a a dropdown item is selected upon a user gesture.
  */
 @customElement(`${prefix}-dropdown`)
 class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
@@ -359,13 +364,13 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
   /* eslint-enable class-methods-use-this */
 
   /**
-   * `true` if this dropdown should be disabled. Corresponds to the attribute with the same name.
+   * `true` if this dropdown should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The helper text. Corresponds to `helper-text` attribute.
+   * The helper text.
    */
   @property({ attribute: 'helper-text' })
   helperText = '';
@@ -377,19 +382,19 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
   invalid = false;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
 
   /**
-   * `true` if this dropdown should use the light UI variant. Corresponds to the attribute with the same name.
+   * `true` if this dropdown should use the light UI variant.
    */
   @property({ type: Boolean, reflect: true })
   light = false;
 
   /**
-   * `true` if this dropdown should be open. Corresponds to the attribute with the same name.
+   * `true` if this dropdown should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;
@@ -407,37 +412,37 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
   selectedItemAssistiveText = 'Selected an item.';
 
   /**
-   * The `aria-label` attribute for the UI indicating the closed state. Corresponds to `toggle-label-closed` attribute.
+   * The `aria-label` attribute for the UI indicating the closed state.
    */
   @property({ attribute: 'toggle-label-closed' })
   toggleLabelClosed = '';
 
   /**
-   * The `aria-label` attribute for the UI indicating the open state. Corresponds to `toggle-label-open` attribute.
+   * The `aria-label` attribute for the UI indicating the open state.
    */
   @property({ attribute: 'toggle-label-open' })
   toggleLabelOpen = '';
 
   /**
-   * The content of the trigger button. Corresponds to `trigger-content` attribute.
+   * The content of the trigger button.
    */
   @property({ attribute: 'trigger-content' })
   triggerContent = '';
 
   /**
-   * `true` if this dropdown should use the inline UI variant. Corresponds to the attribute with the same name.
+   * `true` if this dropdown should use the inline UI variant.
    */
   @property({ reflect: true })
   type = DROPDOWN_TYPE.REGULAR;
 
   /**
-   * The validity message. Corresponds to `validity-message` attribute.
+   * The validity message.
    */
   @property({ attribute: 'validity-message' })
   validityMessage = '';
 
   /**
-   * The value of the selected item. Corresponds to the attribute with the same name.
+   * The value of the selected item.
    */
   @property({ reflect: true })
   value = '';

--- a/src/components/floating-menu/floating-menu-trigger.ts
+++ b/src/components/floating-menu/floating-menu-trigger.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,7 +12,7 @@
  */
 interface BXFloatingMenuTrigger extends HTMLElement {
   /**
-   * `true` if the menu should be open. Corresponds to the attribute with the same name.
+   * `true` if the menu should be open.
    */
   open: boolean;
 

--- a/src/components/floating-menu/floating-menu.ts
+++ b/src/components/floating-menu/floating-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -169,17 +169,17 @@ abstract class BXFloatingMenu extends HostListenerMixin(FocusMixin(LitElement)) 
   protected parent: BXFloatingMenuTrigger | null = null;
 
   /**
-   * How the menu is aligned to the trigger button. Corresponds to the attribute with the same name.
+   * How the menu is aligned to the trigger button.
    */
   abstract alignment: FLOATING_MENU_ALIGNMENT;
 
   /**
-   * The menu direction. Corresponds to the attribute with the same name.
+   * The menu direction.
    */
   abstract direction: FLOATING_MENU_DIRECTION;
 
   /**
-   * `true` if the menu should be open. Corresponds to the attribute with the same name.
+   * `true` if the menu should be open.
    */
   abstract open: boolean;
 

--- a/src/components/form/form-item.ts
+++ b/src/components/form/form-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Presentational element for form items
+ * @element bx-form-item
  */
 @customElement(`${prefix}-form-item`)
 export default class BXFormItem extends LitElement {

--- a/src/components/inline-loading/inline-loading-story.mdx
+++ b/src/components/inline-loading/inline-loading-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Inline loading
 
@@ -14,3 +14,7 @@ This could be in a table, after a primary or secondary button click, or even in 
 <Preview withToolbar>
   <Story id="inline-loading--default-story" height="160px" />
 </Preview>
+
+## `<bx-inline-loading>` attributes and properties
+
+<Props of="bx-inline-loading" />

--- a/src/components/inline-loading/inline-loading.ts
+++ b/src/components/inline-loading/inline-loading.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -45,6 +45,7 @@ export enum INLINE_LOADING_STATE {
 
 /**
  * Lnline loading spinner.
+ * @element bx-inline-loading
  */
 @customElement(`${prefix}-inline-loading`)
 class BXInlineLoading extends LitElement {
@@ -79,7 +80,7 @@ class BXInlineLoading extends LitElement {
   }
 
   /**
-   * The loading status. Corresponds to the attribute with the same name.
+   * The loading status.
    */
   @property({ reflect: true })
   status = INLINE_LOADING_STATE.ACTIVE;

--- a/src/components/input/input-story.mdx
+++ b/src/components/input/input-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Input
 
@@ -8,3 +8,9 @@ A single line field is used when the input anticipated by the user is a single l
 <Preview withToolbar>
   <Story id="input--default-story" height="160px" />
 </Preview>
+
+## `<bx-input>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-input required>`) and `false` means not setting the attribute (e.g. `<bx-input>` without `required` attribute).
+
+<Props of="bx-input" />

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -32,6 +32,10 @@ export enum INPUT_TYPE {
 
 /**
  * Input element. Supports all the usual attributes for textual input types
+ * @element bx-input
+ * @slot helper-text - The helper text.
+ * @slot label-text - The label text.
+ * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-input`)
 export default class BXInput extends FormMixin(LitElement) {
@@ -70,7 +74,7 @@ export default class BXInput extends FormMixin(LitElement) {
   disabled = false;
 
   /**
-   * The helper text. Corresponds to `helper-text` attribute.
+   * The helper text.
    */
   @property({ attribute: 'helper-text' })
   helperText = '';
@@ -82,7 +86,7 @@ export default class BXInput extends FormMixin(LitElement) {
   invalid = false;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
@@ -124,8 +128,7 @@ export default class BXInput extends FormMixin(LitElement) {
   type = INPUT_TYPE.TEXT;
 
   /**
-   * The validity message. Corresponds to `validity-message` attribute.
-   * If present and non-empty, this multi select shows the UI of its invalid state.
+   * The validity message. If present and non-empty, this input shows the UI of its invalid state.
    */
   @property({ attribute: 'validity-message' })
   validityMessage = '';

--- a/src/components/link/link-story.mdx
+++ b/src/components/link/link-story.mdx
@@ -1,0 +1,15 @@
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
+
+# Link
+
+Represents a link. Provided for convenience purpose, you can alternatively use `<a class="bx--link">` with Carbon style in place in light DOM.
+
+<Preview withToolbar>
+  <Story id="link--default-story" height="120px" />
+</Preview>
+
+## `<bx-link>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-link disabled>`) and `false` means not setting the attribute (e.g. `<bx-link>` without `disabled` attribute).
+
+<Props of="bx-link" />

--- a/src/components/link/link-story.ts
+++ b/src/components/link/link-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,6 +13,7 @@ import { boolean } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './link';
+import storyDocs from './link-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
   const { disabled, href, onClick } = parameters?.props?.['bx-link'] ?? {};
@@ -30,6 +31,9 @@ defaultStory.story = {
 export default {
   title: 'Link',
   parameters: {
+    docs: {
+      page: storyDocs,
+    },
     knobs: {
       'bx-link': () => ({
         disabled: boolean('Disabled (disabled)', false),

--- a/src/components/link/link.ts
+++ b/src/components/link/link.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,7 @@ const { prefix } = settings;
 
 /**
  * Link.
+ * @element bx-link
  */
 @customElement(`${prefix}-link`)
 class BXLink extends FocusMixin(LitElement) {
@@ -33,52 +34,49 @@ class BXLink extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if the button should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the button should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The default file name, used if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The default file name, used if this button is rendered as `<a>`.
    */
   @property()
   download!: string;
 
   /**
-   * Link `href`. Corresponds to the attribute with the same name. If present, this button is rendered as `<a>`.
-   * Corresponds to the attribute with the same name.
+   * Link `href`. If present, this button is rendered as `<a>`.
    */
   @property()
   href!: string;
 
   /**
-   * The language of what `href` points to, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
-   * @type {[type]}
+   * The language of what `href` points to, if this button is rendered as `<a>`.
    */
   @property()
   hreflang!: string;
 
   /**
-   * URLs to ping, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * URLs to ping, if this button is rendered as `<a>`.
    */
   @property()
   ping!: string;
 
   /**
-   * The link type, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The link type, if this button is rendered as `<a>`.
    */
   @property()
   rel!: string;
 
   /**
-   * The link target, if this button is rendered as `<a>`. Corresponds to the attribute with the same name.
+   * The link target, if this button is rendered as `<a>`.
    */
   @property()
   target!: string;
 
   /**
    * The default behavior if the button is rendered as `<button>`. MIME type of the `target`if this button is rendered as `<a>`.
-   * Corresponds to the attribute with the same name.
    */
   @property()
   type!: string;

--- a/src/components/list/list-item.ts
+++ b/src/components/list/list-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,8 @@ const { prefix } = settings;
 
 /**
  * List item.
+ * @element bx-list-item
+ * @slot nested - The nested child list.
  */
 @customElement(`${prefix}-list-item`)
 class BXListItem extends LitElement {
@@ -35,7 +37,6 @@ class BXListItem extends LitElement {
   /**
    * `true` if this list item is a child of a nested list.
    * `<bx-ordered-list>` or `<bx-unordered-list>` automatically sets this property.
-   * Corresponds to the attribute with the same name.
    */
   @property({ type: Boolean, reflect: true })
   nested = false;

--- a/src/components/list/list-story.mdx
+++ b/src/components/list/list-story.mdx
@@ -1,0 +1,23 @@
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
+
+# List
+
+Represents a list.
+
+## Ordered list
+
+<Preview withToolbar>
+  <Story id="list--ordered" height="200px" />
+</Preview>
+
+## Unordered list
+
+<Preview withToolbar>
+  <Story id="list--unordered" height="200px" />
+</Preview>
+
+## `<bx-list-item>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-list nested>`) and `false` means not setting the attribute (e.g. `<bx-list>` without `nested` attribute).
+
+<Props of="bx-list-item" />

--- a/src/components/list/list-story.ts
+++ b/src/components/list/list-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,6 +11,7 @@ import { html } from 'lit-element';
 import './ordered-list';
 import './unordered-list';
 import './list-item';
+import storyDocs from './list-story.mdx';
 
 export const ordered = () => html`
   <bx-ordered-list>
@@ -54,4 +55,9 @@ export const unordered = () => html`
 
 export default {
   title: 'List',
+  parameters: {
+    docs: {
+      page: storyDocs,
+    },
+  },
 };

--- a/src/components/loading/loading-story.mdx
+++ b/src/components/loading/loading-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Loading
 
@@ -9,3 +9,9 @@ Although it may not be obvious what is occurring on the back-end, we can communi
 <Preview withToolbar>
   <Story id="loading--default-story" height="320px" />
 </Preview>
+
+## `<bx-loading>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-loading inactive>`) and `false` means not setting the attribute (e.g. `<bx-loading>` without `inactive` attribute).
+
+<Props of="bx-loading" />

--- a/src/components/loading/loading.ts
+++ b/src/components/loading/loading.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,23 +18,24 @@ const { prefix } = settings;
 
 /**
  * Spinner indicating loading state.
+ * @element bx-loading
  */
 @customElement(`${prefix}-loading`)
 class BXLoading extends LitElement {
   /**
-   * The assistive text for the spinner icon. Corresponds to 'assistive-text' attribute.
+   * The assistive text for the spinner icon.
    */
   @property({ attribute: 'assistive-text' })
   assistiveText = 'Loading';
 
   /**
-   * Spinner type. Corresponds to the attribute with the same name.
+   * Spinner type.
    */
   @property()
   type = LOADING_TYPE.REGULAR;
 
   /**
-   * `true` if spinner should stop. Corresponds to the attribute with the same name.
+   * `true` if spinner should stop.
    */
   @property({ type: Boolean, reflect: true })
   inactive = false;

--- a/src/components/modal/modal-body.ts
+++ b/src/components/modal/modal-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Modal body.
+ * @element bx-modal-body
  */
 @customElement(`${prefix}-modal-body`)
 class BXModalBody extends LitElement {

--- a/src/components/modal/modal-close-button.ts
+++ b/src/components/modal/modal-close-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,7 @@ const { prefix } = settings;
 
 /**
  * Modal close button.
+ * @element bx-modal-close-button
  */
 @customElement(`${prefix}-modal-close-button`)
 class BXModalCloseButton extends LitElement {

--- a/src/components/modal/modal-footer.ts
+++ b/src/components/modal/modal-footer.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Modal footer.
+ * @element bx-modal-footer
  */
 @customElement(`${prefix}-modal-footer`)
 class BXModalFooter extends LitElement {

--- a/src/components/modal/modal-header.ts
+++ b/src/components/modal/modal-header.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Modal header.
+ * @element bx-modal-header
  */
 @customElement(`${prefix}-modal-header`)
 class BXModalHeader extends LitElement {

--- a/src/components/modal/modal-heading.ts
+++ b/src/components/modal/modal-heading.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Modal heading.
+ * @element bx-modal-heading
  */
 @customElement(`${prefix}-modal-heading`)
 class BXModalHeading extends LitElement {

--- a/src/components/modal/modal-label.ts
+++ b/src/components/modal/modal-label.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Modal label.
+ * @element bx-modal-label
  */
 @customElement(`${prefix}-modal-label`)
 class BXModalLabel extends LitElement {

--- a/src/components/modal/modal-story.mdx
+++ b/src/components/modal/modal-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Modal
 
@@ -22,3 +22,9 @@ While effective when used correctly, modals should be used sparingly to limit di
 It means that hitting tab key at the last sequential-focusable element in `<bx-modal>` puts focus on the first sequential-focusable element, and hitting Shift-tab key at the first sequential-focusable element in `<bx-modal>` puts focus on the last sequential-focusable element.
 
 Once `<bx-modal>` gets closed, it puts focus on the last focused element before it got open, typically the launcher button.
+
+## `<bx-modal>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-modal open>`) and `false` means not setting the attribute (e.g. `<bx-modal>` without `open` attribute).
+
+<Props of="bx-modal" />

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,14 @@ const PRECEDING = Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_CONT
 // eslint-disable-next-line no-bitwise
 const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_CONTAINED_BY;
 
+/**
+ * Modal.
+ * @element bx-modal
+ * @fires bx-modal-beingclosed
+ *   The custom event fired before this modal is being closed upon a user gesture.
+ *   Cancellation of this event stops the user-initiated action of closing this modal.
+ * @fires bx-modal-closed - The custom event fired after this modal is closed upon a user gesture.
+ */
 @customElement(`${prefix}-modal`)
 class BXModal extends HostListenerMixin(LitElement) {
   /**
@@ -138,13 +146,13 @@ class BXModal extends HostListenerMixin(LitElement) {
   }
 
   /**
-   * The additional CSS class names for the container <div> of the element. Corresponds to `container-class` attribute.
+   * The additional CSS class names for the container <div> of the element.
    */
   @property({ attribute: 'container-class' })
   containerClass = '';
 
   /**
-   * `true` if the modal should be open. Corresponds to the attribute with the same name.
+   * `true` if the modal should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;

--- a/src/components/multi-select/multi-select-item.ts
+++ b/src/components/multi-select/multi-select-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,11 +17,12 @@ const { prefix } = settings;
 
 /**
  * Multi select item.
+ * @element bx-multi-select-item
  */
 @customElement(`${prefix}-multi-select-item`)
 class BXMultiSelectItem extends BXDropdownItem {
   /**
-   * The `name` attribute for the `<input>` for selection. Corresponds to `selection-name` attribute.
+   * The `name` attribute for the `<input>` for selection.
    */
   @property({ attribute: 'selection-name' })
   selectionName = '';

--- a/src/components/multi-select/multi-select-story.mdx
+++ b/src/components/multi-select/multi-select-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Multi select
 
@@ -52,3 +52,15 @@ When user attempts to change selection in multi select item, `bx-multi-select-be
 ## Note on keyboard navigation
 
 Similar to native `<select>`, `<bx-multi-select>` keeps focusing on itself even while the menu is open and user is navigating through arrow keys. Given that, `<bx-multi-select-item>` does not handle keyboard events by itself. `<bx-multi-select>` takes care of handling keyboard events for multi select items and updates `<bx-multi-select-item>`.
+
+## `<bx-multi-select>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-multi-select open>`) and `false` means not setting the attribute (e.g. `<bx-multi-select>` without `open` attribute).
+
+<Props of="bx-multi-select" />
+
+## `<bx-multi-select-item>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-multi-select-item disabled>`) and `false` means not setting the attribute (e.g. `<bx-multi-select-item>` without `disabled` attribute).
+
+<Props of="bx-multi-select-item" />

--- a/src/components/multi-select/multi-select.ts
+++ b/src/components/multi-select/multi-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,11 @@ const { prefix } = settings;
 
 /**
  * Multi select.
+ * @element bx-multi-select
+ * @fires bx-multi-select-beingselected
+ *   The custom event fired before a multi select item is selected upon a user gesture.
+ *   Cancellation of this event stops changing the user-initiated selection.
+ * @fires bx-multi-select-selected - The custom event fired after a a multi select item is selected upon a user gesture.
  */
 @customElement(`${prefix}-multi-select`)
 class BXMultiSelect extends BXDropdown {
@@ -100,7 +105,7 @@ class BXMultiSelect extends BXDropdown {
   }
 
   /**
-   * The `aria-label` attribute for the icon to clear selection. Corresponds to `clear-selection-label` attribute.
+   * The `aria-label` attribute for the icon to clear selection.
    */
   @property({ attribute: 'clear-selection-label' })
   clearSelectionLabel = '';

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -1,19 +1,19 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import settings from 'carbon-components/es/globals/js/settings';
-import { ifDefined } from 'lit-html/directives/if-defined';
-import { html, svg, property, customElement, LitElement } from 'lit-element';
-import Close20 from '@carbon/icons/lib/close/20';
 import CheckmarkFilled20 from '@carbon/icons/lib/checkmark--filled/20';
-import WarningFilled20 from '@carbon/icons/lib/warning--filled/20';
+import Close20 from '@carbon/icons/lib/close/20';
 import ErrorFilled20 from '@carbon/icons/lib/error--filled/20';
+import WarningFilled20 from '@carbon/icons/lib/warning--filled/20';
+import settings from 'carbon-components/es/globals/js/settings';
+import { customElement, html, LitElement, property, svg } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import FocusMixin from '../../globals/mixins/focus';
 import styles from './inline-notification.scss';
 
@@ -73,6 +73,13 @@ const iconsForKinds = {
 
 /**
  * Inline notification.
+ * @element bx-inline-notification
+ * @slot subtitle - The subtitle.
+ * @slot title - The title.
+ * @fires bx-notification-beingclosed
+ *   The custom event fired before this notification is being closed upon a user gesture.
+ *   Cancellation of this event stops the user-initiated action of closing this notification.
+ * @fires bx-notification-closed - The custom event fired after this notification is closed upon a user gesture.
  */
 @customElement(`${prefix}-inline-notification`)
 class BXInlineNotification extends FocusMixin(LitElement) {
@@ -159,31 +166,31 @@ class BXInlineNotification extends FocusMixin(LitElement) {
   }
 
   /**
-   * The a11y text for the close button. Corresponds to `close-button-label` attribute.
+   * The a11y text for the close button.
    */
   @property({ attribute: 'close-button-label' })
   closeButtonLabel!: string;
 
   /**
-   * `true` to hide the close button. Corresponds to `hide-close-button` attribute.
+   * `true` to hide the close button.
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-close-button' })
   hideCloseButton = false;
 
   /**
-   * The a11y text for the icon. Corresponds to `icon-label` attribute.
+   * The a11y text for the icon.
    */
   @property({ attribute: 'icon-label' })
   iconLabel!: string;
 
   /**
-   * Notification kind. Corresponds to the attribute with the same name.
+   * Notification kind.
    */
   @property({ reflect: true })
   kind = NOTIFICATION_KIND.SUCCESS;
 
   /**
-   * `true` if the notification should be open. Corresponds to the attribute with the same name.
+   * `true` if the notification should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = true;

--- a/src/components/notification/notification-story.mdx
+++ b/src/components/notification/notification-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Notification
 
@@ -19,3 +19,15 @@ Toasts are a non-modal, time-based window elements used to display short message
 <Preview withToolbar>
   <Story id="notifications--toast" height="240px" />
 </Preview>
+
+## `<bx-inline-notification>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-inline-notification open>`) and `false` means not setting the attribute (e.g. `<bx-inline-notification>` without `open` attribute).
+
+<Props of="bx-inline-notification" />
+
+## `<bx-toast-notification>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-toast-notification open>`) and `false` means not setting the attribute (e.g. `<bx-toast-notification>` without `open` attribute).
+
+<Props of="bx-toast-notification" />

--- a/src/components/notification/toast-notification.ts
+++ b/src/components/notification/toast-notification.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,13 @@ const { prefix } = settings;
 
 /**
  * Toast notification.
+ * @element bx-toast-notification
+ * @slot subtitle - The subtitle.
+ * @slot title - The title.
+ * @fires bx-notification-beingclosed
+ *   The custom event fired before this notification is being closed upon a user gesture.
+ *   Cancellation of this event stops the user-initiated action of closing this notification.
+ * @fires bx-notification-closed - The custom event fired after this notification is closed upon a user gesture.
  */
 @customElement(`${prefix}-toast-notification`)
 class BXToastNotification extends BXInlineNotification {
@@ -34,7 +41,7 @@ class BXToastNotification extends BXInlineNotification {
   }
 
   /**
-   * The caption. Corresponds to the attribute with the same name.
+   * The caption.
    */
   @property()
   caption = '';

--- a/src/components/number-input/number-input-story.mdx
+++ b/src/components/number-input/number-input-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Number input
 
@@ -7,3 +7,9 @@ Number inputs are similar to text inputs, but contain controls used to increase 
 <Preview withToolbar>
   <Story id="number-input--default-story" height="160px" />
 </Preview>
+
+## `<bx-number-input>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-number-input mobile>`) and `false` means not setting the attribute (e.g. `<bx-number-input>` without `mobile` attribute).
+
+<Props of="bx-number-input" />

--- a/src/components/number-input/number-input.ts
+++ b/src/components/number-input/number-input.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,13 @@ import BXInput from '../input/input';
 
 const { prefix } = settings;
 
+/**
+ * Number input.
+ * @element bx-number-input
+ * @slot helper-text - The helper text.
+ * @slot label-text - The label text.
+ * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
+ */
 @customElement(`${prefix}-number-input`)
 export default class BXNumberInput extends BXInput {
   /**

--- a/src/components/overflow-menu/overflow-menu-body.ts
+++ b/src/components/overflow-menu/overflow-menu-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,23 +16,25 @@ const { prefix } = settings;
 
 /**
  * Overflow menu body.
+ * @element bx-overflow-menu-body
  */
 @customElement(`${prefix}-overflow-menu-body`)
 class BXOverflowMenuBody extends BXFloatingMenu {
   /**
-   * How the menu is aligned to the trigger button. Corresponds to the attribute with the same name.
+   * How the menu is aligned to the trigger button.
    */
   @property()
   alignment = FLOATING_MENU_ALIGNMENT.START;
 
   /**
-   * The menu direction. Corresponds to the attribute with the same name.
+   * The menu direction.
    */
   @property()
   direction = FLOATING_MENU_DIRECTION.BOTTOM;
 
   /**
-   * `true` if the menu should be open. Corresponds to the attribute with the same name.
+   * `true` if the menu should be open.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   open = false;

--- a/src/components/overflow-menu/overflow-menu-item.ts
+++ b/src/components/overflow-menu/overflow-menu-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,23 +16,24 @@ const { prefix } = settings;
 
 /**
  * Overflow menu item.
+ * @element bx-overflow-menu-item
  */
 @customElement(`${prefix}-overflow-menu-item`)
 class BXOverflowMenuItem extends FocusMixin(LitElement) {
   /**
-   * `true` if the action is danger. Corresponds to the attribute with the same name.
+   * `true` if the action is danger.
    */
   @property({ type: Boolean, reflect: true })
   danger = false;
 
   /**
-   * `true` if the overflow menu item should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the overflow menu item should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The link href of the overflow menu item. Corresponds to the attribute with the same name.
+   * The link href of the overflow menu item.
    */
   @property()
   href = '';

--- a/src/components/overflow-menu/overflow-menu-story.mdx
+++ b/src/components/overflow-menu/overflow-menu-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Overflow menu
 
@@ -8,3 +8,19 @@ Create overflow menu item components for each option on the menu.
 <Preview withToolbar>
   <Story id="overflow-menu--default-story" height="240px" />
 </Preview>
+
+## `<bx-overflow-menu>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-overflow-menu open>`) and `false` means not setting the attribute (e.g. `<bx-overflow-menu>` without `open` attribute).
+
+<Props of="bx-overflow-menu" />
+
+## `<bx-overflow-menu-body>` attributes and properties
+
+<Props of="bx-overflow-menu-body" />
+
+## `<bx-overflow-menu-item>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-overflow-menu-item disabled>`) and `false` means not setting the attribute (e.g. `<bx-overflow-menu-item>` without `disabled` attribute).
+
+<Props of="bx-overflow-menu-item" />

--- a/src/components/overflow-menu/overflow-menu.ts
+++ b/src/components/overflow-menu/overflow-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -22,6 +22,8 @@ const { prefix } = settings;
 
 /**
  * Overflow menu.
+ * @element bx-overflow-menu
+ * @slot icon - The icon for the trigger button.
  */
 @customElement(`${prefix}-overflow-menu`)
 class BXOverflowMenu extends HostListenerMixin(FocusMixin(LitElement)) implements BXFloatingMenuTrigger {
@@ -46,7 +48,7 @@ class BXOverflowMenu extends HostListenerMixin(FocusMixin(LitElement)) implement
   };
 
   /**
-   * `true` if the dropdown should be open. Corresponds to the attribute with the same name.
+   * `true` if the dropdown should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;

--- a/src/components/pagination/page-sizes-select.ts
+++ b/src/components/pagination/page-sizes-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,9 @@ const { prefix } = settings;
 
 /**
  * The select box for page sizes.
+ * @element bx-page-sizes-select
+ * @slot label-text - The label text.
+ * @fires bx-page-sizes-select-changed - The custom event fired after the page size is changed.
  */
 @customElement(`${prefix}-page-sizes-select`)
 class BXPageSizesSelect extends FocusMixin(LitElement) {
@@ -55,13 +58,13 @@ class BXPageSizesSelect extends FocusMixin(LitElement) {
   }
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = 'Items per page:';
 
   /**
-   * The value, working as the current page size. Corresponds to the attribute with the same name.
+   * The value, working as the current page size.
    */
   @property({ type: Number })
   value!: number;

--- a/src/components/pagination/pages-select.ts
+++ b/src/components/pagination/pages-select.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,8 @@ const { prefix } = settings;
 
 /**
  * The select box for the current page.
+ * @element bx-pages-select
+ * @fires bx-pages-select-changed - The custom event fired after the page is changed.
  */
 @customElement(`${prefix}-pages-select`)
 class BXPagesSelect extends FocusMixin(LitElement) {
@@ -51,13 +53,13 @@ class BXPagesSelect extends FocusMixin(LitElement) {
   formatSupplementalText = ({ count }) => `of ${count} page${count <= 1 ? '' : 's'}`;
 
   /**
-   * The number of total pages. Corresponds to the attribute with the same name.
+   * The number of total pages.
    */
   @property({ type: Number })
   total!: number;
 
   /**
-   * The value, working as the current page, index that starts with zero. Corresponds to the attribute with the same name.
+   * The value, working as the current page, index that starts with zero.
    */
   @property({ type: Number })
   value!: number;

--- a/src/components/pagination/pagination-story.mdx
+++ b/src/components/pagination/pagination-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Pagination
 
@@ -8,3 +8,17 @@ Can be used in combination with other components like data table.
 <Preview withToolbar>
   <Story id="pagination--default-story" height="160px" />
 </Preview>
+
+## `<bx-pagination>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-pagination at-last-page>`) and `false` means not setting the attribute (e.g. `<bx-pagination>` without `at-last-page` attribute).
+
+<Props of="bx-pagination" />
+
+## `<bx-pages-select>` attributes, properties and events
+
+<Props of="bx-pages-select" />
+
+## `<bx-page-sizes-select>` attributes, properties and events
+
+<Props of="bx-page-sizes-select" />

--- a/src/components/pagination/pagination.ts
+++ b/src/components/pagination/pagination.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,6 +24,11 @@ const { prefix } = settings;
 
 /**
  * Pagination UI.
+ * @element bx-pagination
+ * @slot page-sizes-select - Where to put in the `<page-sizes-select>`.
+ * @fires bx-pages-select-changed - The custom event fired after the current page is changed from `<bx-pages-select>`.
+ * @fires bx-page-sizes-select-changed
+ *   The custom event fired after the number of rows per page is changed from `<bx-page-sizes-select>`.
  */
 @customElement(`${prefix}-pagination`)
 class BXPagination extends FocusMixin(LitElement) {
@@ -114,49 +119,49 @@ class BXPagination extends FocusMixin(LitElement) {
   formatStatusWithIndeterminateTotal = ({ start, end }) => (end == null ? `Item ${start}–` : `Item ${start}–${end}`);
 
   /**
-   * `true` to explicitly state that user is at the last page. Corresponds to `at-last-page` attribute.
+   * `true` to explicitly state that user is at the last page.
    */
   @property({ type: Boolean, attribute: 'at-last-page' })
   atLastPage!: boolean;
 
   /**
-   * `true` if the pagination UI should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the pagination UI should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The assistive text for the button to go to next page. Corresponds to `next-button-text` attribute.
+   * The assistive text for the button to go to next page.
    */
   @property({ attribute: 'next-button-text' })
   nextButtonText = 'Next page';
 
   /**
-   * Number of items per page. Corresponds to `page-size` attribute.
+   * Number of items per page.
    */
   @property({ type: Number, attribute: 'page-size' })
   pageSize = 10;
 
   /**
-   * The label text for the UI to select page size. Corresponds to `page-size-label-text` attribute.
+   * The label text for the UI to select page size.
    */
   @property({ attribute: 'page-size-label-text' })
   pageSizeLabelText!: string;
 
   /**
-   * The assistive text for the button to go to previous page. Corresponds to `prev-button-text` attribute.
+   * The assistive text for the button to go to previous page.
    */
   @property({ attribute: 'prev-button-text' })
   prevButtonText = 'Previous page';
 
   /**
-   * The row number where current page start with, index that starts with zero. Corresponds to the attribute with the same name.
+   * The row number where current page start with, index that starts with zero.
    */
   @property({ type: Number })
   start = 0;
 
   /**
-   * The number of total items. Corresponds to the attribute with the same name.
+   * The number of total items.
    */
   @property({ type: Number })
   total!: number;

--- a/src/components/progress-indicator/progress-indicator-story.mdx
+++ b/src/components/progress-indicator/progress-indicator-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Progress indicator
 
@@ -9,3 +9,15 @@ Use progress indicators to keep the user on track when completing a specific tas
 <Preview withToolbar>
   <Story id="progress-indicator--default-story" height="160px" />
 </Preview>
+
+## `<bx-progress-indicator>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-progress-indicator vertical>`) and `false` means not setting the attribute (e.g. `<bx-progress-indicator>` without `vertical` attribute).
+
+<Props of="bx-progress-indicator" />
+
+## `<bx-progress-step>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-progress-step disabled>`) and `false` means not setting the attribute (e.g. `<bx-progress-step>` without `disabled` attribute).
+
+<Props of="bx-progress-step" />

--- a/src/components/progress-indicator/progress-indicator.ts
+++ b/src/components/progress-indicator/progress-indicator.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,11 +17,12 @@ const { prefix } = settings;
 
 /**
  * Progress indicator.
+ * @element bx-progress-indicator
  */
 @customElement(`${prefix}-progress-indicator`)
 class BXProgressIndicator extends LitElement {
   /**
-   * `true` if the progress indicator should be vertical. Corresponds to the attribute with the same name.
+   * `true` if the progress indicator should be vertical.
    */
   @property({ type: Boolean, reflect: true })
   vertical = false;

--- a/src/components/progress-indicator/progress-step.ts
+++ b/src/components/progress-indicator/progress-step.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -73,41 +73,44 @@ const icons = {
 
 /**
  * Progress step.
+ * @element bx-progress-step
+ * @slot secondary-label-text - The secondary progress label.
  */
 @customElement(`${prefix}-progress-step`)
 class BXProgressStep extends FocusMixin(LitElement) {
   /**
-   * `true` if the progress step should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the progress step should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The a11y text for the icon. Corresponds to `icon-label` attribute.
+   * The a11y text for the icon.
    */
   @property({ attribute: 'icon-label' })
   iconLabel!: string;
 
   /**
-   * The primary progress label. Corresponds to `label-text` attribute.
+   * The primary progress label.
    */
   @property({ attribute: 'label-text' })
   labelText!: string;
 
   /**
-   * The secondary progress label. Corresponds to `secondary-label-text` attribute.
+   * The secondary progress label.
    */
   @property({ attribute: 'secondary-label-text' })
   secondaryLabelText!: string;
 
   /**
-   * The progress state. Corresponds to the attribute with the same name.
+   * The progress state.
    */
   @property()
   state = PROGRESS_STEP_STAT.QUEUED;
 
   /**
-   * `true` if the progress step should be vertical. Corresponds to the attribute with the same name.
+   * `true` if the progress step should be vertical.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   vertical = false;
@@ -141,7 +144,7 @@ class BXProgressStep extends FocusMixin(LitElement) {
       <slot>
         <p role="button" class="${prefix}--progress-label" tabindex="0" aria-describedby="label-tooltip">${labelText}</p>
       </slot>
-      <slot name="secondary-label">
+      <slot name="secondary-label-text">
         ${!secondaryLabelText
           ? undefined
           : html`

--- a/src/components/radio-button/radio-button-group.ts
+++ b/src/components/radio-button/radio-button-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -35,6 +35,8 @@ export enum RADIO_BUTTON_ORIENTATION {
 
 /**
  * Radio button group.
+ * @element bx-radio-button-group
+ * @fires bx-radio-button-group-changed - The custom event fired after this radio button group changes its selected item.
  */
 @customElement(`${prefix}-radio-button-group`)
 class BXRadioButtonGroup extends FormMixin(LitElement) {
@@ -74,31 +76,31 @@ class BXRadioButtonGroup extends FormMixin(LitElement) {
   }
 
   /**
-   * `true` if the check box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the check box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The label position. Corresponds to `label-text` attribute.
+   * The label position.
    */
   @property({ reflect: true, attribute: 'label-position' })
   labelPosition = RADIO_BUTTON_LABEL_POSITION.RIGHT;
 
   /**
-   * The `name` attribute for the `<input>` for selection. Corresponds to the attribute with the same name.
+   * The `name` attribute for the `<input>` for selection.
    */
   @property()
   name!: string;
 
   /**
-   * The orientation to lay out radio buttons. Corresponds to the attribute with the same name.
+   * The orientation to lay out radio buttons.
    */
   @property({ reflect: true })
   orientation = RADIO_BUTTON_ORIENTATION.HORIZONTAL;
 
   /**
-   * The `value` attribute for the `<input>` for selection. Corresponds to the attribute with the same name.
+   * The `value` attribute for the `<input>` for selection.
    */
   @property()
   value!: string;

--- a/src/components/radio-button/radio-button-story.mdx
+++ b/src/components/radio-button/radio-button-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Radio button
 
@@ -7,3 +7,15 @@ Radio buttons are used when a list of two or more options are mutually exclusive
 <Preview withToolbar>
   <Story id="radio-button--default-story" height="160px" />
 </Preview>
+
+## `<bx-radio-button-group>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-radio-button-group disabled>`) and `false` means not setting the attribute (e.g. `<bx-radio-button-group>` without `disabled` attribute).
+
+<Props of="bx-radio-button-group" />
+
+## `<bx-radio-button-group>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-radio-button-group disabled>`) and `false` means not setting the attribute (e.g. `<bx-radio-button-group>` without `disabled` attribute).
+
+<Props of="bx-radio-button-group" />

--- a/src/components/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -111,6 +111,8 @@ class RadioButtonDelegate implements ManagedRadioButtonDelegate {
 
 /**
  * Radio button.
+ * @element bx-radio-button
+ * @fires bx-radio-button-changed - The custom event fired after this radio button changes its checked state.
  */
 @customElement(`${prefix}-radio-button`)
 class BXRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
@@ -169,49 +171,49 @@ class BXRadioButton extends HostListenerMixin(FocusMixin(LitElement)) {
   };
 
   /**
-   * `true` if this radio button should be checked. Corresponds to the attribute with the same name.
+   * `true` if this radio button should be checked.
    */
   @property({ type: Boolean, reflect: true })
   checked = false;
 
   /**
-   * `true` if the check box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the check box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * `true` if the label should be hidden. Corresponds to the attribute with the same name.
+   * `true` if the label should be hidden.
    */
   @property({ type: Boolean, reflect: true, attribute: 'hide-label' })
   hideLabel = false;
 
   /**
-   * The label position. Corresponds to `label-text` attribute.
+   * The label position.
    */
   @property({ reflect: true, attribute: 'label-position' })
   labelPosition = RADIO_BUTTON_LABEL_POSITION.RIGHT;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
 
   /**
-   * The `name` attribute for the `<input>` for selection. Corresponds to the attribute with the same name.
+   * The `name` attribute for the `<input>` for selection.
    */
   @property()
   name!: string;
 
   /**
-   * The orientation to lay out radio buttons. Corresponds to the attribute with the same name.
+   * The orientation to lay out radio buttons.
    */
   @property({ reflect: true })
   orientation = RADIO_BUTTON_ORIENTATION.HORIZONTAL;
 
   /**
-   * The `value` attribute for the `<input>` for selection. Corresponds to the attribute with the same name.
+   * The `value` attribute for the `<input>` for selection.
    */
   @property()
   value!: string;

--- a/src/components/search/search-story.mdx
+++ b/src/components/search/search-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Search
 
@@ -8,3 +8,9 @@ Search can be used as the primary means of discovering content, or as a filter t
 <Preview withToolbar>
   <Story id="search--default-story" height="160px" />
 </Preview>
+
+## `<bx-search>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-search light>`) and `false` means not setting the attribute (e.g. `<bx-search>` without `light` attribute).
+
+<Props of="bx-search" />

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,6 +36,8 @@ export enum SEARCH_SIZE {
 
 /**
  * Search box.
+ * @element bx-search
+ * @fires bx-search-input - The custom event fired after the search content is changed upon a user gesture.
  */
 @customElement(`${prefix}-search`)
 class BXSearch extends FocusMixin(LitElement) {
@@ -78,55 +80,55 @@ class BXSearch extends FocusMixin(LitElement) {
   }
 
   /**
-   * The assistive text for the close button. Corresponds to `close-button-assistive-text` attribute.
+   * The assistive text for the close button.
    */
   @property({ attribute: 'close-button-assistive-text' })
   closeButtonAssistiveText = '';
 
   /**
-   * `true` if the search box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the search box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
 
   /**
-   * `true` if this search box should use the light UI variant. Corresponds to the attribute with the same name.
+   * `true` if this search box should use the light UI variant.
    */
   @property({ type: Boolean, reflect: true })
   light = false;
 
   /**
-   * The form name. Corresponds to the attribute with the same name.
+   * The form name.
    */
   @property()
   name = '';
 
   /**
-   * The placeholder text. Corresponds to the attribute with the same name.
+   * The placeholder text.
    */
   @property()
   placeholder = '';
 
   /**
-   * The search box size. Corresponds to the attribute with the same name.
+   * The search box size.
    */
   @property({ reflect: true })
   size = SEARCH_SIZE.REGULAR;
 
   /**
-   * The `<input>` name. Corresponds to the attribute with the same name.
+   * The `<input>` name.
    */
   @property()
   type = '';
 
   /**
-   * The value. Corresponds to the attribute with the same name.
+   * The value.
    */
   @property({ type: String })
   value = '';

--- a/src/components/skeleton-placeholder/skeleton-placeholder.ts
+++ b/src/components/skeleton-placeholder/skeleton-placeholder.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Skeleton placeholder.
+ * @element bx-skeleton-placeholder
  */
 @customElement(`${prefix}-skeleton-placeholder`)
 class BXSkeletonPlaceholder extends LitElement {

--- a/src/components/skeleton-text/skeleton-text-story.mdx
+++ b/src/components/skeleton-text/skeleton-text-story.mdx
@@ -1,0 +1,15 @@
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
+
+# Skeleton text
+
+<Preview withToolbar>
+  <Story id="skeleton-text--default-story" height="120px" />
+</Preview>
+
+<Preview withToolbar>
+  <Story id="skeleton-text--lines" height="120px" />
+</Preview>
+
+## `<bx-skeleton-text>` attributes and properties
+
+<Props of="bx-skeleton-text" />

--- a/src/components/skeleton-text/skeleton-text-story.ts
+++ b/src/components/skeleton-text/skeleton-text-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,6 +11,7 @@ import { html } from 'lit-element';
 import { select } from '@storybook/addon-knobs';
 import ifNonNull from '../../globals/directives/if-non-null';
 import { SKELETON_TEXT_TYPE } from './skeleton-text';
+import storyDocs from './skeleton-text-story.mdx';
 
 const types = {
   Regular: null,
@@ -52,4 +53,9 @@ lines.story = {
 
 export default {
   title: 'Skeleton text',
+  parameters: {
+    docs: {
+      page: storyDocs,
+    },
+  },
 };

--- a/src/components/skeleton-text/skeleton-text.ts
+++ b/src/components/skeleton-text/skeleton-text.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -36,11 +36,12 @@ export enum SKELETON_TEXT_TYPE {
 
 /**
  * Skeleton text.
+ * @element bx-skeleton-text
  */
 @customElement(`${prefix}-skeleton-text`)
 class BXSkeletonText extends LitElement {
   /**
-   * The type of skeleton text. Corresponds to the attribute with the same name.
+   * The type of skeleton text.
    */
   @property({ reflect: true })
   type = SKELETON_TEXT_TYPE.REGULAR;

--- a/src/components/slider/slider-input.ts
+++ b/src/components/slider/slider-input.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,8 @@ const { prefix } = settings;
 
 /**
  * The `<input>` box for slider.
+ * @element bx-slider-input
+ * @fires bx-slider-input-changed - The custom event fired after the value is changed by user gesture.
  */
 @customElement(`${prefix}-slider-input`)
 class BXSliderInput extends FocusMixin(LitElement) {
@@ -53,25 +55,25 @@ class BXSliderInput extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if the check box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the check box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * `true` if this slider input should use the light UI variant. Corresponds to the attribute with the same name.
+   * `true` if this slider input should use the light UI variant.
    */
   @property({ type: Boolean, reflect: true })
   light = false;
 
   /**
-   * The type of the `<input>`. Corresponds to the attribute with the same name.
+   * The type of the `<input>`.
    */
   @property()
   type!: string;
 
   /**
-   * The value. Corresponds to the attribute with the same name.
+   * The value.
    */
   @property({ type: Number })
   value!: number;

--- a/src/components/slider/slider-story.mdx
+++ b/src/components/slider/slider-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Slider
 
@@ -7,3 +7,15 @@ Sliders provide a visual indication of adjustable content, where the user can mo
 <Preview withToolbar>
   <Story id="slider--default-story" height="160px" />
 </Preview>
+
+## `<bx-slider>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-slider disabled>`) and `false` means not setting the attribute (e.g. `<bx-slider>` without `disabled` attribute).
+
+<Props of="bx-slider" />
+
+## `<bx-slider-input>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-slider-input light>`) and `false` means not setting the attribute (e.g. `<bx-slider-input>` without `light` attribute).
+
+<Props of="bx-slider-input" />

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -43,6 +43,11 @@ const THUMB_DIRECTION = {
 
 /**
  * Slider.
+ * @element bx-slider
+ * @slot label-text - The label text.
+ * @slot max-text - The text for maximum value.
+ * @slot min-text - The text for minimum value.
+ * @fires bx-slider-changed - The custom event fired after the value is changed by user gesture.
  */
 @customElement(`${prefix}-slider`)
 class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
@@ -251,7 +256,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   };
 
   /**
-   * `true` if the check box should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the check box should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -271,7 +276,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   formatMinText = ({ min }: { min: string }) => min;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
@@ -305,13 +310,13 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   }
 
   /**
-   * The form name. Corresponds to the attribute with the same name.
+   * The form name.
    */
   @property()
   name!: string;
 
   /**
-   * The snapping step of the value. Corresponds to the attribute with the same name.
+   * The snapping step of the value.
    */
   @property({ type: Number, reflect: true })
   get step() {
@@ -327,7 +332,6 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   /**
    * A value determining how much the value should increase/decrease by Shift+arrow keys,
    * which will be `(max - min) / stepRatio`.
-   * Corresponds to `step-ratio` attribute.
    */
   @property({ type: Number, reflect: true, attribute: 'step-ratio' })
   get stepRatio() {
@@ -341,7 +345,7 @@ class BXSlider extends HostListenerMixin(FormMixin(FocusMixin(LitElement))) {
   }
 
   /**
-   * The value. Corresponds to the attribute with the same name.
+   * The value.
    */
   @property({ type: Number })
   value = 50;

--- a/src/components/structured-list/structured-list-body.ts
+++ b/src/components/structured-list/structured-list-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Structured list body.
+ * @element bx-structured-list-body
  */
 @customElement(`${prefix}-structured-list-body`)
 class BXStructuredListBody extends LitElement {

--- a/src/components/structured-list/structured-list-cell.ts
+++ b/src/components/structured-list/structured-list-cell.ts
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Structured list cell.
+ * @element bx-structured-list-cell
  */
 @customElement(`${prefix}-structured-list-cell`)
 class BXStructuredListCell extends LitElement {

--- a/src/components/structured-list/structured-list-head.ts
+++ b/src/components/structured-list/structured-list-head.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Structured list header.
+ * @element bx-structured-list-head
  */
 @customElement(`${prefix}-structured-list-head`)
 class BXStructuredListHeader extends LitElement {

--- a/src/components/structured-list/structured-list-header-cell.ts
+++ b/src/components/structured-list/structured-list-header-cell.ts
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Structured list header cell.
+ * @element bx-structured-list-header-cell
  */
 @customElement(`${prefix}-structured-list-header-cell`)
 class BXStructuredListHeaderCell extends LitElement {

--- a/src/components/structured-list/structured-list-header-row.ts
+++ b/src/components/structured-list/structured-list-header-row.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,11 +15,12 @@ const { prefix } = settings;
 
 /**
  * Structured list header row.
+ * @element bx-structured-list-header-row
  */
 @customElement(`${prefix}-structured-list-header-row`)
 class BXStructuredListHeaderRow extends LitElement {
   /**
-   * `true` if parent structured list supports selection. Corresponds to `has-selection` attribute.
+   * `true` if parent structured list supports selection.
    */
   @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
   hasSelection = false;

--- a/src/components/structured-list/structured-list-row.ts
+++ b/src/components/structured-list/structured-list-row.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -73,6 +73,7 @@ class StructuredListRowRadioButtonDelegate implements ManagedRadioButtonDelegate
 
 /**
  * Structured list row.
+ * @element bx-structured-list-row
  */
 @customElement(`${prefix}-structured-list-row`)
 class BXStructuredListRow extends HostListenerMixin(LitElement) {
@@ -127,20 +128,20 @@ class BXStructuredListRow extends HostListenerMixin(LitElement) {
   };
 
   /**
-   * `true` if this structured list row should be selectable and selected. Corresponds to the attribute with the same name.
+   * `true` if this structured list row should be selectable and selected.
    */
   @property({ type: Boolean, reflect: true })
   selected = false;
 
   /**
-   * The `name` attribute for the `<input>` for selection. Corresponds to `selection-name` attribute.
+   * The `name` attribute for the `<input>` for selection.
    * If present, this structured list row will be a selectable one.
    */
   @property({ attribute: 'selection-name' })
   selectionName = '';
 
   /**
-   * The `value` attribute for the `<input>` for selection. Corresponds to `selection-value` attribute.
+   * The `value` attribute for the `<input>` for selection.
    */
   @property({ attribute: 'selection-value' })
   selectionValue = '';

--- a/src/components/structured-list/structured-list-story.mdx
+++ b/src/components/structured-list/structured-list-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Structured list
 
@@ -7,3 +7,15 @@ Structured Lists group content that is similar or related, such as terms or defi
 <Preview withToolbar>
   <Story id="structured-list--default-story" />
 </Preview>
+
+## `<bx-structured-list>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-structured-list has-selection>`) and `false` means not setting the attribute (e.g. `<bx-structured-list>` without `has-selection` attribute).
+
+<Props of="bx-structured-list" />
+
+## `<bx-structured-list-row>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-structured-list-row selected>`) and `false` means not setting the attribute (e.g. `<bx-structured-list-row>` without `selected` attribute).
+
+<Props of="bx-structured-list-row" />

--- a/src/components/structured-list/structured-list.ts
+++ b/src/components/structured-list/structured-list.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,17 +17,18 @@ const { prefix } = settings;
 
 /**
  * Structured list wrapper.
+ * @element bx-structured-list
  */
 @customElement(`${prefix}-structured-list`)
 class BXStructuredList extends FocusMixin(LitElement) {
   /**
-   * `true` if border should be used. Corresponds to the attribute with the same name.
+   * `true` if border should be used.
    */
   @property({ type: Boolean, reflect: true })
   border = false;
 
   /**
-   * `true` if selection should be supported. Corresponds to `has-selection` attribute.
+   * `true` if selection should be supported.
    */
   @property({ type: Boolean, reflect: true, attribute: 'has-selection' })
   hasSelection = false;

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,18 +16,21 @@ const { prefix } = settings;
 
 /**
  * Basic tab.
+ * @element bx-tab
  */
 @customElement(`${prefix}-tab`)
 class BXTab extends BXContentSwitcherItem {
   /**
-   * `true` if this tab should be highlighted. Corresponds to the attribute with the same name.
+   * `true` if this tab should be highlighted.
    * If `true`, parent `<bx-tabs>` selects/deselects this tab upon keyboard interaction.
+   * @private
    */
   @property({ type: Boolean, reflect: true })
   highlighted = false;
 
   /**
-   * `true` if this tab is in a focused `<bx-tabs>`. Corresponds to `in-focus` attribute.
+   * `true` if this tab is in a focused `<bx-tabs>`.
+   * @private
    */
   @property({ type: Boolean, reflect: true, attribute: 'in-focus' })
   inFocus = false;

--- a/src/components/tabs/tabs-story.mdx
+++ b/src/components/tabs/tabs-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Tabs
 
@@ -7,3 +7,15 @@ Tabs are used to quickly navigate between views within the same context.
 <Preview withToolbar>
   <Story id="tabs--default-story" height="320px" />
 </Preview>
+
+## `<bx-tabs>` attributes, properties and events
+
+Note: `bx-content-switcher-*` events are not fired from `<bx-tabs>`.
+
+<Props of="bx-tabs" />
+
+## `<bx-tab>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-tab disabled>`) and `false` means not setting the attribute (e.g. `<bx-tab>` without `disabled` attribute).
+
+<Props of="bx-tab" />

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -59,6 +59,11 @@ export enum TABS_KEYBOARD_ACTION {
 
 /**
  * Tabs.
+ * @element bx-tabs
+ * @fires bx-tabs-beingselected
+ *   The custom event fired before a tab is selected upon a user gesture.
+ *   Cancellation of this event stops changing the user-initiated selection.
+ * @fires bx-tabs-selected - The custom event fired after a a tab is selected upon a user gesture.
  */
 @customElement(`${prefix}-tabs`)
 class BXTabs extends HostListenerMixin(BXContentSwitcher) {
@@ -273,7 +278,7 @@ class BXTabs extends HostListenerMixin(BXContentSwitcher) {
   selectedItemAssistiveText = 'Selected an item.';
 
   /**
-   * The content of the trigger button for narrow mode. Corresponds to `trigger-content` attribute.
+   * The content of the trigger button for narrow mode.
    */
   @property({ attribute: 'trigger-content' })
   triggerContent = '';

--- a/src/components/tag/filter-tag.ts
+++ b/src/components/tag/filter-tag.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,6 +21,7 @@ const { prefix } = settings;
 
 /**
  * Filter tag.
+ * @element bx-filter-tag
  */
 @customElement(`${prefix}-filter-tag`)
 export default class BXFilterTag extends FocusMixin(LitElement) {

--- a/src/components/tag/tag-story.mdx
+++ b/src/components/tag/tag-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Tag
 
@@ -17,3 +17,15 @@ Use tags when content is mapped to multiple categories, and the user needs a way
 <Preview withToolbar>
   <Story id="tag--filter" height="160px" />
 </Preview>
+
+## `<bx-tag>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-tag disabled>`) and `false` means not setting the attribute (e.g. `<bx-tag>` without `disabled` attribute).
+
+<Props of="bx-tag" />
+
+## `<bx-filter-tag>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-filter-tag disabled>`) and `false` means not setting the attribute (e.g. `<bx-filter-tag>` without `disabled` attribute).
+
+<Props of="bx-filter-tag" />

--- a/src/components/tag/tag.ts
+++ b/src/components/tag/tag.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,7 @@ const { prefix } = settings;
 
 /**
  * Tag.
+ * @element bx-tag
  */
 @customElement(`${prefix}-tag`)
 export default class BXTag extends LitElement {

--- a/src/components/textarea/textarea-story.mdx
+++ b/src/components/textarea/textarea-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Textarea
 
@@ -9,3 +9,9 @@ Textarea is a multi-line variant of text input.
 <Preview withToolbar>
   <Story id="textarea--default-story" height="240px" />
 </Preview>
+
+## `<bx-textarea>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-textarea autofocus>`) and `false` means not setting the attribute (e.g. `<bx-textarea>` without `autofocus` attribute).
+
+<Props of="bx-textarea" />

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,7 +19,11 @@ import styles from './textarea.scss';
 const { prefix } = settings;
 
 /**
- * Input element. Supports all the usual attributes for textual input types
+ * Text area.
+ * @element bx-textarea
+ * @slot helper-text - The helper text.
+ * @slot label-text - The label text.
+ * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-textarea`)
 export default class BXTextarea extends FormMixin(LitElement) {
@@ -64,7 +68,7 @@ export default class BXTextarea extends FormMixin(LitElement) {
   disabled = false;
 
   /**
-   * The helper text. Corresponds to `helper-text` attribute.
+   * The helper text.
    */
   @property({ attribute: 'helper-text' })
   helperText = '';
@@ -82,7 +86,7 @@ export default class BXTextarea extends FormMixin(LitElement) {
   invalid = false;
 
   /**
-   * The label text. Corresponds to `label-text` attribute.
+   * The label text.
    */
   @property({ attribute: 'label-text' })
   labelText = '';
@@ -124,7 +128,7 @@ export default class BXTextarea extends FormMixin(LitElement) {
   rows = 4;
 
   /**
-   * The validity message. Corresponds to `validity-message` attribute.
+   * The validity message.
    */
   @property({ attribute: 'validity-message' })
   validityMessage = '';

--- a/src/components/tile/clickable-tile.ts
+++ b/src/components/tile/clickable-tile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,11 +17,12 @@ const { prefix } = settings;
 
 /**
  * Clickable tile.
+ * @element bx-clickable-tile
  */
 @customElement(`${prefix}-clickable-tile`)
 class BXClickableTile extends FocusMixin(LitElement) {
   /**
-   * Link `href`. Corresponds to the attribute with the same name.
+   * Link `href`.
    */
   @property()
   href = '';

--- a/src/components/tile/expandable-tile.ts
+++ b/src/components/tile/expandable-tile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,11 @@ const { prefix } = settings;
 
 /**
  * Expandable tile.
+ * @element bx-expandable-tile
+ * @fires bx-expandable-tile-beingchanged
+ *   The custom event fired before the expanded state is changed upon a user gesture.
+ *   Cancellation of this event stops changing the user-initiated change in expanded state.
+ * @fires bx-expandable-tile-changed - The custom event fired after a the expanded state is changed upon a user gesture.
  */
 @customElement(`${prefix}-expandable-tile`)
 class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
@@ -47,20 +52,18 @@ class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
 
   /**
    * An assistive text for screen reader to announce, telling the collapsed state.
-   * Corresponds to `collapsed-assistive-text` attribute.
    */
   @property({ attribute: 'collapsed-assistive-text' })
   collapsedAssistiveText!: string;
 
   /**
    * An assistive text for screen reader to announce, telling the expanded state.
-   * Corresponds to `expanded-assistive-text` attribute.
    */
   @property({ attribute: 'expanded-assistive-text' })
   expandedAssistiveText!: string;
 
   /**
-   * `true` to expand this expandable tile. Corresponds to the attribute with the same name.
+   * `true` to expand this expandable tile.
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;

--- a/src/components/tile/radio-tile.ts
+++ b/src/components/tile/radio-tile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -28,6 +28,7 @@ const navigationDirectionForKey = {
 
 /**
  * Single-selectable tile.
+ * @element bx-radio-tile
  */
 @customElement(`${prefix}-radio-tile`)
 class BXRadioTile extends HostListenerMixin(SelectableTile) {

--- a/src/components/tile/selectable-tile.ts
+++ b/src/components/tile/selectable-tile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,7 @@ const { prefix } = settings;
 
 /**
  * Multi-selectable tile.
+ * @element bx-selectable-tile
  */
 @customElement(`${prefix}-selectable-tile`)
 class BXSelectableTile extends FocusMixin(LitElement) {
@@ -37,25 +38,25 @@ class BXSelectableTile extends FocusMixin(LitElement) {
   }
 
   /**
-   * The a11y text for the checkmark icon of the selected state. Corresponds to `checkmark-label` attribute.
+   * The a11y text for the checkmark icon of the selected state.
    */
   @property({ attribute: 'checkmark-label' })
   checkmarkLabel!: string;
 
   /**
-   * The form name. Corresponds to the attribute with the same name.
+   * The form name.
    */
   @property()
   name!: string;
 
   /**
-   * `true` to show the selected state. Corresponds to the attribute with the same name.
+   * `true` to show the selected state.
    */
   @property({ type: Boolean, reflect: true })
   selected = false;
 
   /**
-   * The form value. Corresponds to the attribute with the same name.
+   * The form value.
    */
   @property()
   value!: string;

--- a/src/components/tile/tile-group.ts
+++ b/src/components/tile/tile-group.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Tile group.
+ * @element bx-tile-group
  */
 @customElement(`${prefix}-tile-group`)
 class BXTileGroup extends LitElement {

--- a/src/components/tile/tile-story.mdx
+++ b/src/components/tile/tile-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Tile
 
@@ -30,6 +30,10 @@ Clickable tiles cannot contain separate internal CTAs.
   <Story id="tile--clickable" height="160px" />
 </Preview>
 
+## `<bx-clickable-tile>` attributes and properties
+
+<Props of="bx-clickable-tile" />
+
 # Selectable tile
 
 Selectable tiles work like a radio button, where the entire tile is a click target.
@@ -40,11 +44,23 @@ Selectable tiles work well for presenting options to a user in a structured mann
   <Story id="tile--single-selectable" height="320px" />
 </Preview>
 
+## `<bx-radio-tile>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-radio-tile selected>`) and `false` means not setting the attribute (e.g. `<bx-radio-tile>` without `selected` attribute).
+
+<Props of="bx-radio-tile" />
+
 # Multi-selectable tile
 
 <Preview withToolbar>
   <Story id="tile--multi-selectable" height="160px" />
 </Preview>
+
+## `<bx-selectable-tile>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-selectable-tile selected>`) and `false` means not setting the attribute (e.g. `<bx-selectable-tile>` without `selected` attribute).
+
+<Props of="bx-selectable-tile" />
 
 # Expandable tile
 
@@ -56,3 +72,9 @@ Expandable tiles may contain internal CTAs (like links to docs) if the internal 
 <Preview withToolbar>
   <Story id="tile--expandable" />
 </Preview>
+
+## `<bx-expandable-tile>` attributes, properties and events
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-expandable-tile expanded>`) and `false` means not setting the attribute (e.g. `<bx-expandable-tile>` without `expanded` attribute).
+
+<Props of="bx-expandable-tile" />

--- a/src/components/tile/tile.ts
+++ b/src/components/tile/tile.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Basic tile.
+ * @element bx-tile
  */
 @customElement(`${prefix}-tile`)
 class BXTile extends LitElement {

--- a/src/components/toggle/toggle-story.mdx
+++ b/src/components/toggle/toggle-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Toggle
 
@@ -11,3 +11,11 @@ Use `small` property/attribute to make it more compact in size, so they can be u
 <Preview withToolbar>
   <Story id="toggle--default-story" height="160px" />
 </Preview>
+
+## `<bx-toggle>` attributes, properties and events
+
+Note: `bx-checkbox-*` events are not fired from `<bx-toggle>`.
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-toggle small>`) and `false` means not setting the attribute (e.g. `<bx-toggle>` without `small` attribute).
+
+<Props of="bx-toggle" />

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,11 @@ const { prefix } = settings;
 
 /**
  * Basic toggle.
+ * @element bx-toggle
+ * @slot label-text - The label text.
+ * @slot checked-text - The text for the checked state.
+ * @slot unchecked-text - The text for the unchecked state.
+ * @fires bx-toggle-changed - The custom event fired after this changebox changes its checked state.
  */
 @customElement(`${prefix}-toggle`)
 class BXToggle extends BXCheckbox {
@@ -33,19 +38,19 @@ class BXToggle extends BXCheckbox {
   }
 
   /**
-   * The text for the checked state. Corresponds to `checked-text` attribute.
+   * The text for the checked state.
    */
   @property({ attribute: 'checked-text' })
   checkedText = '';
 
   /**
-   * `true` to use the small variant. Corresponds to the attribute with the same name.
+   * `true` to use the small variant.
    */
   @property({ type: Boolean, reflect: true })
   small = false;
 
   /**
-   * The text for the unchecked state. Corresponds to `unchecked-text` attribute.
+   * The text for the unchecked state.
    */
   @property({ attribute: 'unchecked-text' })
   uncheckedText = '';

--- a/src/components/tooltip/tooltip-body.ts
+++ b/src/components/tooltip/tooltip-body.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,19 +24,19 @@ const { prefix } = settings;
 @customElement(`${prefix}-tooltip-body`)
 class BXTooltipBody extends BXFloatingMenu {
   /**
-   * How the menu is aligned to the trigger button. Corresponds to the attribute with the same name.
+   * How the menu is aligned to the trigger button.
    */
   @property()
   alignment = FLOATING_MENU_ALIGNMENT.CENTER;
 
   /**
-   * The menu direction. Corresponds to the attribute with the same name.
+   * The menu direction.
    */
   @property()
   direction = FLOATING_MENU_DIRECTION.BOTTOM;
 
   /**
-   * `true` if the dropdown should be open. Corresponds to the attribute with the same name.
+   * `true` if the dropdown should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;

--- a/src/components/tooltip/tooltip-definition.ts
+++ b/src/components/tooltip/tooltip-definition.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -62,23 +62,25 @@ export enum TOOLTIP_DIRECTION {
 
 /**
  * Definition tooltip.
+ * @element bx-tooltip-definition
+ * @slot body - The tooltip body content.
  */
 @customElement(`${prefix}-tooltip-definition`)
 class BXTooltipDefinition extends FocusMixin(LitElement) {
   /**
-   * How the tooltip is aligned to the trigger button. Corresponds to the attribute with the same name.
+   * How the tooltip is aligned to the trigger button.
    */
   @property()
   alignment = TOOLTIP_ALIGNMENT.CENTER;
 
   /**
-   * The text for the tooltip body. Corresponds to `body-text` attribute.
+   * The text for the tooltip body.
    */
   @property({ attribute: 'body-text' })
   bodyText = '';
 
   /**
-   * The tooltip direction. Corresponds to the attribute with the same name.
+   * The tooltip direction.
    */
   @property()
   direction = TOOLTIP_DIRECTION.BOTTOM;

--- a/src/components/tooltip/tooltip-icon.ts
+++ b/src/components/tooltip/tooltip-icon.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -16,6 +16,8 @@ const { prefix } = settings;
 
 /**
  * Icon tooltip.
+ * @element bx-tooltip-icon
+ * @slot body - The tooltip body content.
  */
 @customElement(`${prefix}-tooltip-icon`)
 class BXTooltipIcon extends BXTooltipDefintion {

--- a/src/components/tooltip/tooltip-story.mdx
+++ b/src/components/tooltip/tooltip-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Tooltip
 
@@ -17,6 +17,12 @@ Interactive tooltips may contain rich text and other interactive elements like b
   <Story id="tooltip--default-story" height="320px" />
 </Preview>
 
+### `<bx-tooltip>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-tooltip open>`) and `false` means not setting the attribute (e.g. `<bx-tooltip>` without `open` attribute).
+
+<Props of="bx-tooltip" />
+
 ## Definition tooltip
 
 The definition tooltip provides additional help or defines an item or term. It may be used on the label of a UI element, or on a word embedded in a paragraph.
@@ -29,6 +35,10 @@ The definition tooltip provides additional help or defines an item or term. It m
   <Story id="tooltip--definition" height="200px" />
 </Preview>
 
+### `<bx-tooltip-definition>` attributes and properties
+
+<Props of="bx-tooltip-definition" />
+
 ## Icon tooltip
 
 An icon tooltip is used to clarify the action or name of an interactive icon button.
@@ -38,3 +48,7 @@ An icon tooltip is used to clarify the action or name of an interactive icon but
 <Preview withToolbar>
   <Story id="tooltip--icon" height="160px" />
 </Preview>
+
+### `<bx-tooltip-icon>` attributes and properties
+
+<Props of="bx-tooltip-icon" />

--- a/src/components/tooltip/tooltip.ts
+++ b/src/components/tooltip/tooltip.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,6 +21,7 @@ const { prefix } = settings;
 
 /**
  * Trigger button of tooltip.
+ * @element bx-tooltip
  */
 @customElement(`${prefix}-tooltip`)
 class BXTooltip extends HostListenerMixin(LitElement) implements BXFloatingMenuTrigger {
@@ -51,7 +52,7 @@ class BXTooltip extends HostListenerMixin(LitElement) implements BXFloatingMenuT
   };
 
   /**
-   * `true` if the dropdown should be open. Corresponds to the attribute with the same name.
+   * `true` if the dropdown should be open.
    */
   @property({ type: Boolean, reflect: true })
   open = false;

--- a/src/components/ui-shell/header-menu-button.ts
+++ b/src/components/ui-shell/header-menu-button.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -21,6 +21,7 @@ const { prefix } = settings;
 
 /**
  * The trigger button for side nav in header nav.
+ * @element bx-header-menu-button
  */
 @customElement(`${prefix}-header-menu-button`)
 class BXHeaderMenuButton extends FocusMixin(LitElement) {
@@ -34,25 +35,25 @@ class BXHeaderMenuButton extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if the button should represent its active state. Corresponds to the attribute with the same name.
+   * `true` if the button should represent its active state.
    */
   @property({ type: Boolean, reflect: true })
   active = false;
 
   /**
-   * The `aria-label` attribute for the button in its active state. Corresponds to `button-label-active` attribute.
+   * The `aria-label` attribute for the button in its active state.
    */
   @property()
   buttonLabelActive!: string;
 
   /**
-   * The `aria-label` attribute for the button in its active state. Corresponds to `button-label-inactive` attribute.
+   * The `aria-label` attribute for the button in its active state.
    */
   @property()
   buttonLabelInactive!: string;
 
   /**
-   * `true` if the button should be disabled. Corresponds to the attribute with the same name.
+   * `true` if the button should be disabled.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;

--- a/src/components/ui-shell/header-menu-item.ts
+++ b/src/components/ui-shell/header-menu-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Header submenu item.
+ * @element bx-header-menu-item
  */
 @customElement(`${prefix}-header-menu-item`)
 class BXHeaderMenuItem extends BXHeaderNavItem {}

--- a/src/components/ui-shell/header-menu.ts
+++ b/src/components/ui-shell/header-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,6 +20,7 @@ const { prefix } = settings;
 
 /**
  * Header menu.
+ * @element bx-header-menu
  */
 @customElement(`${prefix}-header-menu`)
 class BXHeaderMenu extends HostListenerMixin(FocusMixin(LitElement)) {
@@ -68,19 +69,19 @@ class BXHeaderMenu extends HostListenerMixin(FocusMixin(LitElement)) {
   }
 
   /**
-   * `true` if the menu should be expanded. Corresponds to the attribute with the same name.
+   * `true` if the menu should be expanded.
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
   /**
-   * The content of the trigger button. Corresponds to `trigger-content` attribute.
+   * The content of the trigger button.
    */
   @property({ attribute: 'trigger-content' })
   triggerContent = '';
 
   /**
-   * The `aria-label` attribute for the menu UI. Corresponds to `menu-label` attribute.
+   * The `aria-label` attribute for the menu UI.
    */
   @property({ attribute: 'menu-label' })
   menuLabel!: string;

--- a/src/components/ui-shell/header-name.ts
+++ b/src/components/ui-shell/header-name.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,17 +17,18 @@ const { prefix } = settings;
 
 /**
  * The product name UI in header nav.
+ * @element bx-header-name
  */
 @customElement(`${prefix}-header-name`)
 class BXHeaderName extends FocusMixin(LitElement) {
   /**
-   * Link `href`. Corresponds to the attribute with the same name.
+   * Link `href`.
    */
   @property()
   href!: string;
 
   /**
-   * The product name prefix. Corresponds to the attribute with the same name.
+   * The product name prefix.
    */
   @property()
   prefix!: string;

--- a/src/components/ui-shell/header-nav-item.ts
+++ b/src/components/ui-shell/header-nav-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,11 +17,12 @@ const { prefix } = settings;
 
 /**
  * Header nav item.
+ * @element bx-header-nav-item
  */
 @customElement(`${prefix}-header-nav-item`)
 class BXHeaderNavItem extends FocusMixin(LitElement) {
   /**
-   * Link `href`. Corresponds to the attribute with the same name.
+   * Link `href`.
    */
   @property()
   href!: string;

--- a/src/components/ui-shell/header-nav.ts
+++ b/src/components/ui-shell/header-nav.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,11 +15,12 @@ const { prefix } = settings;
 
 /**
  * Header.
+ * @element bx-header-nav
  */
 @customElement(`${prefix}-header-nav`)
 class BXHeaderNav extends LitElement {
   /**
-   * The `aria-label` attribute for the menu bar UI. Corresponds to `menu-bar-label` attribute.
+   * The `aria-label` attribute for the menu bar UI.
    */
   @property({ attribute: 'menu-bar-label' })
   menuBarLabel!: string;

--- a/src/components/ui-shell/header.ts
+++ b/src/components/ui-shell/header.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Header.
+ * @element bx-header
  */
 @customElement(`${prefix}-header`)
 class BXHeader extends LitElement {

--- a/src/components/ui-shell/side-nav-items.ts
+++ b/src/components/ui-shell/side-nav-items.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,6 +15,7 @@ const { prefix } = settings;
 
 /**
  * Side nav items.
+ * @element bx-side-nav-items
  */
 @customElement(`${prefix}-side-nav-items`)
 class BXSideNavItems extends LitElement {

--- a/src/components/ui-shell/side-nav-link.ts
+++ b/src/components/ui-shell/side-nav-link.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,6 +17,8 @@ const { prefix } = settings;
 
 /**
  * Side nav menu item.
+ * @element bx-side-nav-link
+ * @slot title-icon - The icon.
  */
 @customElement(`${prefix}-side-nav-link`)
 class BXSideNavLink extends FocusMixin(LitElement) {
@@ -34,13 +36,13 @@ class BXSideNavLink extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if the menu item should be active. Corresponds to the attribute with the same name.
+   * `true` if the menu item should be active.
    */
   @property({ type: Boolean, reflect: true })
   active = false;
 
   /**
-   * Link `href`. Corresponds to the attribute with the same name.
+   * Link `href`.
    */
   @property()
   href = '';

--- a/src/components/ui-shell/side-nav-menu-item.ts
+++ b/src/components/ui-shell/side-nav-menu-item.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -17,17 +17,18 @@ const { prefix } = settings;
 
 /**
  * Side nav menu item.
+ * @element bx-side-nav-menu-item
  */
 @customElement(`${prefix}-side-nav-menu-item`)
 class BXSideNavMenuItem extends FocusMixin(LitElement) {
   /**
-   * `true` if the menu item should be active. Corresponds to the attribute with the same name.
+   * `true` if the menu item should be active.
    */
   @property({ type: Boolean, reflect: true })
   active = false;
 
   /**
-   * Link `href`. Corresponds to the attribute with the same name.
+   * Link `href`.
    */
   @property()
   href = '';

--- a/src/components/ui-shell/side-nav-menu.ts
+++ b/src/components/ui-shell/side-nav-menu.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,6 +18,8 @@ const { prefix } = settings;
 
 /**
  * Side nav menu.
+ * @element bx-side-nav-menu
+ * @slot title-icon - The icon.
  */
 @customElement(`${prefix}-side-nav-menu`)
 class BXSideNavMenu extends FocusMixin(LitElement) {
@@ -77,25 +79,25 @@ class BXSideNavMenu extends FocusMixin(LitElement) {
   }
 
   /**
-   * `true` if the menu has active menu item. Corresponds to the attribute with the same name.
+   * `true` if the menu has active menu item.
    */
   @property({ type: Boolean, reflect: true })
   active = false;
 
   /**
-   * `true` if the menu should be open. Corresponds to the attribute with the same name.
+   * `true` if the menu should be open.
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
   /**
-   * `true` if the menu should be forced collapsed upon side nav's expanded state. Corresponds to `force-collapsed` attribute.
+   * `true` if the menu should be forced collapsed upon side nav's expanded state.
    */
   @property({ type: Boolean, reflect: true, attribute: 'force-collapsed' })
   forceCollapsed = false;
 
   /**
-   * The title text. Corresponds to the attribute with the same name.
+   * The title text.
    */
   @property()
   title = '';

--- a/src/components/ui-shell/side-nav.ts
+++ b/src/components/ui-shell/side-nav.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,7 @@ const { prefix } = settings;
 
 /**
  * Side nav.
+ * @element bx-side-nav
  */
 @customElement(`${prefix}-side-nav`)
 class BXSideNav extends HostListenerMixin(LitElement) {
@@ -58,13 +59,13 @@ class BXSideNav extends HostListenerMixin(LitElement) {
   }
 
   /**
-   * `true` to expand the side nav. Corresponds to the attribute with the same name.
+   * `true` to expand the side nav.
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
   /**
-   * `true` to make the side nav non-collapsible. Corresponds to the attribute with the same name.
+   * `true` to make the side nav non-collapsible.
    */
   @property({ type: Boolean, reflect: true })
   fixed = false;

--- a/src/components/ui-shell/ui-shell-story.mdx
+++ b/src/components/ui-shell/ui-shell-story.mdx
@@ -1,4 +1,4 @@
-import { Preview, Story } from '@storybook/addon-docs/blocks';
+import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # UI Shell
 
@@ -30,6 +30,30 @@ Side nav in UI Shell consists of the following components:
 
 Unlike `<bx-dropdown>`, etc., user gesture of side nav item won't update the selection by itself. The assumption is that following the link in `<side-nav-link>`/`<side-nav-menu-item>` triggers routing in application, and application chooses which `<side-nav-link>`/`<side-nav-menu-item>` to set `active` attribute to, with the new URL.
 
+### `<bx-side-nav>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-side-nav expanded>`) and `false` means not setting the attribute (e.g. `<bx-side-nav>` without `expanded` attribute).
+
+<Props of="bx-side-nav" />
+
+### `<bx-side-nav-link>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-side-nav-link active>`) and `false` means not setting the attribute (e.g. `<bx-side-nav-link>` without `active` attribute).
+
+<Props of="bx-side-nav-link" />
+
+### `<bx-side-nav-menu>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-side-nav-menu active>`) and `false` means not setting the attribute (e.g. `<bx-side-nav-menu>` without `active` attribute).
+
+<Props of="bx-side-nav-menu" />
+
+### `<bx-side-nav-menu-item>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-side-nav-menu-item active>`) and `false` means not setting the attribute (e.g. `<bx-side-nav-menu-item>` without `active` attribute).
+
+<Props of="bx-side-nav-menu-item" />
+
 ## Header nav
 
 Header nav in UI Shell consists of the following components:
@@ -47,3 +71,31 @@ Header nav in UI Shell consists of the following components:
 <Preview withToolbar>
   <Story id="ui-shell--header" />
 </Preview>
+
+### `<bx-header-nav>` attributes and properties
+
+<Props of="bx-header-nav" />
+
+### `<bx-header-nav-item>` attributes and properties
+
+<Props of="bx-header-nav-item" />
+
+### `<bx-header-menu>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-header-menu expanded>`) and `false` means not setting the attribute (e.g. `<bx-header-menu>` without `expanded` attribute).
+
+<Props of="bx-header-menu" />
+
+### `<bx-header-menu-button>` attributes and properties
+
+Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. `<bx-header-menu-button active>`) and `false` means not setting the attribute (e.g. `<bx-header-menu-button>` without `active` attribute).
+
+<Props of="bx-header-menu-button" />
+
+### `<bx-header-menu-item>` attributes and properties
+
+<Props of="bx-header-menu-item" />
+
+### `<bx-header-name>` attributes and properties
+
+<Props of="bx-header-name" />

--- a/tests/snapshots/bx-progress-step.md
+++ b/tests/snapshots/bx-progress-step.md
@@ -14,7 +14,7 @@
   >
   </p>
 </slot>
-<slot name="secondary-label">
+<slot name="secondary-label-text">
 </slot>
 <span class="bx--progress-line">
 </span>
@@ -34,7 +34,7 @@
     label-text-foo
   </p>
 </slot>
-<slot name="secondary-label">
+<slot name="secondary-label-text">
   <p class="bx--progress-optional">
     secondary-label-text-foo
   </p>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "strict": true,
     "noImplicitAny": false,
     "jsx": "react",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,7 +1039,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
   integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
@@ -1777,10 +1777,23 @@
     "@nodelib/fs.stat" "2.0.1"
     run-parallel "^1.1.9"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
 "@nodelib/fs.stat@2.0.1", "@nodelib/fs.stat@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz#814f71b1167390cfcb6a6b3d9cdeb0951a192c14"
   integrity sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -1793,6 +1806,14 @@
   integrity sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==
   dependencies:
     "@nodelib/fs.scandir" "2.1.1"
+    fastq "^1.6.0"
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
 "@open-wc/semantic-dom-diff@^0.15.0":
@@ -3357,7 +3378,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -5258,6 +5279,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 clone-buffer@^1.0.0:
   version "1.0.0"
@@ -7445,6 +7475,17 @@ fast-glob@^3.0.3:
     merge2 "^1.2.3"
     micromatch "^4.0.2"
 
+fast-glob@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
+  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+
 fast-json-parse@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
@@ -8212,7 +8253,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
   integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
@@ -11764,6 +11805,11 @@ merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+
+merge2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
+  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -16083,7 +16129,7 @@ string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.1.0:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -16833,6 +16879,11 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
+ts-simple-type@~0.3.6:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/ts-simple-type/-/ts-simple-type-0.3.7.tgz#1e77222c3d90d7093f80a954e74c725fd99c911c"
+  integrity sha512-bDXWURwpDpe1mA5E9eldmI0Mpt9zGprhtN/ZTLOJjsAMyeMy1UT7WvGRQghYewIYBYxDZurChhe4DrsPbcCVrA==
+
 tsconfig-paths-webpack-plugin@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.2.0.tgz#6e70bd42915ad0efb64d3385163f0c1270f3e04d"
@@ -16929,6 +16980,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.5.3:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^3.7.0:
   version "3.7.2"
@@ -17665,6 +17721,16 @@ watchpack@^1.5.0, watchpack@^1.6.0:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
 
+web-component-analyzer@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/web-component-analyzer/-/web-component-analyzer-1.0.2.tgz#858cfb6bb2b1a7a8a0bc30f0eeaba2326aab0df7"
+  integrity sha512-WKToacrDMxBp1Nn9+Ox+9Y0ASOxnA1R4hqC39/BfnXtxsCthY3NO8tAvH2zMToL+/b6kpewR79EfmszANj0mvA==
+  dependencies:
+    fast-glob "^3.1.0"
+    ts-simple-type "~0.3.6"
+    typescript "^3.5.3"
+    yargs "^15.0.2"
+
 web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.3.tgz#9bbf5c99ff0908d2da031f1d732492a96571a83f"
@@ -17972,6 +18038,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -18097,6 +18172,14 @@ yargs-parser@^13.0.0, yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -18162,6 +18245,23 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yargs@^15.0.2:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^16.1.0"
 
 yargs@^7.0.0, yargs@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
This adds `custom-elements.json` support in Storybook, showing available attributes, etc. list in Docs pane.
`custom-elements.json` can be generated by `yarn wca` task.