### PR TITLE
chore(lint): add snapshots to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 /dist
 /docs/js
 /tests/coverage
+/tests/snapshots
 es
 node_modules


### PR DESCRIPTION
Adds snapshots to `.prettierignore`, as they are auto-generated files.