### PR TITLE
fix(components): make shadow DOM text selectable

### DIFF
--- a/src/components/accordion/accordion-item.ts
+++ b/src/components/accordion/accordion-item.ts
@@ -85,10 +85,6 @@ class BXAccordionItem extends FocusMixin(LitElement) {
     super.connectedCallback();
   }
 
-  createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
-  }
-
   render() {
     const {
       expandoAssistiveText,

--- a/src/components/data-table/table-batch-actions.ts
+++ b/src/components/data-table/table-batch-actions.ts
@@ -47,10 +47,6 @@ class BXTableBatchActions extends LitElement {
   @property({ type: Number, attribute: 'selected-rows-count' })
   selectedRowsCount = 0;
 
-  createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
-  }
-
   render() {
     const { formatSelectedItemsCount, selectedRowsCount, _handleCancel: handleCancel } = this;
     return html`

--- a/src/components/data-table/table-row.ts
+++ b/src/components/data-table/table-row.ts
@@ -98,10 +98,6 @@ class BXTableRow extends FocusMixin(LitElement) {
   @property({ attribute: 'selection-value' })
   selectionValue = '';
 
-  createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
-  }
-
   connectedCallback() {
     const table = this.closest((this.constructor as typeof BXTableRow).selectorTable);
     if (table) {

--- a/src/components/notification/inline-notification.ts
+++ b/src/components/notification/inline-notification.ts
@@ -207,10 +207,6 @@ class BXInlineNotification extends FocusMixin(LitElement) {
   @property()
   title = '';
 
-  createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
-  }
-
   connectedCallback() {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'alert');


### PR DESCRIPTION
Fixes the side effect of `delegatesFocus` shadow DOM property, similar or equal to [Chromium bug report number 950357](https://bugs.chromium.org/p/chromium/issues/detail?id=950357), where browser attempts to focus on the first focusable element if user clicks on a non-focusable element in shadow DOM.

Such behavior deprives user from the ability to select text in shadow DOM.

Fixes #363.