### PR TITLE
feat(accordion): responsive upon container

### DIFF
--- a/src/components/accordion/accordion-item.ts
+++ b/src/components/accordion/accordion-item.ts
@@ -8,12 +8,47 @@
  */
 
 import settings from 'carbon-components/es/globals/js/settings';
+import { classMap } from 'lit-html/directives/class-map';
 import { html, property, customElement, LitElement } from 'lit-element';
 import ChevronRight16 from '@carbon/icons/lib/chevron--right/16';
 import FocusMixin from '../../globals/mixins/focus';
+import Handle from '../../globals/internal/handle';
 import styles from './accordion.scss';
 
 const { prefix } = settings;
+
+/**
+ * Breakpoints for accordion items. It's different from one in `@carbon/layout` library.
+ */
+export enum ACCORDION_ITEM_BREAKPOINT {
+  /**
+   * Small breakpoint.
+   */
+  SMALL = 'sm',
+
+  /**
+   * Medium breakpoint.
+   */
+  MEDIUM = 'md',
+}
+
+/**
+ * Observes resize of the given element with the given resize observer.
+ * @param observer The resize observer.
+ * @param elem The element to observe the resize.
+ */
+const observeResize = (observer: ResizeObserver, elem: Element) => {
+  if (!elem) {
+    return null;
+  }
+  observer.observe(elem);
+  return {
+    release() {
+      observer.unobserve(elem);
+      return null;
+    },
+  } as Handle;
+};
 
 /**
  * Accordion item.
@@ -25,6 +60,16 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-accordion-item`)
 class BXAccordionItem extends FocusMixin(LitElement) {
+  /**
+   * The current breakpoint.
+   */
+  private _currentBreakpoint?: ACCORDION_ITEM_BREAKPOINT;
+
+  /**
+   * The handle for observing resize of the parent element of this element.
+   */
+  private _hObserveResize: Handle | null = null;
+
   /**
    * Handles user-initiated toggle request of this accordion item.
    * @param open The new open state.
@@ -61,6 +106,20 @@ class BXAccordionItem extends FocusMixin(LitElement) {
   };
 
   /**
+   * The `ResizeObserver` instance for observing element resizes for re-positioning floating menu position.
+   */
+  // TODO: Wait for `.d.ts` update to support `ResizeObserver`
+  // @ts-ignore
+  private _resizeObserver = new ResizeObserver((records: ResizeObserverEntry[]) => {
+    const { width } = records[records.length - 1].contentRect;
+    const { _sizesBreakpoints: sizesBreakpoints } = this.constructor as typeof BXAccordionItem;
+    this._currentBreakpoint = Object.keys(sizesBreakpoints)
+      .sort((lhs, rhs) => sizesBreakpoints[rhs] - sizesBreakpoints[lhs])
+      .find(size => width >= sizesBreakpoints[size]) as ACCORDION_ITEM_BREAKPOINT;
+    this.requestUpdate();
+  });
+
+  /**
    * The assistive text for the expando button.
    */
   @property({ attribute: 'expando-assistive-text' })
@@ -83,6 +142,16 @@ class BXAccordionItem extends FocusMixin(LitElement) {
       this.setAttribute('role', 'listitem');
     }
     super.connectedCallback();
+    if (this._hObserveResize) {
+      this._hObserveResize = this._hObserveResize.release();
+    }
+    this._hObserveResize = observeResize(this._resizeObserver, this);
+  }
+
+  disconnectedCallback() {
+    if (this._hObserveResize) {
+      this._hObserveResize = this._hObserveResize.release();
+    }
   }
 
   createRenderRoot() {
@@ -94,9 +163,16 @@ class BXAccordionItem extends FocusMixin(LitElement) {
       expandoAssistiveText,
       titleText,
       open,
+      _currentBreakpoint: currentBreakpoint,
       _handleClickExpando: handleClickExpando,
       _handleKeydownExpando: handleKeydownExpando,
     } = this;
+    const { _classesBreakpoints: classesBreakpoints } = this.constructor as typeof BXAccordionItem;
+    const { [currentBreakpoint!]: classBreakpoint } = classesBreakpoints;
+    const contentClasses = classMap({
+      [classBreakpoint]: classBreakpoint,
+      [`${prefix}--accordion__content`]: true,
+    });
     return html`
       <button
         type="button"
@@ -112,8 +188,30 @@ class BXAccordionItem extends FocusMixin(LitElement) {
         })}
         <div class="${prefix}--accordion__title"><slot name="title">${titleText}</slot></div>
       </button>
-      <div class="${prefix}--accordion__content"><slot></slot></div>
+      <div class="${contentClasses}"><slot></slot></div>
     `;
+  }
+
+  /**
+   * The CSS classes for breakpoints.
+   * @private
+   */
+  static get _classesBreakpoints() {
+    return {
+      [ACCORDION_ITEM_BREAKPOINT.SMALL]: `${prefix}-ce--accordion__content--${ACCORDION_ITEM_BREAKPOINT.SMALL}`,
+      [ACCORDION_ITEM_BREAKPOINT.MEDIUM]: `${prefix}-ce--accordion__content--${ACCORDION_ITEM_BREAKPOINT.MEDIUM}`,
+    };
+  }
+
+  /**
+   * The breakpoints.
+   * @private
+   */
+  static get _sizesBreakpoints() {
+    return {
+      [ACCORDION_ITEM_BREAKPOINT.SMALL]: 480,
+      [ACCORDION_ITEM_BREAKPOINT.MEDIUM]: 640,
+    };
   }
 
   /**

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2019
+// Copyright IBM Corp. 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -22,4 +22,16 @@ $css--plex: true !default;
 
 :host(#{$prefix}-accordion-item[open]) {
   @extend .#{$prefix}--accordion__item--active;
+
+  .#{$prefix}--accordion__content {
+    padding-right: $carbon--spacing-05;
+  }
+
+  .#{$prefix}-ce--accordion__content--sm {
+    padding-right: $carbon--spacing-09;
+  }
+
+  .#{$prefix}-ce--accordion__content--md {
+    padding-right: 25%;
+  }
 }

--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020
+// Copyright IBM Corp. 2019, 2020
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
This change introduces `<bx-accordion-item>` style responsive to the element width rather than viewport width.

Fixes #362.