### PR TITLE
chore(dependencies): remove ResizeObserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.0",
-    "lodash-es": "^4.17.0",
-    "resize-observer-polyfill": "^1.5.0"
+    "lodash-es": "^4.17.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "^8.0.0",
@@ -193,6 +192,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "replace-ext": "^1.0.0",
+    "resize-observer-polyfill": "^1.5.0",
     "rtlcss": "^2.4.0",
     "rxjs": "^6.4.0",
     "sass-loader": "^7.1.0",

--- a/src/components/floating-menu/floating-menu.ts
+++ b/src/components/floating-menu/floating-menu.ts
@@ -7,7 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ResizeObserver from 'resize-observer-polyfill';
 import { LitElement } from 'lit-element';
 import HostListener from '../../globals/decorators/host-listener';
 import FocusMixin from '../../globals/mixins/focus';
@@ -142,6 +141,8 @@ abstract class BXFloatingMenu extends HostListenerMixin(FocusMixin(LitElement)) 
   /**
    * The `ResizeObserver` instance for observing element resizes for re-positioning floating menu position.
    */
+  // TODO: Wait for `.d.ts` update to support `ResizeObserver`
+  // @ts-ignore
   private _resizeObserver = new ResizeObserver(() => {
     const { container, open, parent, position } = this;
     if (container && open && parent) {

--- a/src/polyfills/index.ts
+++ b/src/polyfills/index.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -20,6 +20,8 @@ import 'core-js/modules/es.object.is.js'; // For src/globals/directives/spread.t
 import 'core-js/modules/es.object.values.js';
 import 'core-js/modules/es.object.entries';
 
+import ResizeObserver from 'resize-observer-polyfill';
+
 import './element-closest';
 import './element-matches';
 import './toggle-attribute';
@@ -33,3 +35,7 @@ import '@webcomponents/shadydom/src/shadydom.js';
 import '@webcomponents/custom-elements/src/custom-elements.js';
 import '@webcomponents/shadycss/entrypoints/scoping-shim.js';
 import '@webcomponents/url/url.js';
+
+if (typeof ResizeObserver === 'undefined') {
+  (window as any).ResizeObserver = ResizeObserver;
+}


### PR DESCRIPTION
This change ensures `ResizeObserver` polyfill is not a hard-dependency, as `ResizeObserver` is supported in all modern browsers.