### PR TITLE
chore(components): move by-state props to enums

### DIFF
--- a/src/components/button/button-skeleton.ts
+++ b/src/components/button/button-skeleton.ts
@@ -33,11 +33,11 @@ class BXButtonSkeleton extends BXButton {
   }
 
   render() {
-    const { autofocus, disabled, download, href, hreflang, ping, rel, small, target, type } = this;
+    const { autofocus, disabled, download, href, hreflang, ping, rel, size, target, type } = this;
     const classes = classMap({
       [`${prefix}--btn`]: true,
       [`${prefix}--skeleton`]: true,
-      [`${prefix}--btn--sm`]: small,
+      [`${prefix}--btn--${size}`]: size,
     });
     return href
       ? html`

--- a/src/components/button/button-story-angular.ts
+++ b/src/components/button/button-story-angular.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,7 +18,7 @@ import baseStory, {
 
 export const defaultStory = ({ parameters }) => ({
   template: `
-    <bx-btn [kind]="kind" [disabled]="disabled" [small]="small" [href]="href" (click)="onClick($event)">Button</bx-btn>
+    <bx-btn [kind]="kind" [disabled]="disabled" [size]="size" [href]="href" (click)="onClick($event)">Button</bx-btn>
   `,
   props: parameters?.props?.['bx-btn'],
 });
@@ -27,7 +27,7 @@ defaultStory.story = baseDefaultStory.story;
 
 export const icon = ({ parameters }) => ({
   template: `
-    <bx-btn [kind]="kind" [disabled]="disabled" [small]="small" [href]="href" (click)="onClick($event)">
+    <bx-btn [kind]="kind" [disabled]="disabled" [size]="size" [href]="href" (click)="onClick($event)">
       <ibm-icon-add16 slot="icon"></ibm-icon-add16>
     </bx-btn>
   `,
@@ -44,7 +44,7 @@ icon.story = {
 
 export const textAndIcon = ({ parameters }) => ({
   template: `
-    <bx-btn [kind]="kind" [disabled]="disabled" [small]="small" [href]="href" (click)="onClick($event)">
+    <bx-btn [kind]="kind" [disabled]="disabled" [size]="size" [href]="href" (click)="onClick($event)">
       Button <ibm-icon-add16 slot="icon"></ibm-icon-add16>
     </bx-btn>
   `,

--- a/src/components/button/button-story-react.tsx
+++ b/src/components/button/button-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,9 +20,9 @@ import { defaultStory as baseDefaultStory, textAndIcon as baseTextAndIcon, skele
 export { default } from './button-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { kind, disabled, small, href } = parameters?.props?.['bx-btn'];
+  const { kind, disabled, size, href } = parameters?.props?.['bx-btn'];
   return (
-    <BXBtn kind={kind} disabled={disabled} small={small} href={href}>
+    <BXBtn kind={kind} disabled={disabled} size={size} href={href}>
       Button
     </BXBtn>
   );
@@ -31,18 +31,18 @@ export const defaultStory = ({ parameters }) => {
 defaultStory.story = baseDefaultStory.story;
 
 export const icon = ({ parameters }) => {
-  const { kind, disabled, small, href } = parameters?.props?.['bx-btn'];
+  const { kind, disabled, size, href } = parameters?.props?.['bx-btn'];
   return (
-    <BXBtn kind={kind} disabled={disabled} small={small} href={href}>
+    <BXBtn kind={kind} disabled={disabled} size={size} href={href}>
       <Add16 slot="icon" />
     </BXBtn>
   );
 };
 
 export const textAndIcon = ({ parameters }) => {
-  const { kind, disabled, small, href } = parameters?.props?.['bx-btn'];
+  const { kind, disabled, size, href } = parameters?.props?.['bx-btn'];
   return (
-    <BXBtn kind={kind} disabled={disabled} small={small} href={href}>
+    <BXBtn kind={kind} disabled={disabled} size={size} href={href}>
       Button <Add16 slot="icon" />
     </BXBtn>
   );
@@ -51,8 +51,8 @@ export const textAndIcon = ({ parameters }) => {
 textAndIcon.story = baseTextAndIcon.story;
 
 export const skeleton = ({ parameters }) => {
-  const { disabled, small, href } = parameters?.props?.['bx-btn-skeleton'];
-  return <BXBtnSkeleton disabled={disabled} small={small} href={href}></BXBtnSkeleton>;
+  const { disabled, size, href } = parameters?.props?.['bx-btn-skeleton'];
+  return <BXBtnSkeleton disabled={disabled} size={size} href={href}></BXBtnSkeleton>;
 };
 
 skeleton.story = baseSkeleton.story;

--- a/src/components/button/button-story-vue.ts
+++ b/src/components/button/button-story-vue.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -15,7 +15,7 @@ export { default } from './button-story';
 
 export const defaultStory = ({ parameters }) => ({
   template: `
-    <bx-btn :kind="kind" :disabled="disabled" :small="small" :href="href" @click="onClick">Button</bx-btn>
+    <bx-btn :kind="kind" :disabled="disabled" :size="size" :href="href" @click="onClick">Button</bx-btn>
   `,
   ...createVueBindingsFromProps(parameters?.props?.['bx-btn']),
 });
@@ -24,7 +24,7 @@ defaultStory.story = baseDefaultStory.story;
 
 export const icon = ({ parameters }) => ({
   template: `
-    <bx-btn :kind="kind" :disabled="disabled" :small="small" :href="href" @click="onClick">
+    <bx-btn :kind="kind" :disabled="disabled" :size="size" :href="href" @click="onClick">
       <add-16 slot="icon"></add-16>
     </bx-btn>
   `,
@@ -36,7 +36,7 @@ export const icon = ({ parameters }) => ({
 
 export const textAndIcon = ({ parameters }) => ({
   template: `
-    <bx-btn :kind="kind" :disabled="disabled" :small="small" :href="href" @click="onClick">
+    <bx-btn :kind="kind" :disabled="disabled" :size="size" :href="href" @click="onClick">
       Button <add-16 slot="icon"></add-16>
     </bx-btn>
   `,

--- a/src/components/button/button-story.ts
+++ b/src/components/button/button-story.ts
@@ -12,7 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
 import Add16 from '@carbon/icons/lib/add/16';
 import ifNonNull from '../../globals/directives/if-non-null';
-import { BUTTON_KIND } from './button';
+import { BUTTON_KIND, BUTTON_SIZE } from './button';
 import './button-skeleton';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import storyDocs from './button-story.mdx';
@@ -24,8 +24,13 @@ const kinds = {
   [`Ghost button (${BUTTON_KIND.GHOST})`]: BUTTON_KIND.GHOST,
 };
 
+const sizes = {
+  [`Regular size`]: null,
+  [`Small size (${BUTTON_SIZE.SMALL})`]: BUTTON_SIZE.SMALL,
+};
+
 export const defaultStory = ({ parameters }) => {
-  const { autofocus, disabled, download, href, hreflang, kind, ping, rel, small, target, type, onClick } =
+  const { autofocus, disabled, download, href, hreflang, kind, ping, rel, size, target, type, onClick } =
     parameters?.props?.['bx-btn'] ?? {};
   return html`
     <bx-btn
@@ -37,7 +42,7 @@ export const defaultStory = ({ parameters }) => {
       kind="${ifNonNull(kind)}"
       ping="${ifNonNull(ping)}"
       rel="${ifNonNull(rel)}"
-      ?small="${small}"
+      size="${ifNonNull(size)}"
       target="${ifNonNull(target)}"
       type="${ifNonNull(type)}"
       @click=${onClick}
@@ -52,18 +57,30 @@ defaultStory.story = {
 };
 
 export const icon = ({ parameters }) => {
-  const { kind, disabled, small, href, onClick } = parameters?.props?.['bx-btn'] ?? {};
+  const { kind, disabled, size, href, onClick } = parameters?.props?.['bx-btn'] ?? {};
   return html`
-    <bx-btn kind=${ifNonNull(kind)} ?disabled=${disabled} ?small=${small} href=${ifNonNull(href || undefined)} @click=${onClick}>
+    <bx-btn
+      kind=${ifNonNull(kind)}
+      ?disabled=${disabled}
+      size=${ifNonNull(size)}
+      href=${ifNonNull(href || undefined)}
+      @click=${onClick}
+    >
       ${Add16({ slot: 'icon' })}
     </bx-btn>
   `;
 };
 
 export const textAndIcon = ({ parameters }) => {
-  const { kind, disabled, small, href, onClick } = parameters?.props?.['bx-btn'] ?? {};
+  const { kind, disabled, size, href, onClick } = parameters?.props?.['bx-btn'] ?? {};
   return html`
-    <bx-btn kind=${ifNonNull(kind)} ?disabled=${disabled} ?small=${small} href=${ifNonNull(href || undefined)} @click=${onClick}>
+    <bx-btn
+      kind=${ifNonNull(kind)}
+      ?disabled=${disabled}
+      size=${ifNonNull(size)}
+      href=${ifNonNull(href || undefined)}
+      @click=${onClick}
+    >
       Button ${Add16({ slot: 'icon' })}
     </bx-btn>
   `;
@@ -74,9 +91,9 @@ textAndIcon.story = {
 };
 
 export const skeleton = ({ parameters }) => {
-  const { disabled, small, href, onClick } = parameters?.props?.['bx-btn-skeleton'];
+  const { disabled, size, href, onClick } = parameters?.props?.['bx-btn-skeleton'];
   return html`
-    <bx-btn-skeleton ?disabled=${disabled} ?small=${small} href=${ifNonNull(href || undefined)} @click=${onClick}>
+    <bx-btn-skeleton ?disabled=${disabled} size=${ifNonNull(size)} href=${ifNonNull(href || undefined)} @click=${onClick}>
     </bx-btn-skeleton>
   `;
 };
@@ -87,7 +104,7 @@ skeleton.story = {
       'bx-btn-skeleton': () => ({
         kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY),
         disabled: boolean('Disabled (disabled)', false),
-        small: boolean('Small (small)', false),
+        size: select('Button size (size)', sizes, null),
         href: textNullable('Link href (href)', ''),
         onClick: action('click'),
       }),
@@ -105,7 +122,7 @@ export default {
       'bx-btn': () => ({
         kind: select('Button kind (kind)', kinds, BUTTON_KIND.PRIMARY),
         disabled: boolean('Disabled (disabled)', false),
-        small: boolean('Small (small)', false),
+        size: select('Button size (size)', sizes, null),
         href: textNullable('Link href (href)', ''),
         onClick: action('click'),
       }),

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -42,6 +42,21 @@ export enum BUTTON_KIND {
 }
 
 /**
+ * Button size.
+ */
+export enum BUTTON_SIZE {
+  /**
+   * Regular size.
+   */
+  REGULAR = '',
+
+  /**
+   * Small size.
+   */
+  SMALL = 'sm',
+}
+
+/**
  * Button.
  * @element bx-btn
  */
@@ -130,10 +145,10 @@ class BXButton extends FocusMixin(LitElement) {
   rel!: string;
 
   /**
-   * `true` if the button should be a small variant.
+   * Button size.
    */
-  @property({ type: Boolean, reflect: true })
-  small = false;
+  @property({ reflect: true })
+  size = BUTTON_SIZE.REGULAR;
 
   /**
    * The link target, if this button is rendered as `<a>`.
@@ -161,7 +176,7 @@ class BXButton extends FocusMixin(LitElement) {
       kind,
       ping,
       rel,
-      small,
+      size,
       target,
       type,
       _hasIcon: hasIcon,
@@ -173,7 +188,7 @@ class BXButton extends FocusMixin(LitElement) {
       [`${prefix}--btn--${kind}`]: kind,
       [`${prefix}--btn--disabled`]: disabled,
       [`${prefix}--btn--icon-only`]: hasIcon && !hasMainContent,
-      [`${prefix}--btn--sm`]: small,
+      [`${prefix}--btn--${size}`]: size,
       [`${prefix}-ce--btn--has-icon`]: hasIcon,
     });
     return href

--- a/src/components/date-picker/date-picker-input.ts
+++ b/src/components/date-picker/date-picker-input.ts
@@ -43,6 +43,21 @@ export enum DATE_PICKER_INPUT_KIND {
 }
 
 /**
+ * Horizontal size, applicable only to the simple variant.
+ */
+export enum DATE_PICKER_INPUT_SIZE_HORIZONTAL {
+  /**
+   * Regular size.
+   */
+  REGULAR = 'regular',
+
+  /**
+   * Short size.
+   */
+  SHORT = 'short',
+}
+
+/**
  * The input box for date picker.
  * @element bx-date-picker-input
  */
@@ -169,8 +184,8 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
    * `true` if this date picker input should use the short UI variant.
    * Effective only when `kind` property is `DATE_PICKER_INPUT_KIND.SIMPLE`.
    */
-  @property({ type: Boolean, reflect: true })
-  short = false;
+  @property({ attribute: 'size-horizontal', reflect: true })
+  sizeHorizontal = DATE_PICKER_INPUT_SIZE_HORIZONTAL.REGULAR;
 
   /**
    * The `type` attribute for the `<input>` in the shadow DOM.

--- a/src/components/date-picker/date-picker-story-angular.ts
+++ b/src/components/date-picker/date-picker-story-angular.ts
@@ -28,6 +28,7 @@ export const defaultStory = ({ parameters }) => ({
       [labelText]="labelText"
       [light]="light"
       [placeholder]="placeholder"
+      [sizeHorizontal]="sizeHorizontal"
       [validityMessage]="validityMessage"
     >
     </bx-date-picker-input>

--- a/src/components/date-picker/date-picker-story-react.tsx
+++ b/src/components/date-picker/date-picker-story-react.tsx
@@ -28,7 +28,7 @@ import {
 export { default } from './date-picker-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage } = parameters?.props?.[
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, sizeHorizontal, validityMessage } = parameters?.props?.[
     'bx-date-picker-input'
   ];
   return (
@@ -40,6 +40,7 @@ export const defaultStory = ({ parameters }) => {
         labelText={labelText}
         light={light}
         placeholder={placeholder}
+        sizeHorizontal={sizeHorizontal}
         validityMessage={validityMessage}
       />
     </BXDatePicker>

--- a/src/components/date-picker/date-picker-story-vue.ts
+++ b/src/components/date-picker/date-picker-story-vue.ts
@@ -29,6 +29,7 @@ export const defaultStory = ({ parameters }) => ({
         :label-text="labelText"
         :light="light"
         :placeholder="placeholder"
+        :size-horizontal="sizeHorizontal"
         :validity-message="validityMessage"
       >
       </bx-date-picker-input>

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -7,11 +7,11 @@
 
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './date-picker';
-import './date-picker-input';
+import { DATE_PICKER_INPUT_SIZE_HORIZONTAL } from './date-picker-input';
 import storyDocs from './date-picker-story.mdx';
 import './date-picker-input-skeleton';
 
@@ -34,8 +34,24 @@ const knobs = {
   }),
 };
 
+const sizesHorizontal = {
+  [`Regular size`]: null,
+  [`Short size (${DATE_PICKER_INPUT_SIZE_HORIZONTAL.SHORT})`]: DATE_PICKER_INPUT_SIZE_HORIZONTAL.SHORT,
+};
+
+const getInputKnobs = () => ({
+  disabled: boolean('Disabled (disabled in <bx-date-picker-input>)', false),
+  hideLabel: boolean('Hide label (hide-label in <bx-date-picker-input>)', false),
+  invalid: boolean('Show invalid state  (invalid)', false),
+  labelText: textNullable('Label text (label-text in <bx-date-picker-input>)', 'Date Picker label'),
+  light: boolean('Light variant (light in <bx-date-picker-input>)', false),
+  placeholder: textNullable('Placeholder text (placeholder in <bx-date-picker-input>)', 'mm/dd/yyyy'),
+  validityMessage: textNullable('The validity message (validity-message)', ''),
+  onInput: action('input'),
+});
+
 export const defaultStory = ({ parameters }) => {
-  const { disabled, hideLabel, invalid, labelText, light, placeholder, validityMessage } =
+  const { disabled, hideLabel, invalid, labelText, light, placeholder, sizeHorizontal, validityMessage } =
     parameters?.props?.['bx-date-picker-input'] ?? {};
   return html`
     <bx-date-picker>
@@ -46,6 +62,7 @@ export const defaultStory = ({ parameters }) => {
         label-text="${ifNonNull(labelText)}"
         ?light="${light}"
         placeholder="${ifNonNull(placeholder)}"
+        size-horizontal="${ifNonNull(sizeHorizontal)}"
         validity-message="${ifNonNull(validityMessage)}"
       >
       </bx-date-picker-input>
@@ -57,7 +74,10 @@ defaultStory.story = {
   name: 'Default',
   parameters: {
     knobs: {
-      'bx-date-picker-input': knobs['bx-date-picker-input'],
+      'bx-date-picker-input': () => ({
+        ...getInputKnobs(),
+        sizeHorizontal: select('Horizontal size (size-horizontal)', sizesHorizontal, null),
+      }),
     },
   },
 };

--- a/src/components/date-picker/date-picker.scss
+++ b/src/components/date-picker/date-picker.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -77,8 +77,8 @@ $css--plex: true !default;
   }
 }
 
-:host(#{$prefix}-date-picker-input[kind='simple'][short]),
-:host(#{$prefix}-date-picker-input-skeleton[kind='simple'][short]) {
+:host(#{$prefix}-date-picker-input[kind='simple'][size-horizontal='short']),
+:host(#{$prefix}-date-picker-input-skeleton[kind='simple'][size-horizontal='short']) {
   .#{$prefix}--date-picker__input {
     width: rem(90px);
   }

--- a/src/components/dropdown/dropdown-story-react.tsx
+++ b/src/components/dropdown/dropdown-story-react.tsx
@@ -30,6 +30,7 @@ export const defaultStory = ({ parameters }) => {
     toggleLabelClosed,
     toggleLabelOpen,
     triggerContent,
+    type,
     value,
     disableSelection,
     onBeforeSelect,
@@ -51,6 +52,7 @@ export const defaultStory = ({ parameters }) => {
       toggleLabelClosed={toggleLabelClosed}
       toggleLabelOpen={toggleLabelOpen}
       triggerContent={triggerContent}
+      type={type}
       value={value}
       onBeforeSelect={handleBeforeSelected}
       onSelect={onSelect}>

--- a/src/components/toggle/toggle-story-angular.ts
+++ b/src/components/toggle/toggle-story-angular.ts
@@ -19,7 +19,7 @@ export const defaultStory = ({ parameters }) => ({
       [disabled]="disabled"
       [labelText]="labelText"
       [name]="name"
-      [small]="small"
+      [size]="size"
       [uncheckedText]="uncheckedText"
       [value]="value"
       (bx-toggle-changed)="onChange($event)"

--- a/src/components/toggle/toggle-story-react.tsx
+++ b/src/components/toggle/toggle-story-react.tsx
@@ -17,7 +17,7 @@ import { defaultStory as baseDefaultStory } from './toggle-story';
 export { default } from './toggle-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onChange } = parameters?.props?.[
+  const { checked, checkedText, disabled, labelText, name, size, uncheckedText, value, onChange } = parameters?.props?.[
     'bx-toggle'
   ];
   return (
@@ -27,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
       disabled={disabled}
       labelText={labelText}
       name={name}
-      small={small}
+      size={size}
       uncheckedText={uncheckedText}
       value={value}
       onChange={onChange}

--- a/src/components/toggle/toggle-story-vue.ts
+++ b/src/components/toggle/toggle-story-vue.ts
@@ -20,7 +20,7 @@ export const defaultStory = ({ parameters }) => ({
       :disabled="disabled"
       :label-text="labelText"
       :name="name"
-      :small="small"
+      :size="size"
       :unchecked-text="uncheckedText"
       :value="value"
       @bx-toggle-changed="onChange"

--- a/src/components/toggle/toggle-story.ts
+++ b/src/components/toggle/toggle-story.ts
@@ -9,14 +9,19 @@
 
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
-import './toggle';
+import { TOGGLE_SIZE } from './toggle';
 import storyDocs from './toggle-story.mdx';
 
+const sizes = {
+  [`Regular size`]: null,
+  [`Small size (${TOGGLE_SIZE.SMALL})`]: TOGGLE_SIZE.SMALL,
+};
+
 export const defaultStory = ({ parameters }) => {
-  const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, onChange } =
+  const { checked, checkedText, disabled, labelText, name, size, uncheckedText, value, onChange } =
     parameters?.props?.['bx-toggle'] ?? {};
   return html`
     <bx-toggle
@@ -25,7 +30,7 @@ export const defaultStory = ({ parameters }) => {
       ?disabled="${disabled}"
       label-text="${ifNonNull(labelText)}"
       name="${ifNonNull(name)}"
-      ?small="${small}"
+      size="${ifNonNull(size)}"
       unchecked-text="${ifNonNull(uncheckedText)}"
       value="${ifNonNull(value)}"
       @bx-toggle-changed="${onChange}"
@@ -50,7 +55,7 @@ export default {
         disabled: boolean('Disabled (disabled)', false),
         labelText: textNullable('Label text (label-text)', 'Toggle'),
         name: textNullable('Name (name)', ''),
-        small: boolean('Use small variant (small)', false),
+        size: select('Toggle size (size)', sizes, null),
         uncheckedText: textNullable('Text for unchecked state (unchecked-text)', 'Off'),
         value: textNullable('Value (value)', ''),
         onChange: action('bx-toggle-changed'),

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -17,6 +17,21 @@ import styles from './toggle.scss';
 const { prefix } = settings;
 
 /**
+ * Toggle size.
+ */
+export enum TOGGLE_SIZE {
+  /**
+   * Regular size.
+   */
+  REGULAR = '',
+
+  /**
+   * Small size.
+   */
+  SMALL = 'small',
+}
+
+/**
  * Basic toggle.
  * @element bx-toggle
  * @slot label-text - The label text.
@@ -27,7 +42,7 @@ const { prefix } = settings;
 @customElement(`${prefix}-toggle`)
 class BXToggle extends BXCheckbox {
   protected _renderCheckmark() {
-    if (!this.small) {
+    if (this.size !== TOGGLE_SIZE.SMALL) {
       return undefined;
     }
     return html`
@@ -44,10 +59,10 @@ class BXToggle extends BXCheckbox {
   checkedText = '';
 
   /**
-   * `true` to use the small variant.
+   * Toggle size.
    */
-  @property({ type: Boolean, reflect: true })
-  small = false;
+  @property({ reflect: true })
+  size = TOGGLE_SIZE.REGULAR;
 
   /**
    * The text for the unchecked state.
@@ -56,10 +71,10 @@ class BXToggle extends BXCheckbox {
   uncheckedText = '';
 
   render() {
-    const { checked, checkedText, disabled, labelText, name, small, uncheckedText, value, _handleChange: handleChange } = this;
+    const { checked, checkedText, disabled, labelText, name, size, uncheckedText, value, _handleChange: handleChange } = this;
     const inputClasses = classMap({
       [`${prefix}--toggle-input`]: true,
-      [`${prefix}--toggle-input--small`]: small,
+      [`${prefix}--toggle-input--${size}`]: size,
     });
     return html`
       <input

--- a/tests/snapshots/bx-toggle.md
+++ b/tests/snapshots/bx-toggle.md
@@ -42,7 +42,7 @@
 ```
 <input
   aria-checked="true"
-  class="bx--toggle-input"
+  class="bx--toggle-input bx--toggle-input--small"
   disabled=""
   id="checkbox"
   name="name-foo"

--- a/tests/spec/button_spec.ts
+++ b/tests/spec/button_spec.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -61,7 +61,7 @@ describe('bx-btn', function() {
     });
 
     it('should make it small when small attribute is set', async function() {
-      elem!.setAttribute('small', '');
+      elem!.setAttribute('size', 'sm');
       await Promise.resolve();
       expect(elem!.shadowRoot!.querySelectorAll('.bx--btn--sm').length).toBe(1);
     });
@@ -93,7 +93,7 @@ describe('bx-btn', function() {
           autofocus: true,
           disabled: true,
           kind: BUTTON_KIND.SECONDARY,
-          small: true,
+          size: 'sm',
           type: 'submit',
         }),
         document.body
@@ -118,7 +118,7 @@ describe('bx-btn', function() {
           kind: BUTTON_KIND.SECONDARY,
           ping: 'about:blank',
           rel: 'noopener',
-          small: true,
+          size: 'sm',
           target: '_blank',
           type: 'text/plain',
         }),

--- a/tests/spec/toggle_spec.ts
+++ b/tests/spec/toggle_spec.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -54,6 +54,7 @@ describe('bx-toggle', function() {
           disabled: true,
           labelText: 'label-text-foo',
           name: 'name-foo',
+          size: 'small',
           value: 'value-foo',
           uncheckedText: 'unchecked-text-foo',
         }),


### PR DESCRIPTION
This change replaes misc boolean attributes with enum attribute. This ensures forward-compatibility in case additional color scheme option may be added.