### PR TITLE
chore(devenv): add more docs to Storybook

### DIFF
--- a/.storybook/angular/config.ts
+++ b/.storybook/angular/config.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,24 +11,31 @@ import '../../src/polyfills';
 
 import addons from '@storybook/addons';
 import { configure, addDecorator, addParameters } from '@storybook/angular';
-import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { withKnobs } from '@storybook/addon-knobs';
 import '../components/focus-trap/focus-trap';
 import { CURRENT_THEME } from '../addon-carbon-theme/shared';
 import theme from './theme';
-import DocsPage from '../DocsPage';
 import containerStyles from '../_container.scss'; // eslint-disable-line import/first
 
 if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
   document.documentElement.setAttribute('dir', 'rtl');
 }
 
+const SORT_ORDER = ['introduction-welcome--page', 'introduction-form-paticipation--page'];
+
 addParameters({
-  docs: {
-    container: DocsContainer,
-    page: DocsPage,
-  },
   options: {
+    showRoots: true,
+    storySort(lhs, rhs) {
+      const [lhsId] = lhs;
+      const [rhsId] = rhs;
+      const lhsSortOrder = SORT_ORDER.indexOf(lhsId);
+      const rhsSortOrder = SORT_ORDER.indexOf(rhsId);
+      if (lhsSortOrder >= 0 && rhsSortOrder >= 0) {
+        return lhsSortOrder - rhsSortOrder;
+      }
+      return 0;
+    },
     theme: theme,
   },
 });
@@ -79,5 +86,8 @@ addons.getChannel().on(CURRENT_THEME, theme => {
   document.documentElement.setAttribute('storybook-carbon-theme', theme);
 });
 
-const req = require.context('../../src/components', true, /\-story\-angular\.[jt]s$/);
-configure(req, module);
+const reqDocs = require.context('../../docs', true, /\-story\-angular\.mdx$/);
+configure(reqDocs, module);
+
+const reqComponents = require.context('../../src/components', true, /\-story\-angular\.[jt]s$/);
+configure(reqComponents, module);

--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -24,8 +24,21 @@ if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
   document.documentElement.setAttribute('dir', 'rtl');
 }
 
+const SORT_ORDER = ['introduction-welcome--page', 'introduction-form-paticipation--page', 'introduction-custom-styles--page'];
+
 addParameters({
   options: {
+    showRoots: true,
+    storySort(lhs, rhs) {
+      const [lhsId] = lhs;
+      const [rhsId] = rhs;
+      const lhsSortOrder = SORT_ORDER.indexOf(lhsId);
+      const rhsSortOrder = SORT_ORDER.indexOf(rhsId);
+      if (lhsSortOrder >= 0 && rhsSortOrder >= 0) {
+        return lhsSortOrder - rhsSortOrder;
+      }
+      return 0;
+    },
     theme: theme,
   },
 });
@@ -74,11 +87,14 @@ addons.getChannel().on(CURRENT_THEME, theme => {
   document.documentElement.setAttribute('storybook-carbon-theme', theme);
 });
 
-const req = require.context('../src/components', true, /\-story\.[jt]s$/);
-configure(req, module);
+const reqDocs = require.context('../docs', true, /\-story\.mdx$/);
+configure(reqDocs, module);
+
+const reqComponents = require.context('../src/components', true, /\-story\.[jt]s$/);
+configure(reqComponents, module);
 
 if (module.hot) {
-  module.hot.accept(req.id, () => {
+  module.hot.accept(reqComponents.id, () => {
     const currentLocationHref = window.location.href;
     window.history.pushState(null, '', currentLocationHref);
     window.location.reload();

--- a/.storybook/react/config.tsx
+++ b/.storybook/react/config.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,11 +11,9 @@ import '../../src/polyfills';
 import React, { StrictMode } from 'react';
 import addons from '@storybook/addons';
 import { configure, addDecorator, addParameters } from '@storybook/react'; // eslint-disable-line import/first
-import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { withKnobs } from '@storybook/addon-knobs';
 import '../components/focus-trap/focus-trap';
 import { CURRENT_THEME } from '../addon-carbon-theme/shared';
-import DocsPage from '../DocsPage';
 import theme from './theme';
 import containerStyles from '../_container.scss'; // eslint-disable-line import/first
 
@@ -23,12 +21,21 @@ if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
   document.documentElement.setAttribute('dir', 'rtl');
 }
 
+const SORT_ORDER = ['introduction-welcome--page', 'introduction-form-paticipation--page'];
+
 addParameters({
-  docs: {
-    container: DocsContainer,
-    page: DocsPage,
-  },
   options: {
+    showRoots: true,
+    storySort(lhs, rhs) {
+      const [lhsId] = lhs;
+      const [rhsId] = rhs;
+      const lhsSortOrder = SORT_ORDER.indexOf(lhsId);
+      const rhsSortOrder = SORT_ORDER.indexOf(rhsId);
+      if (lhsSortOrder >= 0 && rhsSortOrder >= 0) {
+        return lhsSortOrder - rhsSortOrder;
+      }
+      return 0;
+    },
     theme: theme,
   },
 });
@@ -69,11 +76,14 @@ addons.getChannel().on(CURRENT_THEME, theme => {
   document.documentElement.setAttribute('storybook-carbon-theme', theme);
 });
 
-const req = require.context('../../src/components', true, /\-story\-react\.[jt]sx$/);
-configure(req, module);
+const reqDocs = require.context('../../docs', true, /\-story\-react\.mdx$/);
+configure(reqDocs, module);
+
+const reqComponents = require.context('../../src/components', true, /\-story\-react\.[jt]sx$/);
+configure(reqComponents, module);
 
 if (module.hot) {
-  module.hot.accept(req.id, () => {
+  module.hot.accept(reqComponents.id, () => {
     const currentLocationHref = window.location.href;
     window.history.pushState(null, '', currentLocationHref);
     window.location.reload();

--- a/.storybook/vue/config.ts
+++ b/.storybook/vue/config.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,12 +11,10 @@ import '../../src/polyfills';
 
 import addons from '@storybook/addons';
 import { configure, addDecorator, addParameters } from '@storybook/vue';
-import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { withKnobs } from '@storybook/addon-knobs';
 import '../components/focus-trap/focus-trap';
 import { CURRENT_THEME } from '../addon-carbon-theme/shared';
 import theme from './theme';
-import DocsPage from '../DocsPage';
 import containerStyles from '../_container.scss'; // eslint-disable-line import/first
 
 if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
@@ -24,11 +22,8 @@ if (process.env.STORYBOOK_CARBON_CUSTOM_ELEMENTS_USE_RTL === 'true') {
 }
 
 addParameters({
-  docs: {
-    container: DocsContainer,
-    page: DocsPage,
-  },
   options: {
+    showRoots: true,
     theme: theme,
   },
 });

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -32,6 +32,25 @@ module.exports = ({ config, mode }) => {
     };
   }
 
+  const mdxStoryRule = config.module.rules.find(
+    item => item.use && item.use.some && item.use.some(use => /@mdx-js\/loader/i.test(use.loader) && !item.exclude)
+  );
+  if (mdxStoryRule) {
+    // Storybook's default assumes that MDX stories have `.story.mdx`/`.stories.mdx` suffixes.
+    // We put MDX stories to docs/*-story.mdx.
+    mdxStoryRule.test = /\-story(\-(angular|react|vue))?.mdx$/;
+    mdxStoryRule.include = [path.resolve(__dirname, '../docs')];
+  }
+
+  const storyDocsRule = config.module.rules.find(
+    item => item.use && item.use.some && item.use.some(use => /@mdx-js\/loader/i.test(use.loader) && item.exclude)
+  );
+  if (storyDocsRule) {
+    // Storybook's default assumes that MDX stories have `.story.mdx`/`.stories.mdx` suffixes.
+    // We put MDX stories to docs/*-story.mdx.
+    storyDocsRule.exclude = [path.resolve(__dirname, '../docs')];
+  }
+
   // `carbon-custom-elements` does not use `polymer-webpack-loader` as it does not use full-blown Polymer
   const htmlRuleIndex = config.module.rules.findIndex(
     item => item.use && item.use.some && item.use.some(use => /polymer-webpack-loader/i.test(use.loader))

--- a/docs/form-story-angular.mdx
+++ b/docs/form-story-angular.mdx
@@ -1,0 +1,38 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Form paticipation" />
+
+# Having components participate in form with Angular two-way binding
+
+Our form components can be used for Angular two-way binding syntax (`[(ngModel)]`), like below, by using Angular directives for them:
+
+```html
+<bx-input [(ngModel)]="model.username" #username="ngModel" type="text" name="username"></bx-input>
+```
+
+Such Angular directives can be used by importing `BXFormAccessorModule` from `carbon-custom-elements/es/directives-angular/esm2015` or `carbon-custom-elements/es/directives-angular/esm5` into your Angular module:
+
+```javascript
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { BXFormAccessorsModule } from 'carbon-custom-elements/es/directives-angular/esm2015';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, FormsModule, BXFormAccessorsModule],
+  providers: [],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/angular?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>

--- a/docs/form-story-react.mdx
+++ b/docs/form-story-react.mdx
@@ -1,0 +1,43 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Form paticipation" />
+
+# Having components participate in form with `redux-form`
+
+You can use our form components with Redux Form by creating a React component that wraps our form components:
+
+```javascript
+import { Field } from 'redux-form';
+import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
+import BXInput from 'carbon-custom-elements/es/components-react/input/input';
+
+...
+
+// A React component that wraps form components from `carbon-custom-elements`
+const FieldImpl = ({ input, label, type, meta: { touched, error } }) => {
+  const validityMessage = !touched ? undefined : error;
+  return (
+    <BXFormItem>
+      <BXInput
+        {...input}
+        invalid={Boolean(validityMessage)}
+        label-text={label}
+        type={type}
+        placeholder={label}
+        validityMessage={validityMessage}
+      />
+    </BXFormItem>
+  );
+};
+
+...
+
+<Field name="username" type="text" component={FieldImpl} label="Username" />
+```
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/redux-form?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>

--- a/docs/form-story.mdx
+++ b/docs/form-story.mdx
@@ -1,0 +1,42 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Form paticipation" />
+
+# Having components participate in form
+
+Though form elements in `carbon-custom-elements` (e.g. `<bx-input>`) are not native form elements like `<input>`, form elements in `carbon-custom-elements` have some extra APIs that align well to web/framework standards that allow those form elements to participate in form.
+
+## `formdata` event
+
+Browsers supporting [`formdata` event](https://www.chromestatus.com/feature/5662230242656256) fire that event when the user clicks on `<button type="submit">` in `<form>`. Our form components listen to that event to add their values to the `<form>`.
+
+To support other browsers, you can use a regular `<button>` and manually fire a custom event with the same name (`formdata`), like below:
+
+```javascript
+const form = document.querySelector('form');
+const button = form.querySelector('button');
+button.addEventListener('click', () => {
+  const formData = new FormData(form);
+  const event = new CustomEvent('formdata', {
+    bubbles: true,
+    cancelable: false,
+    composed: false,
+  });
+  event.formData = formData;
+  form.dispatchEvent(event);
+  // Now `formData` is populated with the data in `<bx-input>`, etc. in the `<form>`.
+  // You can use `formData` with `fetch()`/XHR instead of letting `<form>` submit the data
+});
+```
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/basic?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+## Framework-specific approaches of form participation
+
+- [Angular two-way binding](https://carbon-custom-elements-angular.netlify.com/?path=/story/introduction-form-paticipation--page)
+- [Redux form](https://carbon-custom-elements-react.netlify.com/?path=/story/introduction-form-paticipation--page)

--- a/docs/styling-story.mdx
+++ b/docs/styling-story.mdx
@@ -1,0 +1,118 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Custom styles" />
+
+# Using custom styles in components
+
+As Shadow DOM (one of the Web Components specs that `carbon-custom-elements` uses) promises, styles that `carbon-custom-elements` defines does not affect styles in your application, or vice versa.
+
+However, in cases where your application or a Carbon-derived style guide wants to change the styles of our components, there are a few options.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Using CSS Custom Properties](#using-css-custom-properties)
+- [Dependency injection](#dependency-injection)
+- [Creating derived components with different style](#creating-derived-components-with-different-style)
+- [CSS Shadow Parts](#css-shadow-parts)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Using CSS Custom Properties
+
+Changes to CSS Custom Properties of the Carbon theme are reflected in the color scheme of `carbon-custom-elements` components:
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/theme-zoning?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '700px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+For example, if you add CSS like below:
+
+```css
+footer {
+  --cds-interactive-02: #6f6f6f; /* `$interactive-02` token for `g100` theme */
+}
+```
+
+The color of the button in the code below changes to the one in the `g100` theme:
+
+```html
+<footer>
+  <bx-btn kind="secondary">Secondary button</bx-btn>
+</footer>
+```
+
+The names of CSS Custom Properties you can use are the Carbon theme tokens prefixed with `--cds-`. The list of Carbon theme tokens can be found at [here](https://github.com/carbon-design-system/carbon/blob/v10.7.0/packages/themes/scss/generated/_themes.scss#L14-L454).
+
+With CSS Custom Properties approach, you can switch the entire theme under the specific element by:
+
+```css
+@import 'carbon-components/scss/globals/scss/css--helpers';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/themes/mixins';
+
+footer {
+  @include carbon--theme($carbon--theme--g100, true); // Emits all theme tokens in CSS Custom Properties
+}
+```
+
+## Dependency injection
+
+You can let our custom elements modules load alternate `CSSResult` module. Below example uses [Webpack `NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to let our custom elements modules load RTL version of `CSSResult` module that is shipped alongside with default `CSSResult` modules, instead of loading the default version:
+
+```javascript
+const reCssBundle = /\.css\.js$/i;
+
+...
+
+module.exports = {
+  ...
+  plugins: [
+    ...
+    new webpack.NormalModuleReplacementPlugin(reCssBundle, resource => {
+      resource.request = resource.request.replace(reCssBundle, '.rtl.css.js');
+    }),
+  ],
+  ...
+};
+```
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/rtl?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+## Creating derived components with different style
+
+You can create a derived class of our component and override [static `styles` property](https://lit-element.polymer-project.org/guide/styles#static-styles), like:
+
+```javascript
+import { css, customElement } from 'lit-element';
+import BXDropdown from 'carbon-custom-elements/es/components/dropdown/dropdown';
+
+@customElement('my-dropdown')
+class MyDropdown extends BXDropdown {
+  // Custom CSS to enforce `field-02` (light) style of the dropdown
+  static styles = css`
+    ${BXDropdown.styles}
+    .bx--list-box {
+      background-color: white;
+    }
+  `;
+}
+```
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/custom-style?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+## CSS Shadow Parts
+
+In the future, we'd like to support [CSS Shadow Parts](https://www.w3.org/TR/css-shadow-parts-1/) too, so you can use your application's CSS to affect `carbon-custom-elements` styles in a more flexible manner.

--- a/docs/welcome-story-angular.mdx
+++ b/docs/welcome-story-angular.mdx
@@ -1,0 +1,34 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Welcome" />
+
+# `carbon-custom-elements` with Angular
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/angular?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+Angular users can use our components in the same manner as native HTML tags, too, once you add [`CUSTOM_ELEMENTS_SCHEMA`](https://angular.io/api/core/CUSTOM_ELEMENTS_SCHEMA) schema to your Angular module, like:
+
+```javascript
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+The `.d.ts` files in `carbon-custom-elements` package are compiled with TypeScript 3.7. You can use TypeScript 3.7 in your Angular application with upcoming Angular `9.0` release, or with the following instructions, so your application can use those `.d.ts` files:
+
+- Set `true` to [`angularCompilerOptions.disableTypeScriptVersionCheck`](https://angular.io/guide/angular-compiler-options#disabletypescriptversioncheck) in `tsconfig.json`
+- In `polyfills.ts`, change [`__importDefault` TypeScript helper](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#example-8) as follows: `window.__importDefault = mod => (mod?.__esModule ? mod : { default: mod })`

--- a/docs/welcome-story-react.mdx
+++ b/docs/welcome-story-react.mdx
@@ -1,0 +1,33 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Welcome" />
+
+# `carbon-custom-elements` with React
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/react?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+You can use wrapper React components in `carbon-custom-elements/es/components-react` generated [automatically from the custom elements](./src/globals/wrappers/createReactCustomElementType.ts) which allows you to use our components seamlessly in your React code. Here's an example:
+
+```javascript
+import React from 'react';
+import { render } from 'react-dom';
+import BXDropdown from 'carbon-custom-elements/es/components-react/dropdown/dropdown';
+import BXDropdownItem from 'carbon-custom-elements/es/components-react/dropdown/dropdown-item';
+
+const App = () => (
+  <BXDropdown triggerContent="Select an item">
+    <BXDropdownItem value="all">Option 1</BXDropdownItem>
+    <BXDropdownItem value="cloudFoundry">Option 2</BXDropdownItem>
+    <BXDropdownItem value="staging">Option 3</BXDropdownItem>
+    <BXDropdownItem value="dea">Option 4</BXDropdownItem>
+    <BXDropdownItem value="router">Option 5</BXDropdownItem>
+  </BXDropdown>
+);
+
+render(<App />, document.getElementById('root'));
+```

--- a/docs/welcome-story.mdx
+++ b/docs/welcome-story.mdx
@@ -1,0 +1,92 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Welcome" />
+
+A Carbon Design System variant that's as easy to use as native HTML elements, with no framework tax, no framework silo.
+
+<p align="center">
+  <a href="https://www.carbondesignsystem.com">
+    <img alt="Carbon Design System" src="https://user-images.githubusercontent.com/3901764/57545698-ce5f2380-7320-11e9-8682-903df232d7b0.png" width="100%" />
+  </a>
+</p>
+
+> Carbon is an open-source design system built by IBM. With the IBM Design
+> Language as its foundation, the system consists of working code, design tools
+> and resources, human interface guidelines, and a vibrant community of
+> contributors.
+
+<p align="center">
+  <a href="https://github.com/carbon-design-system/carbon-custom-elements/blob/master/LICENSE">
+    <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Carbon is released under the Apache-2.0 license" />
+  </a>
+</p>
+
+# `carbon-custom-elements`
+
+`carbon-custom-elements` is a variant of Carbon Design System with Custom Elements v1 and Shadow DOM v1 specs.
+
+Experimental at this moment, with enthusiasm.
+
+The effort stems from https://github.com/carbon-design-system/issue-tracking/issues/121. If you are interested in this project, adding 👍 to the description of that GH issue, or even contributing, will be greatly appreciated!
+
+## Getting started
+
+To install `carbon-custom-elements` in your project, you will need to run the
+following command using [npm](https://www.npmjs.com/):
+
+```bash
+npm install -S carbon-custom-elements carbon-components lit-html lit-element
+```
+
+If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
+instead:
+
+```bash
+yarn add carbon-custom-elements carbon-components lit-html lit-element
+```
+
+### Basic usage
+
+Our example at [CodeSandbox](https://codesandbox.io) shows the most basic usage:
+
+<iframe
+  src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/basic?fontsize=14&hidenavigation=1&theme=light"
+  style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
+  title="carbon-custom-elements-getting-started"
+  sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
+></iframe>
+
+The first thing you need is **setting up a module bundler** to resolve ECMAScript `import`s. Above example uses [Parcel](https://parceljs.org). You can use other bundlers like [Rollup](https://rollupjs.org/)/[Webpack](https://webpack.js.org), too.
+
+Once you set up a module bundler, you can start importing our component modules, like:
+
+```javascript
+import 'carbon-custom-elements/es/components/dropdown/dropdown';
+import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+```
+
+Once you do that, you can use our components in the same manner as native HTML tags, like:
+
+```html
+<bx-dropdown trigger-content="Select an item">
+  <bx-dropdown-item value="all">Option 1</bx-dropdown-item>
+  <bx-dropdown-item value="cloudFoundry">Option 2</bx-dropdown-item>
+  <bx-dropdown-item value="staging">Option 3</bx-dropdown-item>
+  <bx-dropdown-item value="dea">Option 4</bx-dropdown-item>
+  <bx-dropdown-item value="router">Option 5</bx-dropdown-item>
+</bx-dropdown>
+```
+
+### JavaScript framework integration
+
+Given the nature of `carbon-custom-elements` built on top of web standard, `carbon-custom-elements` works well with JavaScript framework of your choice.
+Please follow below links:
+
+- [Angular](https://carbon-custom-elements-angular.netlify.com)
+- [React](https://carbon-custom-elements-react.netlify.com)
+- [Vue](https://carbon-custom-elements-vue.netlify.com)
+
+### Other usage guides
+
+- [Having components participate in form](/?path=/story/introduction-form-paticipation--page)
+- [Using custom styles in components](/?path=/docs/introduction-custom-styles--page)

--- a/src/components/accordion/accordion-story.mdx
+++ b/src/components/accordion/accordion-story.mdx
@@ -12,7 +12,7 @@ The Carbon accordion allows for multiple sections to be expanded simultaneously.
 A chevron is used to indicate the “expand/collapse” action, though the entire header area is clickable for the same action.
 
 <Preview withToolbar>
-  <Story id="accordion--default-story" height="200px" />
+  <Story id="components-accordion--default-story" height="200px" />
 </Preview>
 
 ## `<bx-accordion-item>` attributes, properties and events

--- a/src/components/accordion/accordion-story.ts
+++ b/src/components/accordion/accordion-story.ts
@@ -54,7 +54,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Accordion',
+  title: 'Components/Accordion',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/breadcrumb/breadcrumb-story.ts
+++ b/src/components/breadcrumb/breadcrumb-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -32,5 +32,5 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Breadcrumb',
+  title: 'Components/Breadcrumb',
 };

--- a/src/components/button/button-story.mdx
+++ b/src/components/button/button-story.mdx
@@ -15,7 +15,7 @@ Small buttons may be used when there is not enough space for a regular sized but
 When words are not enough, icons can be used in buttons to better communicate what the button does. Icons are always paired with text.
 
 <Preview withToolbar>
-  <Story id="button--default-story" height="160px" />
+  <Story id="components-button--default-story" height="160px" />
 </Preview>
 
 ## `<bx-btn>` attributes and properties

--- a/src/components/button/button-story.ts
+++ b/src/components/button/button-story.ts
@@ -113,7 +113,7 @@ skeleton.story = {
 };
 
 export default {
-  title: 'Button',
+  title: 'Components/Button',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/checkbox/checkbox-story.mdx
+++ b/src/components/checkbox/checkbox-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Check box in `carbon-custom-elements` represents a combination of a check box and its label.
 
 <Preview withToolbar>
-  <Story id="checkbox--default-story" height="160px" />
+  <Story id="components-checkbox--default-story" height="160px" />
 </Preview>
 
 ## Basic usage

--- a/src/components/checkbox/checkbox-story.ts
+++ b/src/components/checkbox/checkbox-story.ts
@@ -37,7 +37,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Checkbox',
+  title: 'Components/Checkbox',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/code-snippet/code-snippet-story.mdx
+++ b/src/components/code-snippet/code-snippet-story.mdx
@@ -9,7 +9,7 @@ Code snippets are small blocks of reusable code that can be inserted in a code f
 The Terminal style is for single-line.
 
 <Preview withToolbar>
-  <Story id="code-snippet--single-line" height="160px" />
+  <Story id="components-code-snippet--single-line" height="160px" />
 </Preview>
 
 ## Multi line
@@ -17,7 +17,7 @@ The Terminal style is for single-line.
 The Code style is for larger, multi-line code snippets.
 
 <Preview withToolbar>
-  <Story id="code-snippet--multi-line" height="320px" />
+  <Story id="components-code-snippet--multi-line" height="320px" />
 </Preview>
 
 ## Inline
@@ -25,7 +25,7 @@ The Code style is for larger, multi-line code snippets.
 The Inline style is for code used within a block of text.
 
 <Preview withToolbar>
-  <Story id="code-snippet--inline" height="160px" />
+  <Story id="components-code-snippet--inline" height="160px" />
 </Preview>
 
 ## `<bx-code-snippet>` attributes and properties

--- a/src/components/code-snippet/code-snippet-story.ts
+++ b/src/components/code-snippet/code-snippet-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -156,7 +156,7 @@ skeletonMultiLine.story = {
 };
 
 export default {
-  title: 'Code snippet',
+  title: 'Components/Code snippet',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/combo-box/combo-box-story.mdx
+++ b/src/components/combo-box/combo-box-story.mdx
@@ -10,7 +10,7 @@ This will clear any user-inputted text.
 Selecting an item from the dropdown will close the drawer and the selected option will replace the default label.
 
 <Preview withToolbar>
-  <Story id="combo-box--default-story" height="240px" />
+  <Story id="components-combo-box--default-story" height="240px" />
 </Preview>
 
 ## `<bx-combo-box>` attributes, properties and events

--- a/src/components/combo-box/combo-box-story.ts
+++ b/src/components/combo-box/combo-box-story.ts
@@ -65,7 +65,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Combo box',
+  title: 'Components/Combo box',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/content-switcher/content-switcher-story.mdx
+++ b/src/components/content-switcher/content-switcher-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Content switcher manipulates the content shown following an exclusive or “either/or” pattern. It is used to toggle between two or more content sections within the same space on screen. Only one section can be shown at a time.
 
 <Preview withToolbar>
-  <Story id="content-switcher--default-story" height="160px" />
+  <Story id="components-content-switcher--default-story" height="160px" />
 </Preview>
 
 ## `<bx-content-switcher>` attributes, properties and events

--- a/src/components/content-switcher/content-switcher-story.ts
+++ b/src/components/content-switcher/content-switcher-story.ts
@@ -48,7 +48,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Content switcher',
+  title: 'Components/Content switcher',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/copy-button/copy-button-story.mdx
+++ b/src/components/copy-button/copy-button-story.mdx
@@ -6,7 +6,7 @@ Copy button provides the interface of copy button and its feedback tooltip.
 No actual copy is performed, but application can listen to `click` event of `<bx-copy-button>` and interact with the clipboard.
 
 <Preview withToolbar>
-  <Story id="copy-button--default-story" height="120px" />
+  <Story id="components-copy-button--default-story" height="120px" />
 </Preview>
 
 ## `<bx-copy-button>` attributes and properties

--- a/src/components/copy-button/copy-button-story.ts
+++ b/src/components/copy-button/copy-button-story.ts
@@ -32,7 +32,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Copy button',
+  title: 'Components/Copy button',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/data-table/data-table-story.mdx
+++ b/src/components/data-table/data-table-story.mdx
@@ -18,7 +18,7 @@ Data table in `carbon-custom-elements` focuses on primitives that constructs tab
 ## Basic usage
 
 <Preview withToolbar>
-  <Story id="data-table--default-story" height="280px" />
+  <Story id="components-data-table--default-story" height="280px" />
 </Preview>
 
 In the most basic case, you can simply put your table rows/cells in the same way as putting `<tr>`/`<td>` like below, and you'll get Carbon-styled table automatically:
@@ -175,7 +175,7 @@ html`
 ## Sorting
 
 <Preview withToolbar>
-  <Story id="data-table--sortable" height="320px" />
+  <Story id="components-data-table--sortable" height="320px" />
 </Preview>
 
 Adding `sort-direction` attribute to `<bx-table-header-cell>` shows the sorting UI in the table header cell.

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -736,7 +736,7 @@ skeleton.story = {
 };
 
 export default {
-  title: 'Data table',
+  title: 'Components/Data table',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/date-picker/date-picker-story.mdx
+++ b/src/components/date-picker/date-picker-story.mdx
@@ -9,7 +9,7 @@ Date and time pickers allow users to select a single or a range of dates and tim
 A simple Date Picker consists of an input field and no calendar.
 
 <Preview withToolbar>
-  <Story id="date-picker--default-story" height="160px" />
+  <Story id="components-date-picker--default-story" height="160px" />
 </Preview>
 
 ## Single date picker
@@ -17,7 +17,7 @@ A simple Date Picker consists of an input field and no calendar.
 A single Date Picker consists of an input field and a calendar.
 
 <Preview withToolbar>
-  <Story id="date-picker--single-with-calendar" height="480px" />
+  <Story id="components-date-picker--single-with-calendar" height="480px" />
 </Preview>
 
 ## Range date picker
@@ -25,7 +25,7 @@ A single Date Picker consists of an input field and a calendar.
 A range Date Picker consists of two input fields and a calendar.
 
 <Preview withToolbar>
-  <Story id="date-picker--range-with-calendar" height="480px" />
+  <Story id="components-date-picker--range-with-calendar" height="480px" />
 </Preview>
 
 ## `<bx-date-picker>` attributes, properties and events

--- a/src/components/date-picker/date-picker-story.ts
+++ b/src/components/date-picker/date-picker-story.ts
@@ -201,7 +201,7 @@ skeletonRange.story = {
 };
 
 export default {
-  title: 'Date picker',
+  title: 'Components/Date picker',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/dropdown/dropdown-story.mdx
+++ b/src/components/dropdown/dropdown-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Dropdown presents a list of options that can be used to filter or sort existing content.
 
 <Preview withToolbar>
-  <Story id="dropdown--default-story" height="240px" />
+  <Story id="components-dropdown--default-story" height="240px" />
 </Preview>
 
 ## `<bx-dropdown>` attributes, properties and events

--- a/src/components/dropdown/dropdown-story.ts
+++ b/src/components/dropdown/dropdown-story.ts
@@ -96,7 +96,7 @@ export const skeleton = () =>
   `;
 
 export default {
-  title: 'Dropdown',
+  title: 'Components/Dropdown',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/icon/icon-story.ts
+++ b/src/components/icon/icon-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -69,5 +69,5 @@ withTitle.story = {
 };
 
 export default {
-  title: 'Icon',
+  title: 'Components/Icon',
 };

--- a/src/components/inline-loading/inline-loading-story.mdx
+++ b/src/components/inline-loading/inline-loading-story.mdx
@@ -12,7 +12,7 @@ The component provides feedback to the user about the progress of the action the
 This could be in a table, after a primary or secondary button click, or even in a modal.
 
 <Preview withToolbar>
-  <Story id="inline-loading--default-story" height="160px" />
+  <Story id="components-inline-loading--default-story" height="160px" />
 </Preview>
 
 ## `<bx-inline-loading>` attributes and properties

--- a/src/components/inline-loading/inline-loading-story.ts
+++ b/src/components/inline-loading/inline-loading-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -32,7 +32,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Inline loading',
+  title: 'Components/Inline loading',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/input/input-story.mdx
+++ b/src/components/input/input-story.mdx
@@ -6,7 +6,7 @@ Text fields enable the user to interact with and input data.
 A single line field is used when the input anticipated by the user is a single line of text as opposed to a paragraph.
 
 <Preview withToolbar>
-  <Story id="input--default-story" height="160px" />
+  <Story id="components-input--default-story" height="160px" />
 </Preview>
 
 ## `<bx-input>` attributes and properties

--- a/src/components/input/input-story.ts
+++ b/src/components/input/input-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -104,7 +104,7 @@ withoutFormItemWrapper.story = {
 };
 
 export default {
-  title: 'Input',
+  title: 'Components/Input',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/link/link-story.mdx
+++ b/src/components/link/link-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Represents a link. Provided for convenience purpose, you can alternatively use `<a class="bx--link">` with Carbon style in place in light DOM.
 
 <Preview withToolbar>
-  <Story id="link--default-story" height="120px" />
+  <Story id="components-link--default-story" height="120px" />
 </Preview>
 
 ## `<bx-link>` attributes and properties

--- a/src/components/link/link-story.ts
+++ b/src/components/link/link-story.ts
@@ -29,7 +29,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Link',
+  title: 'Components/Link',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/list/list-story.mdx
+++ b/src/components/list/list-story.mdx
@@ -7,13 +7,13 @@ Represents a list.
 ## Ordered list
 
 <Preview withToolbar>
-  <Story id="list--ordered" height="200px" />
+  <Story id="components-list--ordered" height="200px" />
 </Preview>
 
 ## Unordered list
 
 <Preview withToolbar>
-  <Story id="list--unordered" height="200px" />
+  <Story id="components-list--unordered" height="200px" />
 </Preview>
 
 ## `<bx-list-item>` attributes and properties

--- a/src/components/list/list-story.ts
+++ b/src/components/list/list-story.ts
@@ -54,7 +54,7 @@ export const unordered = () => html`
 `;
 
 export default {
-  title: 'List',
+  title: 'Components/List',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/loading/loading-story.mdx
+++ b/src/components/loading/loading-story.mdx
@@ -7,7 +7,7 @@ The waiting experience is a crucial design opportunity.
 Although it may not be obvious what is occurring on the back-end, we can communicate clearly to reassure the user that progress is happening.
 
 <Preview withToolbar>
-  <Story id="loading--default-story" height="320px" />
+  <Story id="components-loading--default-story" height="320px" />
 </Preview>
 
 ## `<bx-loading>` attributes and properties

--- a/src/components/loading/loading-story.ts
+++ b/src/components/loading/loading-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -31,7 +31,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Loading',
+  title: 'Components/Loading',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/modal/modal-story.mdx
+++ b/src/components/modal/modal-story.mdx
@@ -7,7 +7,7 @@ They are most effective when a task must be completed before a user can continue
 While effective when used correctly, modals should be used sparingly to limit disruption to a user experience.
 
 <Preview withToolbar>
-  <Story id="modal--default-story" height="320px" />
+  <Story id="components-modal--default-story" height="320px" />
 </Preview>
 
 ## Focus management

--- a/src/components/modal/modal-story.ts
+++ b/src/components/modal/modal-story.ts
@@ -49,7 +49,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Modal',
+  title: 'Components/Modal',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/multi-select/multi-select-story.mdx
+++ b/src/components/multi-select/multi-select-story.mdx
@@ -10,7 +10,7 @@ Multi select in `carbon-custom-elements` focuses on primitives consisting of the
 | `<bx-multi-select-item>` | The select item |
 
 <Preview withToolbar>
-  <Story id="multi-select--default-story" height="240px" />
+  <Story id="components-multi-select--default-story" height="240px" />
 </Preview>
 
 ## Basic usage

--- a/src/components/multi-select/multi-select-story.ts
+++ b/src/components/multi-select/multi-select-story.ts
@@ -81,7 +81,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Multi select',
+  title: 'Components/Multi select',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/notification/notification-story.mdx
+++ b/src/components/notification/notification-story.mdx
@@ -9,7 +9,7 @@ Notifications are messages that communicate information to the user.
 Inline notifications show up in task flows, to notify users of the status of an action. They usually appear at the top of the primary content area.
 
 <Preview withToolbar>
-  <Story id="notifications--inline" height="160px" />
+  <Story id="components-notifications--inline" height="160px" />
 </Preview>
 
 ## Toast notification
@@ -17,7 +17,7 @@ Inline notifications show up in task flows, to notify users of the status of an 
 Toasts are a non-modal, time-based window elements used to display short messages; they usually appear at the bottom of the screen and disappear after a few seconds.
 
 <Preview withToolbar>
-  <Story id="notifications--toast" height="240px" />
+  <Story id="components-notifications--toast" height="240px" />
 </Preview>
 
 ## `<bx-inline-notification>` attributes, properties and events

--- a/src/components/notification/notification-story.ts
+++ b/src/components/notification/notification-story.ts
@@ -133,7 +133,7 @@ toast.story = {
 };
 
 export default {
-  title: 'Notifications',
+  title: 'Components/Notifications',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/number-input/number-input-story.mdx
+++ b/src/components/number-input/number-input-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Number inputs are similar to text inputs, but contain controls used to increase or decrease an incremental value.
 
 <Preview withToolbar>
-  <Story id="number-input--default-story" height="160px" />
+  <Story id="components-number-input--default-story" height="160px" />
 </Preview>
 
 ## `<bx-number-input>` attributes and properties

--- a/src/components/number-input/number-input-story.ts
+++ b/src/components/number-input/number-input-story.ts
@@ -120,5 +120,5 @@ export const skeleton = () =>
   `;
 
 export default {
-  title: 'Number Input',
+  title: 'Components/Number Input',
 };

--- a/src/components/overflow-menu/overflow-menu-story.mdx
+++ b/src/components/overflow-menu/overflow-menu-story.mdx
@@ -6,7 +6,7 @@ Overflow menu is used when additional options are available to the user and ther
 Create overflow menu item components for each option on the menu.
 
 <Preview withToolbar>
-  <Story id="overflow-menu--default-story" height="240px" />
+  <Story id="components-overflow-menu--default-story" height="240px" />
 </Preview>
 
 ## `<bx-overflow-menu>` attributes and properties

--- a/src/components/overflow-menu/overflow-menu-story.ts
+++ b/src/components/overflow-menu/overflow-menu-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -41,7 +41,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Overflow menu',
+  title: 'Components/Overflow menu',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/pagination/pageination-story.ts
+++ b/src/components/pagination/pageination-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -47,7 +47,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Pagination',
+  title: 'Components/Pagination',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/pagination/pagination-story.mdx
+++ b/src/components/pagination/pagination-story.mdx
@@ -6,7 +6,7 @@ The pagination component is used to switch through multiple pages of items, when
 Can be used in combination with other components like data table.
 
 <Preview withToolbar>
-  <Story id="pagination--default-story" height="160px" />
+  <Story id="components-pagination--default-story" height="160px" />
 </Preview>
 
 ## `<bx-pagination>` attributes, properties and events

--- a/src/components/progress-indicator/progress-indicator-story.mdx
+++ b/src/components/progress-indicator/progress-indicator-story.mdx
@@ -7,7 +7,7 @@ Progress indicator is a visual representation of a users progress through a set 
 Use progress indicators to keep the user on track when completing a specific task. By dividing the end goal into smaller, sub-tasks, it increases the percentage of completeness as each task is completed.
 
 <Preview withToolbar>
-  <Story id="progress-indicator--default-story" height="160px" />
+  <Story id="components-progress-indicator--default-story" height="160px" />
 </Preview>
 
 ## `<bx-progress-indicator>` attributes and properties

--- a/src/components/progress-indicator/progress-indicator-story.ts
+++ b/src/components/progress-indicator/progress-indicator-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -96,5 +96,5 @@ skeleton.story = {
 };
 
 export default {
-  title: 'Progress indicator',
+  title: 'Components/Progress indicator',
 };

--- a/src/components/radio-button/radio-button-story.mdx
+++ b/src/components/radio-button/radio-button-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Radio buttons are used when a list of two or more options are mutually exclusive, meaning the user must select only one option.
 
 <Preview withToolbar>
-  <Story id="radio-button--default-story" height="160px" />
+  <Story id="components-radio-button--default-story" height="160px" />
 </Preview>
 
 ## `<bx-radio-button-group>` attributes, properties and events

--- a/src/components/radio-button/radio-button-story.ts
+++ b/src/components/radio-button/radio-button-story.ts
@@ -75,5 +75,5 @@ export const skeleton = () =>
   `;
 
 export default {
-  title: 'Radio button',
+  title: 'Components/Radio button',
 };

--- a/src/components/search/search-story.mdx
+++ b/src/components/search/search-story.mdx
@@ -6,7 +6,7 @@ Search enables users to specify a word or a phrase to find particular relevant p
 Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
 
 <Preview withToolbar>
-  <Story id="search--default-story" height="160px" />
+  <Story id="components-search--default-story" height="160px" />
 </Preview>
 
 ## `<bx-search>` attributes, properties and events

--- a/src/components/search/search-story.ts
+++ b/src/components/search/search-story.ts
@@ -72,5 +72,5 @@ export const skeleton = () =>
   `;
 
 export default {
-  title: 'Search',
+  title: 'Components/Search',
 };

--- a/src/components/skeleton-placeholder/skeleton-placeholder-story.ts
+++ b/src/components/skeleton-placeholder/skeleton-placeholder-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,5 +20,5 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Skeleton placeholder',
+  title: 'Components/Skeleton placeholder',
 };

--- a/src/components/skeleton-text/skeleton-text-story.mdx
+++ b/src/components/skeleton-text/skeleton-text-story.mdx
@@ -3,11 +3,11 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 # Skeleton text
 
 <Preview withToolbar>
-  <Story id="skeleton-text--default-story" height="120px" />
+  <Story id="components-skeleton-text--default-story" height="120px" />
 </Preview>
 
 <Preview withToolbar>
-  <Story id="skeleton-text--lines" height="120px" />
+  <Story id="components-skeleton-text--lines" height="120px" />
 </Preview>
 
 ## `<bx-skeleton-text>` attributes and properties

--- a/src/components/skeleton-text/skeleton-text-story.ts
+++ b/src/components/skeleton-text/skeleton-text-story.ts
@@ -52,7 +52,7 @@ lines.story = {
 };
 
 export default {
-  title: 'Skeleton text',
+  title: 'Components/Skeleton text',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/slider/slider-story.mdx
+++ b/src/components/slider/slider-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Sliders provide a visual indication of adjustable content, where the user can move the handle along a horizontal track to increase or decrease the value.
 
 <Preview withToolbar>
-  <Story id="slider--default-story" height="160px" />
+  <Story id="components-slider--default-story" height="160px" />
 </Preview>
 
 ## `<bx-slider>` attributes, properties and events

--- a/src/components/slider/slider-story.ts
+++ b/src/components/slider/slider-story.ts
@@ -81,7 +81,7 @@ export const skeleton = () =>
   `;
 
 export default {
-  title: 'Slider',
+  title: 'Components/Slider',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/structured-list/structured-list-story.mdx
+++ b/src/components/structured-list/structured-list-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Structured Lists group content that is similar or related, such as terms or definitions.
 
 <Preview withToolbar>
-  <Story id="structured-list--default-story" />
+  <Story id="components-structured-list--default-story" />
 </Preview>
 
 ## `<bx-structured-list>` attributes and properties

--- a/src/components/structured-list/structured-list-story.ts
+++ b/src/components/structured-list/structured-list-story.ts
@@ -113,5 +113,5 @@ export const skeleton = () => html`
 `;
 
 export default {
-  title: 'Structured list',
+  title: 'Components/Structured list',
 };

--- a/src/components/tabs/tabs-story.mdx
+++ b/src/components/tabs/tabs-story.mdx
@@ -5,7 +5,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 Tabs are used to quickly navigate between views within the same context.
 
 <Preview withToolbar>
-  <Story id="tabs--default-story" height="320px" />
+  <Story id="components-tabs--default-story" height="320px" />
 </Preview>
 
 ## `<bx-tabs>` attributes, properties and events

--- a/src/components/tabs/tabs-story.ts
+++ b/src/components/tabs/tabs-story.ts
@@ -123,5 +123,5 @@ export const skeleton = () => html`
 `;
 
 export default {
-  title: 'Tabs',
+  title: 'Components/Tabs',
 };

--- a/src/components/tag/tag-story.mdx
+++ b/src/components/tag/tag-story.mdx
@@ -9,13 +9,13 @@ Multiple or single tags can be used to categorize items.
 Use tags when content is mapped to multiple categories, and the user needs a way to differentiate between them.
 
 <Preview withToolbar>
-  <Story id="tag--default-story" height="160px" />
+  <Story id="components-tag--default-story" height="160px" />
 </Preview>
 
 ## Filter tag
 
 <Preview withToolbar>
-  <Story id="tag--filter" height="160px" />
+  <Story id="components-tag--filter" height="160px" />
 </Preview>
 
 ## `<bx-tag>` attributes and properties

--- a/src/components/tag/tag-story.ts
+++ b/src/components/tag/tag-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -74,5 +74,5 @@ export default {
       page: storyDocs,
     },
   },
-  title: 'Tag',
+  title: 'Components/Tag',
 };

--- a/src/components/textarea/textarea-story.mdx
+++ b/src/components/textarea/textarea-story.mdx
@@ -7,7 +7,7 @@ Text inputs enable the user to interact with and input content and data. This co
 Textarea is a multi-line variant of text input.
 
 <Preview withToolbar>
-  <Story id="textarea--default-story" height="240px" />
+  <Story id="components-textarea--default-story" height="240px" />
 </Preview>
 
 ## `<bx-textarea>` attributes and properties

--- a/src/components/textarea/textarea-story.ts
+++ b/src/components/textarea/textarea-story.ts
@@ -137,5 +137,5 @@ export const skeleton = () =>
   `;
 
 export default {
-  title: 'Textarea',
+  title: 'Components/Textarea',
 };

--- a/src/components/tile/tile-story-vue.ts
+++ b/src/components/tile/tile-story-vue.ts
@@ -121,7 +121,7 @@ export const expandable = ({ parameters }) => {
 expandable.story = basEexpandable.story;
 
 export default {
-  title: 'Tile',
+  title: 'Components/Tile',
   decorators: [
     () => ({
       template: `<div><story /></div>`,

--- a/src/components/tile/tile-story.mdx
+++ b/src/components/tile/tile-story.mdx
@@ -17,7 +17,7 @@ Read-only tiles are often seen on marketing pages to promote content.
 These tiles can have internal calls-to-action (CTAs), such as a button or a link.
 
 <Preview withToolbar>
-  <Story id="tile--default-story" height="160px" />
+  <Story id="components-tile--default-story" height="160px" />
 </Preview>
 
 # Clickable tile
@@ -27,7 +27,7 @@ which redirects the user to a new page.
 Clickable tiles cannot contain separate internal CTAs.
 
 <Preview withToolbar>
-  <Story id="tile--clickable" height="160px" />
+  <Story id="components-tile--clickable" height="160px" />
 </Preview>
 
 ## `<bx-clickable-tile>` attributes and properties
@@ -41,7 +41,7 @@ Selectable tiles may contain internal CTAs (like links to docs) if the internal 
 Selectable tiles work well for presenting options to a user in a structured manner, such as a set of pricing plans.
 
 <Preview withToolbar>
-  <Story id="tile--single-selectable" height="320px" />
+  <Story id="components-tile--single-selectable" height="320px" />
 </Preview>
 
 ## `<bx-radio-tile>` attributes and properties
@@ -53,7 +53,7 @@ Note: For `boolean` attributes, `true` means simply setting the attribute (e.g. 
 # Multi-selectable tile
 
 <Preview withToolbar>
-  <Story id="tile--multi-selectable" height="160px" />
+  <Story id="components-tile--multi-selectable" height="160px" />
 </Preview>
 
 ## `<bx-selectable-tile>` attributes and properties
@@ -70,7 +70,7 @@ When expanded, tiles push content down the page.
 Expandable tiles may contain internal CTAs (like links to docs) if the internal CTA is given its own click target.
 
 <Preview withToolbar>
-  <Story id="tile--expandable" />
+  <Story id="components-tile--expandable" />
 </Preview>
 
 ## `<bx-expandable-tile>` attributes, properties and events

--- a/src/components/tile/tile-story.ts
+++ b/src/components/tile/tile-story.ts
@@ -160,7 +160,7 @@ expandable.story = {
 };
 
 export default {
-  title: 'Tile',
+  title: 'Components/Tile',
   decorators: [
     story =>
       html`

--- a/src/components/toggle/toggle-story.mdx
+++ b/src/components/toggle/toggle-story.mdx
@@ -9,7 +9,7 @@ They are commonly used for “on/off” switches.
 Use `small` property/attribute to make it more compact in size, so they can be used in use cases such as data tables.
 
 <Preview withToolbar>
-  <Story id="toggle--default-story" height="160px" />
+  <Story id="components-toggle--default-story" height="160px" />
 </Preview>
 
 ## `<bx-toggle>` attributes, properties and events

--- a/src/components/toggle/toggle-story.ts
+++ b/src/components/toggle/toggle-story.ts
@@ -43,7 +43,7 @@ defaultStory.story = {
 };
 
 export default {
-  title: 'Toggle',
+  title: 'Components/Toggle',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/tooltip/tooltip-story.mdx
+++ b/src/components/tooltip/tooltip-story.mdx
@@ -14,7 +14,7 @@ Interactive tooltips may contain rich text and other interactive elements like b
 * Don’t use without a label. Consider the context a user needs before clicking a link
 
 <Preview withToolbar>
-  <Story id="tooltip--default-story" height="320px" />
+  <Story id="components-tooltip--default-story" height="320px" />
 </Preview>
 
 ### `<bx-tooltip>` attributes and properties
@@ -32,7 +32,7 @@ The definition tooltip provides additional help or defines an item or term. It m
 * Do not use a definition tooltip on words with fewer than two letters
 
 <Preview withToolbar>
-  <Story id="tooltip--definition" height="200px" />
+  <Story id="components-tooltip--definition" height="200px" />
 </Preview>
 
 ### `<bx-tooltip-definition>` attributes and properties
@@ -46,7 +46,7 @@ An icon tooltip is used to clarify the action or name of an interactive icon but
 * The tooltip content should only contain one or two words.
 
 <Preview withToolbar>
-  <Story id="tooltip--icon" height="160px" />
+  <Story id="components-tooltip--icon" height="160px" />
 </Preview>
 
 ### `<bx-tooltip-icon>` attributes and properties

--- a/src/components/tooltip/tooltip-story.ts
+++ b/src/components/tooltip/tooltip-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -124,7 +124,7 @@ icon.story = {
 };
 
 export default {
-  title: 'Tooltip',
+  title: 'Components/Tooltip',
   parameters: {
     docs: {
       page: storyDocs,

--- a/src/components/ui-shell/ui-shell-story.mdx
+++ b/src/components/ui-shell/ui-shell-story.mdx
@@ -17,7 +17,7 @@ Side nav in UI Shell consists of the following components:
 | `<side-nav-menu-item>` | Nav item, working as as a sub-item and as a link |
 
 <Preview withToolbar>
-  <Story id="ui-shell--side-nav" />
+  <Story id="components-ui-shell--side-nav" />
 </Preview>
 
 ### Expanding/collapsing
@@ -69,7 +69,7 @@ Header nav in UI Shell consists of the following components:
 | `<bx-header-name>`        | The UI to show product name                   |
 
 <Preview withToolbar>
-  <Story id="ui-shell--header" />
+  <Story id="components-ui-shell--header" />
 </Preview>
 
 ### `<bx-header-nav>` attributes and properties

--- a/src/components/ui-shell/ui-shell-story.ts
+++ b/src/components/ui-shell/ui-shell-story.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -233,7 +233,7 @@ header.story = {
 };
 
 export default {
-  title: 'UI Shell',
+  title: 'Components/UI Shell',
   parameters: {
     docs: {
       page: storyDocs,


### PR DESCRIPTION
Adds `.mdx` to the Storybook environment so that `carbon-custom-elements` users can better understand how to use the library by looking at the Storybook environment.

![image](https://user-images.githubusercontent.com/1259051/76140795-490fe100-60a1-11ea-94fd-3ccd57dc7602.png)
