### PR TITLE
fix(floating-menu): support for modal

### DIFF
--- a/src/components/floating-menu/floating-menu.ts
+++ b/src/components/floating-menu/floating-menu.ts
@@ -334,7 +334,7 @@ abstract class BXFloatingMenu extends HostListenerMixin(FocusMixin(LitElement)) 
    * The CSS selector to find the element to put this floating menu in.
    */
   static get selectorContainer() {
-    return '[data-floating-menu-container]';
+    return '[data-floating-menu-container],bx-modal';
   }
 }
 


### PR DESCRIPTION
This change adds support for floating menus in modal by ensuring that floating menu body is in between `<bx-modal>`'s focus sentinels. Otherwise, an attempt to focus on floating menu body interferes with `<bx-modal>`' s focus-wrapping behavior that attemps moving focus back
in modal content.