### PR TITLE
chore(lint): fix an error in check-license.js

### DIFF
--- a/tools/check-license.js
+++ b/tools/check-license.js
@@ -20,26 +20,42 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const { currentYear, reLicenseTextCurrentYear, reLicenseTextSingleYear, reLicenseTextRange } = reLicense;
 
-const check = (paths, { testCurrentYear, writeCurrentYear }) =>
-  Promise.all(
-    paths.map(async item => {
-      const contents = await readFile(item, 'utf8');
-      const result = (testCurrentYear || writeCurrentYear ? reLicenseTextCurrentYear : reLicense).test(contents);
-      if (!result) {
-        if (writeCurrentYear) {
-          const newContents = contents
-            .replace(reLicenseTextSingleYear, match => `${match}, ${currentYear}`)
-            .replace(reLicenseTextRange, (match, token) => `${token}${currentYear}`);
-          if (!reLicenseTextCurrentYear.test(newContents)) {
-            throw new Error(`Could not find license text in: ${item}`);
+/**
+ * Checks files with the given paths for valid license text.
+ *
+ * @param {string[]} paths The file paths to check for valid license text.
+ * @param {object} options The options.
+ * @param {boolean} options.testCurrentYear `true` to see if the license text contains the current year.
+ * @param {boolean} options.writeCurrentYear `true` to update the given file with the current year for the license text.
+ * @returns {Promise<void>} The promise that is fulfilled when the check finishes.
+ */
+const check = async (paths, { testCurrentYear, writeCurrentYear }) => {
+  const filesWithErrors = (
+    await Promise.all(
+      paths.map(async item => {
+        const contents = await readFile(item, 'utf8');
+        const result = (testCurrentYear || writeCurrentYear ? reLicenseTextCurrentYear : reLicense).test(contents);
+        if (!result) {
+          if (writeCurrentYear) {
+            const newContents = contents
+              .replace(reLicenseTextSingleYear, match => `${match}, ${currentYear}`)
+              .replace(reLicenseTextRange, (match, token) => `${token}${currentYear}`);
+            if (!reLicenseTextCurrentYear.test(newContents)) {
+              return item;
+            }
+            await writeFile(item, newContents, 'utf8');
+          } else {
+            return item;
           }
-          await writeFile(item, newContents, 'utf8');
-        } else {
-          throw new Error(`Could not find license text in: ${item}`);
         }
-      }
-    })
-  );
+        return undefined;
+      })
+    )
+  ).filter(Boolean);
+  if (filesWithErrors.length > 0) {
+    throw new Error(`Cannot find license text in: ${filesWithErrors.join(', ')}`);
+  }
+};
 
 const { args, ...options } = commander
   .option('-c, --test-current-year', 'Ensures the license header represents the current year')


### PR DESCRIPTION
This change fixes an issue in license checker code where files are being clobbered when one file is found as missing license header (completely) while another file is updating license year.