### PR TITLE
feat(dropdown): introduce size variants

### DIFF
--- a/src/components/combo-box/combo-box-story-angular.ts
+++ b/src/components/combo-box/combo-box-story-angular.ts
@@ -20,6 +20,7 @@ export const defaultStory = ({ parameters }) => ({
       [invalid]="invalid"
       [helperText]="helperText"
       [labelText]="labelText"
+      [size]="size"
       [validityMessage]="validityMessage"
       [value]="value"
       [triggerContent]="triggerContent"

--- a/src/components/combo-box/combo-box-story-react.tsx
+++ b/src/components/combo-box/combo-box-story-react.tsx
@@ -27,6 +27,7 @@ export const defaultStory = ({ parameters }) => {
     invalid,
     labelText,
     light,
+    size,
     validityMessage,
     value,
     triggerContent,
@@ -49,6 +50,7 @@ export const defaultStory = ({ parameters }) => {
       light={light}
       helperText={helperText}
       labelText={labelText}
+      size={size}
       validityMessage={validityMessage}
       value={value}
       triggerContent={triggerContent}

--- a/src/components/combo-box/combo-box-story-vue.ts
+++ b/src/components/combo-box/combo-box-story-vue.ts
@@ -22,6 +22,7 @@ export const defaultStory = ({ parameters }) => ({
       :light="light"
       :helper-text="helperText"
       :label-text="labelText"
+      :size="size"
       :validity-message="validityMessage"
       :value="value"
       :trigger-content="triggerContent"

--- a/src/components/combo-box/combo-box-story.ts
+++ b/src/components/combo-box/combo-box-story.ts
@@ -10,9 +10,8 @@
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import { DROPDOWN_COLOR_SCHEME, DROPDOWN_TYPE } from '../dropdown/dropdown';
 import ifNonNull from '../../globals/directives/if-non-null';
-import './combo-box';
+import { DROPDOWN_COLOR_SCHEME, DROPDOWN_SIZE, DROPDOWN_TYPE } from './combo-box';
 import './combo-box-item';
 import storyDocs from './combo-box-story.mdx';
 
@@ -26,6 +25,12 @@ const types = {
   [`Inline (${DROPDOWN_TYPE.INLINE})`]: DROPDOWN_TYPE.INLINE,
 };
 
+const sizes = {
+  'Regular size': null,
+  [`Small size (${DROPDOWN_SIZE.SMALL})`]: DROPDOWN_SIZE.SMALL,
+  [`Extra large size (${DROPDOWN_SIZE.EXTRA_LARGE})`]: DROPDOWN_SIZE.EXTRA_LARGE,
+};
+
 export const defaultStory = ({ parameters }) => {
   const {
     open,
@@ -34,6 +39,7 @@ export const defaultStory = ({ parameters }) => {
     helperText,
     invalid,
     labelText,
+    size,
     value,
     triggerContent,
     type,
@@ -58,6 +64,7 @@ export const defaultStory = ({ parameters }) => {
       ?invalid=${invalid}
       helper-text=${helperText}
       label-text=${labelText}
+      size="${ifNonNull(size)}"
       validity-message=${validityMessage}
       value=${value}
       trigger-content=${triggerContent}
@@ -92,6 +99,7 @@ export default {
         helperText: text('Helper text (helper-text)', 'Optional helper text'),
         invalid: boolean('Show invalid state  (invalid)', false),
         labelText: text('Label text (label-text)', 'Combo box title'),
+        size: select('Dropdown size (size)', sizes, null),
         value: text('The value of the selected item (value)', ''),
         triggerContent: text('The placeholder content (trigger-content)', 'Filter...'),
         type: select('UI type (type)', types, null),

--- a/src/components/combo-box/combo-box.scss
+++ b/src/components/combo-box/combo-box.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -42,6 +42,28 @@ $css--plex: true !default;
   @extend .#{$prefix}--list-box__menu-item;
 
   display: block;
+
+  .#{$prefix}--list-box__menu-item__option {
+    height: 100%;
+  }
+}
+
+:host(#{$prefix}-combo-box-item[size='sm']) {
+  height: rem(32px);
+
+  .#{$prefix}--list-box__menu-item__option {
+    padding-top: rem(7px);
+    padding-bottom: rem(7px);
+  }
+}
+
+:host(#{$prefix}-combo-box-item[size='xl']) {
+  height: rem(48px);
+
+  .#{$prefix}--list-box__menu-item__option {
+    padding-top: rem(15px);
+    padding-bottom: rem(15px);
+  }
 }
 
 :host(#{$prefix}-combo-box-item[disabled]) .#{$prefix}--list-box__menu-item__option {

--- a/src/components/combo-box/combo-box.ts
+++ b/src/components/combo-box/combo-box.ts
@@ -16,6 +16,8 @@ import BXDropdown, { DROPDOWN_KEYBOARD_ACTION } from '../dropdown/dropdown';
 import BXComboBoxItem from './combo-box-item';
 import styles from './combo-box.scss';
 
+export { DROPDOWN_COLOR_SCHEME, DROPDOWN_SIZE, DROPDOWN_TYPE } from '../dropdown/dropdown';
+
 const { prefix } = settings;
 
 /**

--- a/src/components/dropdown/dropdown-item.ts
+++ b/src/components/dropdown/dropdown-item.ts
@@ -9,6 +9,7 @@
 
 import settings from 'carbon-components/es/globals/js/settings';
 import { html, property, customElement, LitElement } from 'lit-element';
+import { DROPDOWN_SIZE } from './dropdown';
 import styles from './dropdown.scss';
 
 const { prefix } = settings;
@@ -39,6 +40,12 @@ class BXDropdownItem extends LitElement {
    */
   @property({ type: Boolean, reflect: true })
   selected = false;
+
+  /**
+   * Dropdown size.
+   */
+  @property({ reflect: true })
+  size = DROPDOWN_SIZE.REGULAR;
 
   /**
    * The `value` attribute that is set to the parent `<bx-dropdown>` when this dropdown item is selected.

--- a/src/components/dropdown/dropdown-story-angular.ts
+++ b/src/components/dropdown/dropdown-story-angular.ts
@@ -19,6 +19,7 @@ export const defaultStory = ({ parameters }) => ({
       [disabled]="disabled"
       [helperText]="helperText"
       [labelText]="labelText"
+      [size]="size"
       [value]="value"
       [triggerContent]="triggerContent"
       (bx-dropdown-beingselected)="handleBeforeSelect($event)"

--- a/src/components/dropdown/dropdown-story-react.tsx
+++ b/src/components/dropdown/dropdown-story-react.tsx
@@ -30,6 +30,7 @@ export const defaultStory = ({ parameters }) => {
     light,
     toggleLabelClosed,
     toggleLabelOpen,
+    size,
     triggerContent,
     type,
     value,
@@ -51,6 +52,7 @@ export const defaultStory = ({ parameters }) => {
       light={light}
       helperText={helperText}
       labelText={labelText}
+      size={size}
       toggleLabelClosed={toggleLabelClosed}
       toggleLabelOpen={toggleLabelOpen}
       triggerContent={triggerContent}

--- a/src/components/dropdown/dropdown-story-vue.ts
+++ b/src/components/dropdown/dropdown-story-vue.ts
@@ -37,6 +37,7 @@ export const defaultStory = ({ parameters }) => {
         :light="light"
         :helper-text="helperText"
         :label-text="labelText"
+        :size="size"
         :value="value"
         :trigger-content="triggerContent"
         @bx-dropdown-beingselected="handleBeforeSelect"

--- a/src/components/dropdown/dropdown-story.ts
+++ b/src/components/dropdown/dropdown-story.ts
@@ -12,7 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
-import { DROPDOWN_COLOR_SCHEME, DROPDOWN_TYPE } from './dropdown';
+import { DROPDOWN_COLOR_SCHEME, DROPDOWN_SIZE, DROPDOWN_TYPE } from './dropdown';
 import './dropdown-item';
 import './dropdown-skeleton';
 import storyDocs from './dropdown-story.mdx';
@@ -20,6 +20,12 @@ import storyDocs from './dropdown-story.mdx';
 const colorSchemes = {
   [`Regular`]: null,
   [`Light (${DROPDOWN_COLOR_SCHEME.LIGHT})`]: DROPDOWN_COLOR_SCHEME.LIGHT,
+};
+
+const sizes = {
+  'Regular size': null,
+  [`Small size (${DROPDOWN_SIZE.SMALL})`]: DROPDOWN_SIZE.SMALL,
+  [`Extra large size (${DROPDOWN_SIZE.EXTRA_LARGE})`]: DROPDOWN_SIZE.EXTRA_LARGE,
 };
 
 const types = {
@@ -34,6 +40,7 @@ export const defaultStory = ({ parameters }) => {
     disabled,
     helperText,
     labelText,
+    size,
     type,
     value,
     triggerContent,
@@ -56,6 +63,7 @@ export const defaultStory = ({ parameters }) => {
       ?disabled=${disabled}
       helper-text=${ifNonNull(helperText)}
       label-text=${ifNonNull(labelText)}
+      size="${ifNonNull(size)}"
       type="${ifNonNull(type)}"
       value=${ifNonNull(value)}
       trigger-content=${ifNonNull(triggerContent)}
@@ -81,6 +89,7 @@ defaultStory.story = {
         disabled: boolean('Disabled (disabled)', false),
         helperText: textNullable('Helper text (helper-text)', 'Optional helper text'),
         labelText: textNullable('Label text (label-text)', 'Dropdown title'),
+        size: select('Dropdown size (size)', sizes, null),
         type: select('Dropdown type (type)', types, null),
         value: textNullable('The value of the selected item (value)', ''),
         triggerContent: textNullable('The default content of the trigger button (trigger-content)', 'Select an item'),

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -38,6 +38,28 @@ $css--plex: true !default;
 :host(#{$prefix}-dropdown-item) {
   @extend .#{$prefix}--list-box__menu-item;
   display: block;
+
+  .#{$prefix}--list-box__menu-item__option {
+    height: 100%;
+  }
+}
+
+:host(#{$prefix}-dropdown-item[size='sm']) {
+  height: rem(32px);
+
+  .#{$prefix}--list-box__menu-item__option {
+    padding-top: rem(7px);
+    padding-bottom: rem(7px);
+  }
+}
+
+:host(#{$prefix}-dropdown-item[size='xl']) {
+  height: rem(48px);
+
+  .#{$prefix}--list-box__menu-item__option {
+    padding-top: rem(15px);
+    padding-bottom: rem(15px);
+  }
 }
 
 :host(#{$prefix}-dropdown-item[disabled]) .#{$prefix}--list-box__menu-item__option {

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -63,6 +63,26 @@ export enum DROPDOWN_KEYBOARD_ACTION {
 }
 
 /**
+ * Dropdown size.
+ */
+export enum DROPDOWN_SIZE {
+  /**
+   * Regular size.
+   */
+  REGULAR = '',
+
+  /**
+   * Small size.
+   */
+  SMALL = 'sm',
+
+  /**
+   * Extra large size.
+   */
+  EXTRA_LARGE = 'xl',
+}
+
+/**
  * Dropdown types.
  */
 export enum DROPDOWN_TYPE {
@@ -428,6 +448,12 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
   selectedItemAssistiveText = 'Selected an item.';
 
   /**
+   * Dropdown size.
+   */
+  @property({ reflect: true })
+  size = DROPDOWN_SIZE.REGULAR;
+
+  /**
    * The `aria-label` attribute for the UI indicating the closed state.
    */
   @property({ attribute: 'toggle-label-closed' })
@@ -468,8 +494,13 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
   }
 
   shouldUpdate(changedProperties) {
+    const { selectorItem } = this.constructor as typeof BXDropdown;
+    if (changedProperties.has('size')) {
+      forEach(this.querySelectorAll(selectorItem), elem => {
+        (elem as BXDropdownItem).size = this.size;
+      });
+    }
     if (changedProperties.has('value')) {
-      const { selectorItem } = this.constructor as typeof BXDropdown;
       // `<bx-multi-select>` updates selection beforehand
       // because our rendering logic for `<bx-multi-select>` looks for selected items via `qSA()`
       forEach(this.querySelectorAll(selectorItem), elem => {
@@ -514,6 +545,7 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
       open,
       toggleLabelClosed,
       toggleLabelOpen,
+      size,
       type,
       validityMessage,
       _assistiveStatusText: assistiveStatusText,
@@ -535,6 +567,7 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
       [`${prefix}--list-box--disabled`]: disabled,
       [`${prefix}--list-box--inline`]: inline,
       [`${prefix}--list-box--expanded`]: open,
+      [`${prefix}--list-box--${size}`]: size,
       [`${prefix}--dropdown--invalid`]: invalid,
       [`${prefix}--dropdown--inline`]: inline,
       [`${prefix}--dropdown--selected`]: selectedItemsCount > 0,

--- a/src/components/multi-select/multi-select-story-angular.ts
+++ b/src/components/multi-select/multi-select-story-angular.ts
@@ -23,6 +23,7 @@ export const defaultStory = ({ parameters }) => ({
       [labelText]="labelText"
       [toggleLabelClosed]="toggleLabelClosed"
       [toggleLabelOpen]="toggleLabelOpen"
+      [size]="size"
       [triggerContent]="triggerContent"
       [type]="type"
       [validityMessage]="validityMessage"

--- a/src/components/multi-select/multi-select-story-react.tsx
+++ b/src/components/multi-select/multi-select-story-react.tsx
@@ -28,6 +28,7 @@ export const defaultStory = ({ parameters }) => {
     labelText,
     light,
     open,
+    size,
     toggleLabelClosed,
     toggleLabelOpen,
     triggerContent,
@@ -53,6 +54,7 @@ export const defaultStory = ({ parameters }) => {
       clearSelectionLabel={clearSelectionLabel}
       helperText={helperText}
       labelText={labelText}
+      size={size}
       toggleLabelClosed={toggleLabelClosed}
       toggleLabelOpen={toggleLabelOpen}
       triggerContent={triggerContent}

--- a/src/components/multi-select/multi-select-story-vue.ts
+++ b/src/components/multi-select/multi-select-story-vue.ts
@@ -23,6 +23,7 @@ export const defaultStory = ({ parameters }) => ({
       :clear-selection-label="clearSelectionLabel"
       :helper-text="helperText"
       :label-text="labelText"
+      :size="size"
       :toggle-label-closed="toggleLabelClosed"
       :toggle-label-open="toggleLabelOpen"
       :trigger-content="triggerContent"

--- a/src/components/multi-select/multi-select-story.ts
+++ b/src/components/multi-select/multi-select-story.ts
@@ -10,16 +10,21 @@
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
-import { DROPDOWN_COLOR_SCHEME, DROPDOWN_TYPE } from '../dropdown/dropdown';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
-import './multi-select';
+import { DROPDOWN_COLOR_SCHEME, DROPDOWN_SIZE, DROPDOWN_TYPE } from './multi-select';
 import './multi-select-item';
 import storyDocs from './multi-select-story.mdx';
 
 const colorSchemes = {
   [`Regular`]: null,
   [`Light (${DROPDOWN_COLOR_SCHEME.LIGHT})`]: DROPDOWN_COLOR_SCHEME.LIGHT,
+};
+
+const sizes = {
+  'Regular size': null,
+  [`Small size (${DROPDOWN_SIZE.SMALL})`]: DROPDOWN_SIZE.SMALL,
+  [`Extra large size (${DROPDOWN_SIZE.EXTRA_LARGE})`]: DROPDOWN_SIZE.EXTRA_LARGE,
 };
 
 const types = {
@@ -36,6 +41,7 @@ export const defaultStory = ({ parameters }) => {
     invalid,
     labelText,
     open,
+    size,
     toggleLabelClosed,
     toggleLabelOpen,
     triggerContent,
@@ -63,6 +69,7 @@ export const defaultStory = ({ parameters }) => {
       clear-selection-label=${ifNonNull(clearSelectionLabel)}
       helper-text=${ifNonNull(helperText)}
       label-text=${ifNonNull(labelText)}
+      size=${ifNonNull(size)}
       toggle-label-closed=${ifNonNull(toggleLabelClosed)}
       toggle-label-open=${ifNonNull(toggleLabelOpen)}
       trigger-content=${ifNonNull(triggerContent)}
@@ -103,6 +110,7 @@ export default {
         toggleLabelClosed: textNullable('a11y label for the UI indicating the closed state (toggle-label-closed)', ''),
         toggleLabelOpen: textNullable('a11y label for the UI indicating the closed state (toggle-label-open)', ''),
         triggerContent: textNullable('The default content of the trigger button (trigger-content)', 'Select items'),
+        size: select('Dropdown size (size)', sizes, null),
         type: select('UI type (type)', types, null),
         validityMessage: textNullable('The validity message (validity-message)', ''),
         disableSelection: boolean(

--- a/src/components/multi-select/multi-select.scss
+++ b/src/components/multi-select/multi-select.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2019, 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -44,6 +44,8 @@ $css--plex: true !default;
   }
 
   .#{$prefix}--list-box__menu-item__option {
+    height: 100%;
+
     .#{$prefix}--checkbox-wrapper {
       width: 100%;
       height: 100%;
@@ -55,6 +57,24 @@ $css--plex: true !default;
       margin: 0;
       flex-direction: row;
     }
+  }
+}
+
+:host(#{$prefix}-multi-select-item[size='sm']) {
+  height: rem(32px);
+
+  .#{$prefix}--list-box__menu-item__option {
+    padding-top: rem(7px);
+    padding-bottom: rem(7px);
+  }
+}
+
+:host(#{$prefix}-multi-select-item[size='xl']) {
+  height: rem(48px);
+
+  .#{$prefix}--list-box__menu-item__option {
+    padding-top: rem(15px);
+    padding-bottom: rem(15px);
   }
 }
 

--- a/src/components/multi-select/multi-select.ts
+++ b/src/components/multi-select/multi-select.ts
@@ -15,6 +15,8 @@ import BXDropdown, { DROPDOWN_KEYBOARD_ACTION } from '../dropdown/dropdown';
 import BXMultiSelectItem from './multi-select-item';
 import styles from './multi-select.scss';
 
+export { DROPDOWN_COLOR_SCHEME, DROPDOWN_SIZE, DROPDOWN_TYPE } from '../dropdown/dropdown';
+
 const { prefix } = settings;
 
 /**
@@ -134,18 +136,21 @@ class BXMultiSelect extends BXDropdown {
   unselectedAllAssistiveText = 'Unselected all items.';
 
   shouldUpdate(changedProperties) {
+    const { selectorItem } = this.constructor as typeof BXMultiSelect;
+    if (changedProperties.has('size')) {
+      forEach(this.querySelectorAll(selectorItem), elem => {
+        (elem as BXMultiSelectItem).size = this.size;
+      });
+    }
     if (changedProperties.has('value')) {
       const { value } = this;
       const values = !value ? [] : value.split(',');
-      const { selectorItem } = this.constructor as typeof BXMultiSelect;
       // Updates selection beforehand because our rendering logic for `<bx-multi-select>` looks for selected items via `qSA()`
       const items = this.querySelectorAll(selectorItem);
       forEach(items, elem => {
         (elem as BXMultiSelectItem).selected = values.indexOf((elem as BXMultiSelectItem).value) >= 0;
       });
       this._selectedItemsCount = filter(items, elem => values.indexOf((elem as BXMultiSelectItem).value) >= 0).length;
-    } else {
-      super.shouldUpdate(changedProperties);
     }
     return true;
   }


### PR DESCRIPTION
Introduces size variants for `<bx-combo-box>`, `<bx-dropdown>` and `<bx-multi-select>`, which are enabled by `size="sm"` or `size="xl"` attribute (and its corresponding property).