### PR TITLE
chore(react-wrapper): generate type definitions

### DIFF
--- a/examples/codesandbox/form/redux-form/package.json
+++ b/examples/codesandbox/form/redux-form/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-transform-runtime": "^7.8.0",
     "@babel/preset-react": "^7.8.0",
     "@types/lodash-es": "^4.17.0",
+    "@types/react": "^16.9.0",
     "parcel-bundler": "^1.10.0"
   },
   "scripts": {

--- a/examples/codesandbox/react/package.json
+++ b/examples/codesandbox/react/package.json
@@ -20,6 +20,7 @@
     "@babel/preset-env": "^7.8.0",
     "@babel/preset-react": "^7.8.0",
     "@types/lodash-es": "^4.17.0",
+    "@types/react": "^16.9.0",
     "parcel-bundler": "^1.10.0"
   },
   "scripts": {

--- a/gulp-tasks/build.js
+++ b/gulp-tasks/build.js
@@ -15,6 +15,7 @@ const { promisify } = require('util');
 const asyncDone = require('async-done');
 const gulp = require('gulp');
 const filter = require('gulp-filter');
+const rename = require('gulp-rename');
 const sourcemaps = require('gulp-sourcemaps');
 const babel = require('gulp-babel');
 const sass = require('gulp-sass');
@@ -29,6 +30,7 @@ const autoprefixer = require('autoprefixer');
 const rtlcss = require('rtlcss');
 const replaceExtension = require('replace-ext');
 const babelPluginCreateReactCustomElementType = require('../tools/babel-plugin-create-react-custom-element-type');
+const babelPluginCreateReactCustomElementTypeDef = require('../tools/babel-plugin-create-react-custom-element-type-def');
 const babelPluginResourceJSPaths = require('../tools/babel-plugin-resource-js-paths');
 const fixHostPseudo = require('../tools/postcss-fix-host-pseudo');
 const createSVGResultFromCarbonIcon = require('../tools/svg-result-carbon-icon');
@@ -129,6 +131,34 @@ module.exports = {
           )
           .pipe(prettier())
           .pipe(header(banner))
+          .pipe(gulp.dest(`${config.jsDestDir}/components-react`))
+      );
+    },
+
+    async reactTypes() {
+      const banner = await readFileAsync(path.resolve(__dirname, '../tools/license.js'), 'utf8');
+      await promisifyStream(() =>
+        gulp
+          .src([`${config.srcDir}/components/**/*.ts`, `!${config.srcDir}/**/*-story*.ts*`, `!${config.srcDir}/**/stories/*.ts`])
+          .pipe(
+            babel({
+              babelrc: false,
+              plugins: [
+                ['@babel/plugin-syntax-decorators', { decoratorsBeforeExport: true }],
+                '@babel/plugin-syntax-typescript',
+                '@babel/plugin-proposal-nullish-coalescing-operator',
+                '@babel/plugin-proposal-optional-chaining',
+                babelPluginCreateReactCustomElementTypeDef,
+              ],
+            })
+          )
+          .pipe(prettier())
+          .pipe(header(banner))
+          .pipe(
+            rename(pathObj => {
+              pathObj.extname = '.d.ts';
+            })
+          )
           .pipe(gulp.dest(`${config.jsDestDir}/components-react`))
       );
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -19,6 +19,7 @@ const test = require('./gulp-tasks/test');
 gulp.task('build:modules:icons', build.modules.icons);
 gulp.task('build:modules:css', build.modules.css);
 gulp.task('build:modules:react', build.modules.react);
+gulp.task('build:modules:react-types', build.modules.reactTypes);
 gulp.task('build:modules:scripts', build.modules.scripts);
 gulp.task('build:modules:types', build.modules.types);
 gulp.task(
@@ -27,6 +28,7 @@ gulp.task(
     gulp.task('build:modules:icons'),
     gulp.task('build:modules:css'),
     gulp.task('build:modules:react'),
+    gulp.task('build:modules:react-types'),
     gulp.task('build:modules:scripts'),
     gulp.task('build:modules:types')
   )

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "gulp-jsdoc3": "^1.0.0",
     "gulp-postcss": "^8.0.0",
     "gulp-prettier": "^2.1.0",
+    "gulp-rename": "^2.0.0",
     "gulp-sass": "^4.0.0",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-typescript": "^5.0.0",

--- a/tools/babel-plugin-create-react-custom-element-type-def.js
+++ b/tools/babel-plugin-create-react-custom-element-type-def.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { default: template } = require('@babel/template');
+const { createMetadataVisitor } = require('./babel-plugin-create-react-custom-element-type');
+
+module.exports = function generateCreateReactCustomElementType(api) {
+  const { types: t } = api;
+  const metadataVisitor = createMetadataVisitor(api);
+
+  const types = {
+    Boolean: 'boolean',
+    Number: 'number',
+  };
+
+  return {
+    name: 'create-react-custom-element-type',
+    visitor: {
+      Program(path, { file }) {
+        const declaredProps = {};
+        const customEvents = {};
+        const context = { file, declaredProps, customEvents };
+        // Gathers metadata of custom element properties and events, into `context`
+        path.traverse(metadataVisitor, context);
+
+        const { className, classComments = [] } = context;
+        const props = Object.keys(declaredProps).reduce((acc, key) => {
+          const { comments = [], type } = declaredProps[key];
+          return [...acc, comments.map(({ value }) => `/*${value}*/`).join('\n'), `${key}?: ${types[type] || 'string'};`];
+        }, []);
+
+        const build = template(
+          `
+            import { Component } from 'react';
+
+            interface ComponentProps {
+              ${props.join('\n')}
+            }
+
+            ${classComments.map(({ value }) => `/*${value}*/`).join('\n')}
+            declare class ${className} extends Component<ComponentProps> {}
+            export default ${className};
+          `,
+          {
+            plugins: ['typescript'],
+            preserveComments: true,
+            sourceType: 'module',
+          }
+        );
+
+        const body = build();
+        path.replaceWith(t.program(body));
+        path.stop();
+      },
+    },
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9289,6 +9289,11 @@ gulp-prettier@^2.1.0:
     safe-buffer "^5.1.2"
     through2 "^3.0.0"
 
+gulp-rename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-2.0.0.tgz#9bbc3962b0c0f52fc67cd5eaff6c223ec5b9cf6c"
+  integrity sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==
+
 gulp-sass@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-4.0.2.tgz#cfb1e3eff2bd9852431c7ce87f43880807d8d505"


### PR DESCRIPTION
This change introduces a new Babel plugin to generate `.d.ts` for React wrapper components.

![react-types](https://user-images.githubusercontent.com/1259051/75770715-d72b5500-5d8b-11ea-8694-b732de997caf.gif)
