### PR TITLE
chore(build): upgrade to TypeScript 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "temp": "^0.9.0",
     "ts-loader": "^6.0.0",
     "tsickle": "^0.37.0",
-    "typescript": "^3.7.0",
+    "typescript": "^3.8.0",
     "use-debounce": "^3.2.0",
     "vue": "^2.6.0",
     "vue-eslint-parser": "^6.0.0",      

--- a/yarn.lock
+++ b/yarn.lock
@@ -18542,10 +18542,10 @@ typescript@^3.5.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
-typescript@^3.7.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.8.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
TypeScript 3.8 (commit `91ffa1c752ac26882b1426fb4c9012701c1d908e` in microsoft/TypeScript repo) seems to have removed `loadend` from `HTMLElementEventMap` that made our `.d.ts` files compiled with TypeScript 3.7 incompatible with TypeScript 3.8 applications.

This change upgrades our build toolchain to TypeScript 3.8 to address that problem. Our examples (notably Angular one) using TypeScript 3.7 doesn't seem to have been broken with such change.

Fixes #328.