### PR TITLE
fix(input): fix attribute name

### DIFF
--- a/src/components/date-picker/date-picker-input.ts
+++ b/src/components/date-picker/date-picker-input.ts
@@ -190,7 +190,7 @@ class BXDatePickerInput extends ValidityMixin(FocusMixin(LitElement)) {
   /**
    * The special validity message for `required`.
    */
-  @property()
+  @property({ attribute: 'required-validity-message' })
   requiredValidityMessage = 'Please fill out this field.';
 
   /**

--- a/src/components/dropdown/dropdown.ts
+++ b/src/components/dropdown/dropdown.ts
@@ -409,7 +409,7 @@ class BXDropdown extends ValidityMixin(HostListenerMixin(FocusMixin(LitElement))
   /**
    * The special validity message for `required`.
    */
-  @property()
+  @property({ attribute: 'required-validity-message' })
   requiredValidityMessage = 'Please fill out this field.';
 
   /**

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -125,7 +125,7 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
   /**
    * The special validity message for `required`.
    */
-  @property()
+  @property({ attribute: 'required-validity-message' })
   requiredValidityMessage = 'Please fill out this field.';
 
   /**

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -125,7 +125,7 @@ export default class BXTextarea extends ValidityMixin(FormMixin(LitElement)) {
   /**
    * The special validity message for `required`.
    */
-  @property()
+  @property({ attribute: 'required-validity-message' })
   requiredValidityMessage = 'Please fill out this field.';
 
   /**


### PR DESCRIPTION
This change fixes wrong `requiredValidityMessage` attribute names in various components, which should have been dash-cased.