### PR TITLE
chore(components): expando announcing content

### DIFF
--- a/src/components/accordion/accordion-item.ts
+++ b/src/components/accordion/accordion-item.ts
@@ -120,12 +120,6 @@ class BXAccordionItem extends FocusMixin(LitElement) {
   });
 
   /**
-   * The assistive text for the expando button.
-   */
-  @property({ attribute: 'expando-assistive-text' })
-  expandoAssistiveText = 'Expand/Collapse';
-
-  /**
    * `true` if the check box should be open.
    */
   @property({ type: Boolean, reflect: true })
@@ -156,7 +150,6 @@ class BXAccordionItem extends FocusMixin(LitElement) {
 
   render() {
     const {
-      expandoAssistiveText,
       titleText,
       open,
       _currentBreakpoint: currentBreakpoint,
@@ -173,18 +166,17 @@ class BXAccordionItem extends FocusMixin(LitElement) {
       <button
         type="button"
         class="${prefix}--accordion__heading"
-        title="${expandoAssistiveText}"
+        aria-controls="content"
         aria-expanded="${String(Boolean(open))}"
         @click="${handleClickExpando}"
         @keydown="${handleKeydownExpando}"
       >
         ${ChevronRight16({
           class: `${prefix}--accordion__arrow`,
-          'aria-label': expandoAssistiveText,
         })}
         <div class="${prefix}--accordion__title"><slot name="title">${titleText}</slot></div>
       </button>
-      <div class="${contentClasses}"><slot></slot></div>
+      <div id="content" class="${contentClasses}"><slot></slot></div>
     `;
   }
 

--- a/src/components/tile/expandable-tile.ts
+++ b/src/components/tile/expandable-tile.ts
@@ -52,22 +52,10 @@ class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
   };
 
   /**
-   * An assistive text for screen reader to announce, telling the collapsed state.
-   */
-  @property({ attribute: 'collapsed-assistive-text' })
-  collapsedAssistiveText!: string;
-
-  /**
    * The color scheme.
    */
   @property({ attribute: 'color-scheme', reflect: true })
   colorScheme = FORM_ELEMENT_COLOR_SCHEME.REGULAR;
-
-  /**
-   * An assistive text for screen reader to announce, telling the expanded state.
-   */
-  @property({ attribute: 'expanded-assistive-text' })
-  expandedAssistiveText!: string;
 
   /**
    * `true` to expand this expandable tile.
@@ -80,19 +68,21 @@ class BXExpandableTile extends HostListenerMixin(FocusMixin(LitElement)) {
   }
 
   render() {
-    const { collapsedAssistiveText, expandedAssistiveText, expanded } = this;
-    const assistiveText = expanded ? expandedAssistiveText : collapsedAssistiveText;
+    const { expanded } = this;
     return html`
-      <button class="${prefix}--tile__chevron" aria-labelledby="icon">
+      <button
+        class="${prefix}--tile__chevron"
+        aria-labelledby="above-the-fold-content"
+        aria-controls="below-the-fold-content"
+        aria-expanded="${String(Boolean(expanded))}"
+      >
         ${ChevronDown16({
           id: 'icon',
-          alt: assistiveText,
-          description: assistiveText,
-          'aria-label': assistiveText,
         })}
       </button>
-      <div class="${prefix}--tile-content">
-        <slot></slot>
+      <div id="content" class="${prefix}--tile-content">
+        <div id="above-the-fold-content"><slot name="above-the-fold-content"></slot></div>
+        <div id="below-the-fold-content"><slot></slot></div>
       </div>
     `;
   }

--- a/src/components/tile/tile-story-angular.ts
+++ b/src/components/tile/tile-story-angular.ts
@@ -99,7 +99,7 @@ export const expandable = ({ parameters }) => ({
       (bx-expandable-tile-beingchanged)="handleBeforeChange($event)"
       (bx-expandable-tile-changed)="handleAfterChange($event)"
     >
-      <bx-tile-above-the-fold-content style="height: 200px">
+      <bx-tile-above-the-fold-content slot="above-the-fold-content" style="height: 200px">
         Above the fold content here
       </bx-tile-above-the-fold-content>
       <bx-tile-below-the-fold-content style="height: 300px">

--- a/src/components/tile/tile-story-react.tsx
+++ b/src/components/tile/tile-story-react.tsx
@@ -97,7 +97,9 @@ export const expandable = ({ parameters }) => {
   };
   return (
     <BXExpandableTile colorScheme={colorScheme} expanded={expanded} onBeforeChange={handleBeforeChanged} onChange={onChange}>
-      <BXTileAboveTheFoldContent style={{ height: '200px' }}>Above the fold content here</BXTileAboveTheFoldContent>
+      <BXTileAboveTheFoldContent slot="above-the-fold-content" style={{ height: '200px' }}>
+        Above the fold content here
+      </BXTileAboveTheFoldContent>
       <BXTileBelowTheFoldContent style={{ height: '300px' }}>Below the fold content here</BXTileBelowTheFoldContent>
     </BXExpandableTile>
   );

--- a/src/components/tile/tile-story-vue.ts
+++ b/src/components/tile/tile-story-vue.ts
@@ -112,7 +112,7 @@ export const expandable = ({ parameters }) => {
         @bx-expandable-tile-beingchanged="handleBeforeChange"
         @bx-expandable-tile-changed="handleAfterChange"
       >
-        <bx-tile-above-the-fold-content style="height: 200px">
+        <bx-tile-above-the-fold-content slot="above-the-fold-content" style="height: 200px">
           Above the fold content here
         </bx-tile-above-the-fold-content>
         <bx-tile-below-the-fold-content style="height: 300px">

--- a/src/components/tile/tile-story.ts
+++ b/src/components/tile/tile-story.ts
@@ -154,7 +154,7 @@ export const expandable = ({ parameters }) => {
       @bx-expandable-tile-beingchanged=${handleBeforeChanged}
       @bx-expandable-tile-changed=${onChange}
     >
-      <bx-tile-above-the-fold-content style="height: 200px">
+      <bx-tile-above-the-fold-content slot="above-the-fold-content" style="height: 200px">
         Above the fold content here
       </bx-tile-above-the-fold-content>
       <bx-tile-below-the-fold-content style="height: 300px">


### PR DESCRIPTION
This change lets screen reader announce the content associated with expando along with the ARIA state, instead of using assistive text like "Expand/Collapse". Doing so provides more natural announcement for screen reader users, as well as reduces the need for additional attributes for screen reader, allowing us to reduce the maintenance cost and allowing user to reduce translations.