### PR TITLE
feat(components): form validation API support

### DIFF
--- a/src/components/date-picker/date-picker-input.ts
+++ b/src/components/date-picker/date-picker-input.ts
@@ -13,6 +13,7 @@ import Calendar16 from '@carbon/icons/lib/calendar/16';
 import settings from 'carbon-components/es/globals/js/settings';
 import ifNonNull from '../../globals/directives/if-non-null';
 import FocusMixin from '../../globals/mixins/focus';
+import ValidityMixin from '../../globals/mixins/validity';
 import styles from './date-picker.scss';
 
 const { prefix } = settings;
@@ -62,7 +63,7 @@ export enum DATE_PICKER_INPUT_SIZE_HORIZONTAL {
  * @element bx-date-picker-input
  */
 @customElement(`${prefix}-date-picker-input`)
-class BXDatePickerInput extends FocusMixin(LitElement) {
+class BXDatePickerInput extends ValidityMixin(FocusMixin(LitElement)) {
   /**
    * The `<slot>` for the validity message.
    */
@@ -179,6 +180,18 @@ class BXDatePickerInput extends FocusMixin(LitElement) {
    */
   @property()
   placeholder!: string;
+
+  /**
+   * `true` if the value is required.
+   */
+  @property({ type: Boolean, reflect: true })
+  required = false;
+
+  /**
+   * The special validity message for `required`.
+   */
+  @property()
+  requiredValidityMessage = 'Please fill out this field.';
 
   /**
    * `true` if this date picker input should use the short UI variant.

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -16,6 +16,7 @@ import ChevronDown16 from '@carbon/icons/lib/chevron--down/16';
 import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
 import FocusMixin from '../../globals/mixins/focus';
 import HostListenerMixin from '../../globals/mixins/host-listener';
+import ValidityMixin from '../../globals/mixins/validity';
 import HostListener from '../../globals/decorators/host-listener';
 import { find, forEach, indexOf } from '../../globals/internal/collection-helpers';
 import BXDropdownItem from './dropdown-item';
@@ -82,7 +83,7 @@ export enum DROPDOWN_TYPE {
  * @fires bx-dropdown-selected - The custom event fired after a a dropdown item is selected upon a user gesture.
  */
 @customElement(`${prefix}-dropdown`)
-class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
+class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))) {
   /**
    * The latest status of this dropdown, for screen reader to accounce.
    */
@@ -398,6 +399,18 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
    */
   @property({ type: Boolean, reflect: true })
   open = false;
+
+  /**
+   * `true` if the value is required.
+   */
+  @property({ type: Boolean, reflect: true })
+  required = false;
+
+  /**
+   * The special validity message for `required`.
+   */
+  @property()
+  requiredValidityMessage = 'Please fill out this field.';
 
   /**
    * An assistive text for screen reader to announce, telling the open state.

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -13,6 +13,7 @@ import settings from 'carbon-components/es/globals/js/settings';
 import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
 import ifNonEmpty from '../../globals/directives/if-non-empty';
 import FormMixin from '../../globals/mixins/form';
+import ValidityMixin from '../../globals/mixins/validity';
 import styles from './input.scss';
 
 const { prefix } = settings;
@@ -38,7 +39,7 @@ export enum INPUT_TYPE {
  * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-input`)
-export default class BXInput extends FormMixin(LitElement) {
+export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
   /**
    * Handles `oninput` event on the `<input>`.
    * @param event The event.
@@ -120,6 +121,12 @@ export default class BXInput extends FormMixin(LitElement) {
    */
   @property({ type: Boolean, reflect: true })
   required = false;
+
+  /**
+   * The special validity message for `required`.
+   */
+  @property()
+  requiredValidityMessage = 'Please fill out this field.';
 
   /**
    * The type of the input. Can be one of the types listed in the INPUT_TYPE enum

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -14,6 +14,7 @@ import WarningFilled16 from '@carbon/icons/lib/warning--filled/16';
 import ifNonEmpty from '../../globals/directives/if-non-empty';
 import ifNonNull from '../../globals/directives/if-non-null';
 import FormMixin from '../../globals/mixins/form';
+import ValidityMixin from '../../globals/mixins/validity';
 import styles from './textarea.scss';
 
 const { prefix } = settings;
@@ -26,7 +27,7 @@ const { prefix } = settings;
  * @slot validity-message - The validity message. If present and non-empty, this input shows the UI of its invalid state.
  */
 @customElement(`${prefix}-textarea`)
-export default class BXTextarea extends FormMixin(LitElement) {
+export default class BXTextarea extends ValidityMixin(FormMixin(LitElement)) {
   /**
    * Handles `oninput` event on the `<input>`.
    * @param event The event.
@@ -120,6 +121,12 @@ export default class BXTextarea extends FormMixin(LitElement) {
    */
   @property({ type: Boolean, reflect: true })
   required = false;
+
+  /**
+   * The special validity message for `required`.
+   */
+  @property()
+  requiredValidityMessage = 'Please fill out this field.';
 
   /**
    * The number of rows for the textarea to show by default

--- a/src/globals/mixins/validity.ts
+++ b/src/globals/mixins/validity.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * @param Base The base class.
+ * @returns A mix-in implementing `.setCustomValidity()` method.
+ */
+const ValidityMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
+  abstract class ValidityMixinImpl extends Base {
+    // Not using TypeScript `protected` due to: microsoft/TypeScript#17744
+    /**
+     * Checks if the value meets the constrants.
+     * @returns `true` if the value meets the constrants. `false` otherwise.
+     * @protected
+     */
+    _testValidity() {
+      const { required, value } = this;
+      return !required || value;
+    }
+
+    /**
+     * `true` to show the UI of the invalid state.
+     */
+    abstract invalid: boolean;
+
+    /**
+     * `true` if the value is required.
+     */
+    abstract required: boolean;
+
+    /**
+     * The special validity message for `required`.
+     */
+    abstract requiredValidityMessage: string;
+
+    /**
+     * The validity message.
+     */
+    abstract validityMessage: string;
+
+    /**
+     * The value.
+     */
+    abstract value: string;
+
+    /**
+     * Checks if the value meets the constrants.
+     * Fires cancelable `invalid` event if it doesn't.
+     * @returns `true` if the value meets the constrants. `false` otherwise.
+     */
+    checkValidity() {
+      if (!this._testValidity()) {
+        if (
+          this.dispatchEvent(
+            new CustomEvent('invalid', {
+              bubbles: false,
+              cancelable: true,
+              composed: false,
+            })
+          )
+        ) {
+          this.invalid = true;
+          this.validityMessage = this.requiredValidityMessage;
+        }
+        return false;
+      }
+      this.invalid = false;
+      this.validityMessage = '';
+      return true;
+    }
+
+    /**
+     * Sets the given custom validity message.
+     * @param validityMessage The custom validity message
+     */
+    setCustomValidity(validityMessage: string) {
+      this.invalid = Boolean(validityMessage);
+      this.validityMessage = validityMessage;
+    }
+  }
+  return ValidityMixinImpl;
+};
+
+export default ValidityMixin;

--- a/tests/spec/input_spec.ts
+++ b/tests/spec/input_spec.ts
@@ -1,14 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, render } from 'lit-html';
-import { INPUT_TYPE } from '../../src/components/input/input';
+import EventManager from '../utils/event-manager';
+
+import BXInput, { INPUT_TYPE } from '../../src/components/input/input';
 import { defaultStory } from '../../src/components/input/input-story';
 
 /**
@@ -34,6 +36,8 @@ const template = (props?) =>
   });
 
 describe('bx-input', function() {
+  const events = new EventManager();
+
   describe('Rendering', function() {
     it('Should render with various attributes', async function() {
       render(
@@ -104,7 +108,58 @@ describe('bx-input', function() {
     });
   });
 
+  describe('Form validation', function() {
+    let elem: Element;
+
+    beforeEach(async function() {
+      render(template(), document.body);
+      await Promise.resolve();
+      elem = document.body.querySelector('bx-input')!;
+    });
+
+    it('should support checking if required value exists', async function() {
+      const input = elem as BXInput;
+      input.required = true;
+      const spyInvalid = jasmine.createSpy('invalid');
+      events.on(input, 'invalid', spyInvalid);
+      expect(input.checkValidity()).toBe(false);
+      expect(spyInvalid).toHaveBeenCalled();
+      expect(input.invalid).toBe(true);
+      expect(input.validityMessage).toBe('Please fill out this field.');
+      input.value = 'value-foo';
+      expect(input.checkValidity()).toBe(true);
+      expect(input.invalid).toBe(false);
+      expect(input.validityMessage).toBe('');
+    });
+
+    it('should support canceling required check', async function() {
+      const input = elem as BXInput;
+      input.required = true;
+      events.on(input, 'invalid', event => {
+        event.preventDefault();
+      });
+      expect(input.checkValidity()).toBe(false);
+      expect(input.invalid).toBe(false);
+      expect(input.validityMessage).toBe('');
+    });
+
+    it('should treat empty custom validity message as not invalid', async function() {
+      const input = elem as BXInput;
+      input.setCustomValidity('');
+      expect(input.invalid).toBe(false);
+      expect(input.validityMessage).toBe('');
+    });
+
+    it('should treat non-empty custom validity message as invalid', async function() {
+      const input = elem as BXInput;
+      input.setCustomValidity('validity-message-foo');
+      expect(input.invalid).toBe(true);
+      expect(input.validityMessage).toBe('validity-message-foo');
+    });
+  });
+
   afterEach(async function() {
+    events.reset();
     await render(undefined!, document.body);
   });
 });

--- a/tests/spec/textarea_spec.ts
+++ b/tests/spec/textarea_spec.ts
@@ -1,13 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { html, render } from 'lit-html';
+import EventManager from '../utils/event-manager';
+
 import BXTextarea from '../../src/components/textarea/textarea';
 import { defaultStory } from '../../src/components/textarea/textarea-story';
 
@@ -34,6 +36,8 @@ const template = (props?) =>
   });
 
 describe('bx-textarea', function() {
+  const events = new EventManager();
+
   describe('Rendering', function() {
     it('Should render with various attributes', async function() {
       render(
@@ -131,7 +135,58 @@ describe('bx-textarea', function() {
     });
   });
 
+  describe('Form validation', function() {
+    let elem: Element;
+
+    beforeEach(async function() {
+      render(template(), document.body);
+      await Promise.resolve();
+      elem = document.body.querySelector('bx-textarea')!;
+    });
+
+    it('should support checking if required value exists', async function() {
+      const textarea = elem as BXTextarea;
+      textarea.required = true;
+      const spyInvalid = jasmine.createSpy('invalid');
+      events.on(textarea, 'invalid', spyInvalid);
+      expect(textarea.checkValidity()).toBe(false);
+      expect(spyInvalid).toHaveBeenCalled();
+      expect(textarea.invalid).toBe(true);
+      expect(textarea.validityMessage).toBe('Please fill out this field.');
+      textarea.value = 'value-foo';
+      expect(textarea.checkValidity()).toBe(true);
+      expect(textarea.invalid).toBe(false);
+      expect(textarea.validityMessage).toBe('');
+    });
+
+    it('should support canceling required check', async function() {
+      const textarea = elem as BXTextarea;
+      textarea.required = true;
+      events.on(textarea, 'invalid', event => {
+        event.preventDefault();
+      });
+      expect(textarea.checkValidity()).toBe(false);
+      expect(textarea.invalid).toBe(false);
+      expect(textarea.validityMessage).toBe('');
+    });
+
+    it('should treat empty custom validity message as not invalid', async function() {
+      const textarea = elem as BXTextarea;
+      textarea.setCustomValidity('');
+      expect(textarea.invalid).toBe(false);
+      expect(textarea.validityMessage).toBe('');
+    });
+
+    it('should treat non-empty custom validity message as invalid', async function() {
+      const textarea = elem as BXTextarea;
+      textarea.setCustomValidity('validity-message-foo');
+      expect(textarea.invalid).toBe(true);
+      expect(textarea.validityMessage).toBe('validity-message-foo');
+    });
+  });
+
   afterEach(async function() {
-    await render(template({ hasContent: false }), document.body);
+    events.reset();
+    await render(undefined, document.body);
   });
 });


### PR DESCRIPTION
This change introduces a new mix-in that supports `checkValidity()` and `setCustomValidity()` APIs.

This is separate from the mix-in for `formdata` event, due to date picker. Date picker handles `formdata` event on `<bx-date-picker>`, but handles form validation on `<bx-date-picker-input>`, as the range mode has form validation UI both on start/end dates.