### PR TITLE
chore(progress-indicator): flexible style for line

### DIFF
--- a/src/components/progress-indicator/progress-indicator.scss
+++ b/src/components/progress-indicator/progress-indicator.scss
@@ -25,6 +25,13 @@ $css--plex: true !default;
   @extend .#{$prefix}--progress-step--incomplete;
 
   outline: none;
+
+  // Carbon core style has hard-coded width whose value is the same as `.bx--progress-step`.
+  // We override it so changing width of `<bx-progress-step>` automatically changes the width here.
+  // https://github.com/carbon-design-system/carbon-custom-elements/issues/325
+  .#{$prefix}--progress-line {
+    width: 100%;
+  }
 }
 
 :host(#{$prefix}-progress-step[disabled]) {


### PR DESCRIPTION
This change ensures the elements in shadow DOM catches up with change in the width of `<bx-progress-step>`.

Fixes #325.