### PR TITLE
chore(tabs): remove disabled knob

### DIFF
--- a/src/components/content-switcher/content-switcher-story-angular.ts
+++ b/src/components/content-switcher/content-switcher-story-angular.ts
@@ -14,7 +14,6 @@ import baseStory, { defaultStory as baseDefaultStory } from './content-switcher-
 export const defaultStory = ({ parameters }) => ({
   template: `
     <bx-content-switcher
-      [disabled]="disabled"
       [value]="value"
       (bx-content-switcher-beingselected)="handleBeforeSelect($event)"
       (bx-content-switcher-selected)="handleAfterSelect($event)"

--- a/src/components/content-switcher/content-switcher-story-react.tsx
+++ b/src/components/content-switcher/content-switcher-story-react.tsx
@@ -19,7 +19,7 @@ import { defaultStory as baseDefaultStory } from './content-switcher-story';
 export { default } from './content-switcher-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, value, disableSelection, onBeforeSelect, onSelect } = parameters?.props?.['bx-content-switcher'];
+  const { value, disableSelection, onBeforeSelect, onSelect } = parameters?.props?.['bx-content-switcher'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -27,7 +27,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return (
-    <BXContentSwitcher disabled={disabled} value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect}>
+    <BXContentSwitcher value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect}>
       <BXContentSwitcherItem value="all">Option 1</BXContentSwitcherItem>
       <BXContentSwitcherItem value="cloudFoundry" disabled>
         Option 2

--- a/src/components/content-switcher/content-switcher-story-vue.ts
+++ b/src/components/content-switcher/content-switcher-story-vue.ts
@@ -31,7 +31,6 @@ export const defaultStory = ({ parameters }) => {
   return {
     template: `
       <bx-content-switcher
-        :disabled="disabled"
         :value="value"
         @bx-content-switcher-beingselected="handleBeforeSelect"
         @bx-content-switcher-selected="handleAfterSelect"

--- a/src/components/content-switcher/content-switcher-story.ts
+++ b/src/components/content-switcher/content-switcher-story.ts
@@ -19,8 +19,7 @@ import storyDocs from './content-switcher-story.mdx';
 const noop = () => {};
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, value, disableSelection, onBeforeSelect = noop, onSelect = noop } =
-    parameters?.props?.['bx-content-switcher'] ?? {};
+  const { value, disableSelection, onBeforeSelect = noop, onSelect = noop } = parameters?.props?.['bx-content-switcher'] ?? {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -29,7 +28,6 @@ export const defaultStory = ({ parameters }) => {
   };
   return html`
     <bx-content-switcher
-      ?disabled="${disabled}"
       value="${ifNonNull(value)}"
       @bx-content-switcher-beingselected="${handleBeforeSelected}"
       @bx-content-switcher-selected="${onSelect}"
@@ -55,7 +53,6 @@ export default {
     },
     knobs: {
       'bx-content-switcher': () => ({
-        disabled: boolean('Disabled (disabled)', false),
         value: textNullable('The value of the selected item (value)', ''),
         disableSelection: boolean(
           'Disable user-initiated selection change (Call event.preventDefault() in bx-content-switcher-beingselected event)',

--- a/src/components/tabs/tabs-story-angular.ts
+++ b/src/components/tabs/tabs-story-angular.ts
@@ -14,7 +14,6 @@ import baseStory, { defaultStory as baseDefaultStory } from './tabs-story';
 export const defaultStory = ({ parameters }) => ({
   template: `
     <bx-tabs
-      [disabled]="disabled"
       [triggerContent]="triggerContent"
       [type]="type"
       [value]="value"

--- a/src/components/tabs/tabs-story-react.tsx
+++ b/src/components/tabs/tabs-story-react.tsx
@@ -24,7 +24,7 @@ import styles from './tabs-story.scss';
 export { default } from './tabs-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, triggerContent, type, value, disableSelection, onBeforeSelect, onSelect } = parameters?.props?.['bx-tabs'];
+  const { triggerContent, type, value, disableSelection, onBeforeSelect, onSelect } = parameters?.props?.['bx-tabs'];
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
     if (disableSelection) {
@@ -34,13 +34,7 @@ export const defaultStory = ({ parameters }) => {
   return (
     <>
       <style type="text/css">{styles.cssText}</style>
-      <BXTabs
-        disabled={disabled}
-        triggerContent={triggerContent}
-        type={type}
-        value={value}
-        onBeforeSelect={handleBeforeSelected}
-        onSelect={onSelect}>
+      <BXTabs triggerContent={triggerContent} type={type} value={value} onBeforeSelect={handleBeforeSelected} onSelect={onSelect}>
         <BXTab id="tab-all" target="panel-all" value="all">
           Option 1
         </BXTab>

--- a/src/components/tabs/tabs-story-vue.ts
+++ b/src/components/tabs/tabs-story-vue.ts
@@ -31,7 +31,6 @@ export const defaultStory = ({ parameters }) => {
   return {
     template: `
         <bx-tabs
-          :disabled="disabled"
           :trigger-content="triggerContent"
           :type="type"
           :value="value"

--- a/src/components/tabs/tabs-story.ts
+++ b/src/components/tabs/tabs-story.ts
@@ -27,7 +27,7 @@ const types = {
 };
 
 export const defaultStory = ({ parameters }) => {
-  const { disabled, triggerContent, type, value, disableSelection, onBeforeSelect = noop, onSelect = noop } =
+  const { triggerContent, type, value, disableSelection, onBeforeSelect = noop, onSelect = noop } =
     parameters?.props?.['bx-tabs'] || {};
   const handleBeforeSelected = (event: CustomEvent) => {
     onBeforeSelect(event);
@@ -40,7 +40,6 @@ export const defaultStory = ({ parameters }) => {
       ${styles}
     </style>
     <bx-tabs
-      ?disabled="${disabled}"
       trigger-content="${ifNonNull(triggerContent)}"
       type="${ifNonNull(type)}"
       value="${ifNonNull(value)}"
@@ -101,7 +100,6 @@ defaultStory.story = {
     },
     knobs: {
       'bx-tabs': () => ({
-        disabled: boolean('Disabled (disabled)', false),
         triggerContent: textNullable(
           'The default content of the trigger button for narrow screen (trigger-content)',
           'Select an item'


### PR DESCRIPTION
This change removes Storybook knobs for `disabled` property from `<bx-content-switcher>` and `<bx-tabs>`, because it was never supported.

Disabling can be done per-item level, i.e. `<bx-content-switcher-item>` and `<bx-tab>`.