### PR TITLE
fix(date-picker): disable mobile mode

### DIFF
--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -179,6 +179,7 @@ class BXDatePicker extends LitElement {
     return {
       allowInput: true,
       dateFormat: this.dateFormat ?? (this.constructor as typeof BXDatePicker).defaultDateFormat,
+      disableMobile: true,
       errorHandler: handleFlatpickrError,
       locale,
       maxDate,


### PR DESCRIPTION
This change disables the mobile mode in `flatpickr` given such mode is hostile to our design.

Fixes #351.