### PR TITLE
fix(accordion): make chevron center-aligned

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -18,6 +18,13 @@ $css--plex: true !default;
 
   display: block;
   outline: none;
+
+  .#{$prefix}--accordion__heading {
+    padding-top: calc((#{$container-03} - #{map-get($body-long-01, 'line-height')}) / 2);
+    padding-bottom: calc((#{$container-03} - #{map-get($body-long-01, 'line-height')}) / 2);
+    height: auto;
+    min-height: $container-03;
+  }
 }
 
 :host(#{$prefix}-accordion-item[open]) {


### PR DESCRIPTION
We had a recent change in accordion style presumably to support multi-lines accordion title. However, the change made the text top-aligned for single line condition, and the CSS actually didn't support multi-lines accordion title. This change fixes those problems.