### PR TITLE
chore(devenv): remove danger knob

### DIFF
--- a/src/components/modal/modal-story-angular.ts
+++ b/src/components/modal/modal-story-angular.ts
@@ -14,7 +14,6 @@ import baseStory, { defaultStory as baseDefaultStory } from './modal-story';
 export const defaultStory = ({ parameters }) => ({
   template: `
     <bx-modal
-      [danger]="danger"
       [open]="open"
       [size]="size"
       (bx-modal-beingclosed)="handleBeforeClose($event)"

--- a/src/components/modal/modal-story-react.tsx
+++ b/src/components/modal/modal-story-react.tsx
@@ -32,7 +32,7 @@ import { defaultStory as baseDefaultStory } from './modal-story';
 export { default } from './modal-story';
 
 export const defaultStory = ({ parameters }) => {
-  const { danger, open, size, disableClose, onBeforeClose, onClose } = parameters?.props?.['bx-modal'];
+  const { open, size, disableClose, onBeforeClose, onClose } = parameters?.props?.['bx-modal'];
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -40,7 +40,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return (
-    <BXModal danger={danger} open={open} size={size} onBeforeClose={handleBeforeClose} onClose={onClose}>
+    <BXModal open={open} size={size} onBeforeClose={handleBeforeClose} onClose={onClose}>
       <BXModalHeader>
         <BXModalCloseButton />
         <BXModalLabel>Label (Optional)</BXModalLabel>

--- a/src/components/modal/modal-story-vue.ts
+++ b/src/components/modal/modal-story-vue.ts
@@ -15,7 +15,6 @@ export { default } from './modal-story';
 export const defaultStory = ({ parameters }) => ({
   template: `
     <bx-modal
-      :danger="danger"
       :open="open"
       :size="size"
       @bx-modal-beingclosed="handleBeforeClose"

--- a/src/components/modal/modal-story.ts
+++ b/src/components/modal/modal-story.ts
@@ -29,7 +29,7 @@ const sizes = {
 };
 
 export const defaultStory = ({ parameters }) => {
-  const { danger, open, size, disableClose, onBeforeClose, onClose } = parameters?.props?.['bx-modal'] ?? {};
+  const { open, size, disableClose, onBeforeClose, onClose } = parameters?.props?.['bx-modal'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -37,13 +37,7 @@ export const defaultStory = ({ parameters }) => {
     }
   };
   return html`
-    <bx-modal
-      ?danger="${danger}"
-      ?open="${open}"
-      size="${ifNonNull(size)}"
-      @bx-modal-beingclosed=${handleBeforeClose}
-      @bx-modal-closed=${onClose}
-    >
+    <bx-modal ?open="${open}" size="${ifNonNull(size)}" @bx-modal-beingclosed=${handleBeforeClose} @bx-modal-closed=${onClose}>
       <bx-modal-header>
         <bx-modal-close-button></bx-modal-close-button>
         <bx-modal-label>Label (Optional)</bx-modal-label>


### PR DESCRIPTION
This change removes `danger` knob from `<bx-modal>` stories.

`<bx-modal>` has never supported `danger` attribute, as danger modal can be done by putting danger button into `<bx-modal-footer>`.