### PR TITLE
chore(components): use focusin/focusout events

### DIFF
--- a/src/components/data-table/table-toolbar-search.ts
+++ b/src/components/data-table/table-toolbar-search.ts
@@ -40,7 +40,7 @@ class BXTableToolbarSearch extends HostListenerMixin(BXSearch) {
   /**
    * Handles `focus` event handler on this element.
    */
-  @HostListener('focus')
+  @HostListener('focusin')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusIn() {
     this._handleUserInitiatedExpand();
@@ -50,7 +50,7 @@ class BXTableToolbarSearch extends HostListenerMixin(BXSearch) {
    * Handles `blur` event handler on this element.
    * @param event The event.
    */
-  @HostListener('blur')
+  @HostListener('focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusOut(event: FocusEvent) {
     if (!this.contains(event.relatedTarget as Node) && !this.value) {

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -219,7 +219,7 @@ class BXDropdown extends HostListenerMixin(FocusMixin(LitElement)) {
    * Handles `blur` event handler on the document this element is in.
    * @param event The event.
    */
-  @HostListener('blur')
+  @HostListener('focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   protected _handleFocusOut(event: FocusEvent) {
     if (!this.contains(event.relatedTarget as Node)) {

--- a/src/components/floating-menu/floating-menu.ts
+++ b/src/components/floating-menu/floating-menu.ts
@@ -151,7 +151,7 @@ abstract class BXFloatingMenu extends HostListenerMixin(FocusMixin(LitElement)) 
     }
   });
 
-  @HostListener('blur')
+  @HostListener('focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleBlur = ({ relatedTarget }: FocusEvent) => {
     if (!this.contains(relatedTarget as Node)) {

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -67,7 +67,7 @@ class BXModal extends HostListenerMixin(LitElement) {
    * Handles `blur` event on this element.
    * @param event The event.
    */
-  @HostListener('shadowRoot:blur')
+  @HostListener('shadowRoot:focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleBlur = ({ target, relatedTarget }: FocusEvent) => {
     const oldContains = target !== this && this.contains(target as Node);

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -91,7 +91,7 @@ class BXTabs extends HostListenerMixin(BXContentSwitcher) {
   /**
    * Handles `focus` event handler on this element.
    */
-  @HostListener('focus')
+  @HostListener('focusin')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusIn() {
     const { selectorItem } = this.constructor as typeof BXTabs;
@@ -104,7 +104,7 @@ class BXTabs extends HostListenerMixin(BXContentSwitcher) {
    * Handles `blur` event handler on this element.
    * @param event The event.
    */
-  @HostListener('blur')
+  @HostListener('focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleFocusOut({ relatedTarget }: FocusEvent) {
     if (!this.contains(relatedTarget as Node)) {

--- a/src/components/ui-shell/header-menu.ts
+++ b/src/components/ui-shell/header-menu.ts
@@ -60,7 +60,7 @@ class BXHeaderMenu extends HostListenerMixin(FocusMixin(LitElement)) {
   /**
    * Handles `blur` event handler on this element.
    */
-  @HostListener('blur')
+  @HostListener('focusout')
   // @ts-ignore: The decorator refers to this method but TS thinks this method is not referred to
   private _handleBlur({ relatedTarget }: FocusEvent) {
     if (!this.contains(relatedTarget as Node)) {

--- a/src/globals/mixins/host-listener.ts
+++ b/src/globals/mixins/host-listener.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -49,45 +49,9 @@ const HostListenerMixin = <T extends Constructor<HTMLElement>>(Base: T) => {
               shadowRoot: this.shadowRoot,
             }[targetName] || this;
 
-          // Determines the event type for delegated `focus`/`blur` event
-          const hasFocusin = 'onfocusin' in this.ownerDocument!.defaultView!;
-          const delegatedType: string = {
-            focusin: hasFocusin ? 'focusin' : 'focus',
-            focus: hasFocusin ? 'focusin' : 'focus',
-            focusout: hasFocusin ? 'focusout' : 'blur',
-            blur: hasFocusin ? 'focusout' : 'blur',
-          }[unprefixedType];
-
-          // Sees if `capture` option of event listener conflicts with `capture` option to use for delegated `focus`/`blur` event
           const { options } = hostListeners[listenerName][type];
-          // Despite https://dom.spec.whatwg.org/#concept-flatten-options, primitive type to boolean type coercion seems to happen
-          const isCaptureGiven =
-            Object(options) === options
-              ? typeof (options as AddEventListenerOptions).capture !== 'undefined'
-              : typeof options !== 'undefined';
-          if (delegatedType && isCaptureGiven) {
-            throw new Error(
-              '`capture` event listener option with `@HostListener()` cannot be used ' +
-                'for `focusin`, `focus`, `focusout` and `blur` events.'
-            );
-          }
 
-          // Modifies event listener options with `capture` option to use for delegated `focus`/`blur` event
-          let massagedOptions: boolean | AddEventListenerOptions = typeof options === 'undefined' ? false : options;
-          if (delegatedType) {
-            if (Object(options) === options) {
-              massagedOptions = {
-                ...Object(options),
-                capture: !hasFocusin,
-              };
-            } else {
-              massagedOptions = !hasFocusin;
-            }
-          }
-
-          this._handles.add(
-            on(target, (delegatedType || unprefixedType) as keyof HTMLElementEventMap, this[listenerName], massagedOptions)
-          );
+          this._handles.add(on(target, unprefixedType as keyof HTMLElementEventMap, this[listenerName], options));
         });
       });
     }


### PR DESCRIPTION
This change moves from `focus` to `focusin` and `blur` to `focusout`, given `focusin`/`focusout` events are supported by all browsers now.

This change also removes the code that allowed us to use event delegation technique with `focus`/`blur` events.