### PR TITLE
feat(react-wrapper): support non-attribute props

### DIFF
--- a/tests/spec/createReactCustomElementType_spec.ts
+++ b/tests/spec/createReactCustomElementType_spec.ts
@@ -108,6 +108,20 @@ describe('React wrapper', function() {
     });
   });
 
+  describe('Direct property mapping', function() {
+    it('Should map to properties instead of to attributes', function() {
+      const Component = createReactCustomElementType('test-foo', {
+        foo: {
+          attribute: false,
+        },
+      });
+      act(() => {
+        render(React.createElement(Component, { foo: { foo: 'Foo', bar: 'Bar' } }), container);
+      });
+      expect(container.querySelector('test-foo').foo).toEqual({ foo: 'Foo', bar: 'Bar' });
+    });
+  });
+
   describe('Event handling', function() {
     it('Should support string-based event descriptor', function() {
       const Component = createReactCustomElementType('test-foo', {

--- a/tools/babel-plugin-create-react-custom-element-type.js
+++ b/tools/babel-plugin-create-react-custom-element-type.js
@@ -234,11 +234,12 @@ module.exports = function generateCreateReactCustomElementType(api) {
    *   The list of `{ attribute: 'attribute-name', serialize: typeSerializer }` generated from `@property()` decorators.
    */
   const buildPropsDescriptor = declaredProps =>
-    Object.keys(declaredProps)
-      .filter(name => declaredProps[name].attribute !== false)
-      .map(name => {
-        const { type, attribute } = declaredProps[name];
-        const propDesciptor = [];
+    Object.keys(declaredProps).map(name => {
+      const { type, attribute } = declaredProps[name];
+      const propDesciptor = [];
+      if (attribute === false) {
+        propDesciptor.push(t.objectProperty(t.identifier('attribute'), t.booleanLiteral(false)));
+      } else {
         if (type && type !== 'String') {
           const serializer = serializers[type];
           if (!serializer) {
@@ -249,8 +250,9 @@ module.exports = function generateCreateReactCustomElementType(api) {
         if (attribute) {
           propDesciptor.push(t.objectProperty(t.identifier('attribute'), t.stringLiteral(attribute)));
         }
-        return t.objectProperty(t.identifier(name), t.objectExpression(propDesciptor));
-      });
+      }
+      return t.objectProperty(t.identifier(name), t.objectExpression(propDesciptor));
+    });
 
   /**
    * @param {Object<string, StringLiteral|TemplateLiteral>}


### PR DESCRIPTION
This change adds support to React wrapper components for custom element properties that have no mapping to attribute.