### PR TITLE
chore(package): add type field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "carbon-custom-elements",
   "version": "1.0.0-beta.8",
   "license": "Apache-2.0",
+  "type": "module",
   "main": "es/index.js",
   "module": "es/index.js",
   "typings": "es/index.d.ts",


### PR DESCRIPTION
This will enable Node to import our modules directly without requiring a transpiled version, though we have few modules that is meant to be used in non-browser environment.