### PR TITLE
feat(combo-box): add inline variant

### DIFF
--- a/src/components/combo-box/combo-box-story-angular.ts
+++ b/src/components/combo-box/combo-box-story-angular.ts
@@ -21,6 +21,7 @@ export const defaultStory = ({ parameters }) => ({
       [helperText]="helperText"
       [labelText]="labelText"
       [size]="size"
+      [type]="type"
       [validityMessage]="validityMessage"
       [value]="value"
       [triggerContent]="triggerContent"

--- a/src/components/combo-box/combo-box-story-react.tsx
+++ b/src/components/combo-box/combo-box-story-react.tsx
@@ -28,6 +28,7 @@ export const defaultStory = ({ parameters }) => {
     labelText,
     light,
     size,
+    type,
     validityMessage,
     value,
     triggerContent,
@@ -51,6 +52,7 @@ export const defaultStory = ({ parameters }) => {
       helperText={helperText}
       labelText={labelText}
       size={size}
+      type={type}
       validityMessage={validityMessage}
       value={value}
       triggerContent={triggerContent}

--- a/src/components/combo-box/combo-box-story-vue.ts
+++ b/src/components/combo-box/combo-box-story-vue.ts
@@ -23,6 +23,7 @@ export const defaultStory = ({ parameters }) => ({
       :helper-text="helperText"
       :label-text="labelText"
       :size="size"
+      :type="type"
       :validity-message="validityMessage"
       :value="value"
       :trigger-content="triggerContent"

--- a/src/components/combo-box/combo-box-story.ts
+++ b/src/components/combo-box/combo-box-story.ts
@@ -21,7 +21,7 @@ const colorSchemes = {
 };
 
 const types = {
-  [`Regular (${DROPDOWN_TYPE.REGULAR})`]: null,
+  Regular: null,
   [`Inline (${DROPDOWN_TYPE.INLINE})`]: DROPDOWN_TYPE.INLINE,
 };
 
@@ -40,10 +40,10 @@ export const defaultStory = ({ parameters }) => {
     invalid,
     labelText,
     size,
-    value,
     triggerContent,
     type,
     validityMessage,
+    value,
     disableSelection,
     onBeforeSelect,
     onSelect,
@@ -100,10 +100,10 @@ export default {
         invalid: boolean('Show invalid state  (invalid)', false),
         labelText: text('Label text (label-text)', 'Combo box title'),
         size: select('Dropdown size (size)', sizes, null),
-        value: text('The value of the selected item (value)', ''),
         triggerContent: text('The placeholder content (trigger-content)', 'Filter...'),
         type: select('UI type (type)', types, null),
         validityMessage: text('The validity message (validity-message)', ''),
+        value: text('The value of the selected item (value)', ''),
         disableSelection: boolean(
           'Disable user-initiated selection change (Call event.preventDefault() in bx-combo-box-beingselected event)',
           false

--- a/src/components/combo-box/combo-box.scss
+++ b/src/components/combo-box/combo-box.scss
@@ -36,6 +36,14 @@ $css--plex: true !default;
 
 :host(#{$prefix}-combo-box[type='inline']) {
   @extend .#{$prefix}--list-box__wrapper--inline;
+
+  .#{$prefix}--list-box__field {
+    padding-left: 0;
+  }
+
+  .#{$prefix}--text-input {
+    border-bottom: none;
+  }
 }
 
 :host(#{$prefix}-combo-box-item) {


### PR DESCRIPTION
Adds inline variant to `<bx-combo-box>`, which is enabled by `type="inline"` attribute and its corresponding property.