### PR TITLE
chore(number-input): add tests

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -183,7 +183,7 @@ export default class BXInput extends ValidityMixin(FormMixin(LitElement)) {
   /**
    * The value of the input.
    */
-  @property()
+  @property({ reflect: true })
   value = '';
 
   createRenderRoot() {

--- a/src/components/number-input/number-input-story.ts
+++ b/src/components/number-input/number-input-story.ts
@@ -18,7 +18,7 @@ import createProps from './stories/helpers';
 import storyDocs from './number-input-story.mdx';
 
 export const defaultStory = ({ parameters }) => {
-  const { colorScheme, disabled, value, placeholder, invalid, mobile, min, max, size, step, onInput } =
+  const { colorScheme, disabled, value, placeholder, invalid, mobile, min, max, size, step, onInput, name } =
     parameters?.props?.['bx-number-input'] ?? {};
   return html`
     <bx-number-input
@@ -27,6 +27,7 @@ export const defaultStory = ({ parameters }) => {
       value="${ifNonNull(value)}"
       placeholder="${ifNonNull(placeholder)}"
       ?invalid="${invalid}"
+      name="${name}"
       ?mobile="${mobile}"
       min="${ifNonNull(min)}"
       max="${ifNonNull(max)}"

--- a/src/components/number-input/number-input.ts
+++ b/src/components/number-input/number-input.ts
@@ -45,20 +45,6 @@ export default class BXNumberInput extends BXInput {
   @query('input')
   protected _input!: HTMLInputElement;
 
-  /**
-   * Handles incrementing the value in the input
-   */
-  protected _handleIncrement() {
-    this._input.stepUp();
-  }
-
-  /**
-   * Handles decrementing the value in the input
-   */
-  protected _handleDecrement() {
-    this._input.stepDown();
-  }
-
   _testValidity() {
     if (this._input?.valueAsNumber > Number(this.max)) {
       return NUMBER_INPUT_VALIDATION_STATUS.EXCEEDED_MAXIMUM;
@@ -85,6 +71,8 @@ export default class BXNumberInput extends BXInput {
   protected _max = '';
 
   protected _step = '1';
+
+  protected _value = '';
 
   /**
    * The color scheme.
@@ -135,6 +123,31 @@ export default class BXNumberInput extends BXInput {
   }
 
   /**
+   * The value of the input.
+   */
+  @property({ reflect: true })
+  get value() {
+    // once we have the input we can directly query for the value
+    if (this._input) {
+      return this._input.value;
+    }
+    // but before then _value will work fine
+    return this._value;
+  }
+
+  set value(value) {
+    const oldValue = this._value;
+    this._value = value;
+    // make sure that lit-element updates the right properties
+    this.requestUpdate('value', oldValue);
+    // we set the value directly on the input (when available)
+    // so that programatic manipulation updates the UI correctly
+    if (this._input) {
+      this._input.value = value;
+    }
+  }
+
+  /**
    * Set to `true` to enable the mobile variant of the number input
    */
   @property({ type: Boolean, reflect: true })
@@ -173,6 +186,20 @@ export default class BXNumberInput extends BXInput {
    */
   @property({ attribute: 'validity-message-min' })
   validityMessageMin = '';
+
+  /**
+   * Handles incrementing the value in the input
+   */
+  stepUp() {
+    this._input.stepUp();
+  }
+
+  /**
+   * Handles decrementing the value in the input
+   */
+  stepDown() {
+    this._input.stepDown();
+  }
 
   createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -215,7 +242,7 @@ export default class BXNumberInput extends BXInput {
         aria-atomic="true"
         type="button"
         ?disabled=${this.disabled}
-        @click=${this._handleIncrement}
+        @click=${this.stepUp}
       >
         ${CaretUp16()}
       </button>
@@ -228,7 +255,7 @@ export default class BXNumberInput extends BXInput {
         aria-atomic="true"
         type="button"
         ?disabled=${this.disabled}
-        @click=${this._handleDecrement}
+        @click=${this.stepDown}
       >
         ${CaretDown16()}
       </button>
@@ -247,7 +274,7 @@ export default class BXNumberInput extends BXInput {
         ?readonly="${this.readonly}"
         ?required="${this.required}"
         type="number"
-        .value="${this.value}"
+        .value="${this._value}"
         @input="${handleInput}"
         min="${ifNonEmpty(this.min)}"
         max="${ifNonEmpty(this.max)}"

--- a/tests/snapshots/bx-number-input.md
+++ b/tests/snapshots/bx-number-input.md
@@ -1,0 +1,78 @@
+# `bx-number-input`
+
+## `Rendering`
+
+####   `Should render with various attributes`
+
+```
+<div class="bx--number bx--number--lg">
+  <label
+    class="bx--label bx--label--disabled"
+    for="input"
+  >
+    <slot name="label-text">
+    </slot>
+  </label>
+  <div class="bx--form__helper-text bx--form__helper-text--disabled">
+    <slot name="helper-text">
+    </slot>
+  </div>
+  <div class="bx--number__input-wrapper">
+    <input
+      aria-atomic="true"
+      disabled=""
+      id="input"
+      max="200"
+      min="-100"
+      name="name-foo"
+      placeholder="placeholder-foo"
+      role="alert"
+      step="1"
+      type="number"
+    >
+    <div class="bx--number__controls">
+      <button
+        aria-atomic="true"
+        aria-label="increase number input"
+        aria-live="polite"
+        class="bx--number__control-btn up-icon"
+        disabled=""
+        type="button"
+      >
+      </button>
+      <button
+        aria-atomic="true"
+        aria-label="decrease number input"
+        aria-live="polite"
+        class="bx--number__control-btn down-icon"
+        disabled=""
+        type="button"
+      >
+      </button>
+    </div>
+  </div>
+  <div
+    class="bx--form-requirement"
+    hidden=""
+  >
+    <slot name="validity-message">
+    </slot>
+  </div>
+  <div
+    class="bx--form-requirement"
+    hidden=""
+  >
+    <slot name="validity-message-max">
+    </slot>
+  </div>
+  <div
+    class="bx--form-requirement"
+    hidden=""
+  >
+    <slot name="validity-message-min">
+    </slot>
+  </div>
+</div>
+
+```
+

--- a/tests/spec/number-input_spec.ts
+++ b/tests/spec/number-input_spec.ts
@@ -1,0 +1,260 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, render } from 'lit-html';
+import EventManager from '../utils/event-manager';
+
+import BXNumberInput from '../../src/components/number-input/number-input';
+import { defaultStory } from '../../src/components/number-input/number-input-story';
+
+/**
+ * @param formData A `FormData` instance.
+ * @returns The given `formData` converted to a classic key-value pair.
+ */
+const getValues = (formData: FormData) => {
+  const values = {};
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [key, value] of formData.entries()) {
+    values[key] = value;
+  }
+  return values;
+};
+
+const template = (props?) =>
+  defaultStory({
+    parameters: {
+      props: {
+        'bx-number-input': props,
+      },
+    },
+  });
+
+describe('bx-number-input', function() {
+  const events = new EventManager();
+
+  describe('Rendering', function() {
+    it('Should render with various attributes', async function() {
+      render(
+        template({
+          autocomplete: 'on',
+          autofocus: true,
+          disabled: true,
+          helperText: 'helper-text-foo',
+          labelText: 'label-text-foo',
+          name: 'name-foo',
+          pattern: 'pattern-foo',
+          placeholder: 'placeholder-foo',
+          readonly: true,
+          required: true,
+          validityMessage: 'validity-message-foo',
+          value: '50',
+          step: '1',
+          max: '200',
+          min: '-100',
+        }),
+        document.body
+      );
+      await Promise.resolve();
+      expect(document.body.querySelector('bx-number-input')).toMatchSnapshot({ mode: 'shadow' });
+    });
+  });
+
+  // most of this describe is borrowed from the input tests
+  describe('Event-based form participation', function() {
+    it('Should respond to `formdata` event', async function() {
+      render(
+        html`
+          <form>
+            ${template({
+              name: 'name-foo',
+              value: '50',
+            })}
+          </form>
+        `,
+        document.body
+      );
+      await Promise.resolve();
+      const formData = new FormData();
+      const event = new CustomEvent('formdata', { bubbles: true, cancelable: false, composed: false });
+      (event as any).formData = formData; // TODO: Wait for `FormDataEvent` being available in `lib.dom.d.ts`
+      const form = document.querySelector('form');
+      form!.dispatchEvent(event);
+      expect(getValues(formData)).toEqual({ 'name-foo': '50' });
+    });
+
+    it('Should not respond to `formdata` event if disabled', async function() {
+      render(
+        html`
+          <form>
+            ${template({
+              disabled: true,
+              name: 'name-foo',
+              value: '50',
+            })}
+          </form>
+        `,
+        document.body
+      );
+      await Promise.resolve();
+      const formData = new FormData();
+      const event = new CustomEvent('formdata', { bubbles: true, cancelable: false, composed: false });
+      (event as any).formData = formData; // TODO: Wait for `FormDataEvent` being available in `lib.dom.d.ts`
+      const form = document.querySelector('form');
+      form!.dispatchEvent(event);
+      expect(getValues(formData)).toEqual({});
+    });
+  });
+
+  // most of this describe is borrowed from the input tests
+  describe('Form validation', function() {
+    let elem: Element;
+
+    beforeEach(async function() {
+      render(template(), document.body);
+      await Promise.resolve();
+      elem = document.body.querySelector('bx-number-input')!;
+    });
+
+    // This test is skipped for now since there seems to be a bug somewhere in the test stack.
+    // Running the same code manually in a browser works as expected.
+    // Given that the rest of the test suit passes it seems reasonable that it's an issue
+    // with this specific test case
+    // eslint-disable-next-line
+    xit('should support checking if required value exists', async function() {
+      const input = elem as BXNumberInput;
+      input.value = null as any;
+      input.required = true;
+      const spyInvalid = jasmine.createSpy('invalid');
+      events.on(input, 'invalid', spyInvalid);
+      expect(input.checkValidity()).toBe(false);
+      expect(spyInvalid).toHaveBeenCalled();
+      expect(input.invalid).toBe(true);
+      expect(input.validityMessage).toBe('Please fill out this field.');
+      input.value = '50';
+      await Promise.resolve();
+      expect(input.checkValidity()).toBe(true);
+      expect(input.invalid).toBe(false);
+      expect(input.validityMessage).toBe('');
+    });
+
+    it('should support canceling required check', async function() {
+      const input = elem as BXNumberInput;
+      input.required = true;
+      events.on(input, 'invalid', event => {
+        event.preventDefault();
+      });
+      expect(input.checkValidity()).toBe(false);
+      expect(input.invalid).toBe(false);
+      expect(input.validityMessage).toBe('');
+    });
+
+    it('should treat empty custom validity message as not invalid', async function() {
+      const input = elem as BXNumberInput;
+      input.setCustomValidity('');
+      expect(input.invalid).toBe(false);
+      expect(input.validityMessage).toBe('');
+    });
+
+    it('should treat non-empty custom validity message as invalid', async function() {
+      const input = elem as BXNumberInput;
+      input.setCustomValidity('validity-message-foo');
+      expect(input.invalid).toBe(true);
+      expect(input.validityMessage).toBe('validity-message-foo');
+    });
+
+    it('should warn if a value less than the min', async function() {
+      const input = elem as BXNumberInput;
+      input.min = '50';
+      input.value = '0';
+      await Promise.resolve();
+      expect(input.checkValidity()).toBe(false);
+    });
+
+    it('should warn if a value is greater than the max', async function() {
+      const input = elem as BXNumberInput;
+      input.max = '50';
+      input.value = '51';
+      await Promise.resolve();
+      expect(input.checkValidity()).toBe(false);
+    });
+  });
+
+  describe('Number input specific functionality', function() {
+    let elem: Element;
+
+    beforeEach(async function() {
+      render(template(), document.body);
+      await Promise.resolve();
+      elem = document.body.querySelector('bx-number-input')!;
+    });
+
+    it('should increment values', async function() {
+      const input = elem as BXNumberInput;
+      const initialValue = Number(input.value);
+      const stepSize = Number(input.step);
+      input.stepUp();
+      expect(Number(input.value)).toEqual(initialValue + stepSize);
+    });
+
+    it('should decrement values', async function() {
+      const input = elem as BXNumberInput;
+      const initialValue = Number(input.value);
+      const stepSize = Number(input.step);
+      input.stepDown();
+      expect(Number(input.value)).toEqual(initialValue - stepSize);
+    });
+
+    it('should increment values by the step amount', async function() {
+      const input = elem as BXNumberInput;
+      const initialValue = Number(input.value);
+      input.step = '50';
+      await Promise.resolve(); // wait for the value to apply
+      const stepSize = Number(input.step);
+      input.stepUp();
+      await Promise.resolve(); // wait for the value to apply
+      expect(Number(input.value)).toEqual(initialValue + stepSize);
+    });
+
+    it('should decrement values by the step amount', async function() {
+      const input = elem as BXNumberInput;
+      const initialValue = Number(input.value);
+      input.step = '50';
+      await Promise.resolve(); // wait for the value to apply
+      const stepSize = Number(input.step);
+      input.stepDown();
+      await Promise.resolve(); // wait for the value to apply
+      expect(Number(input.value)).toEqual(initialValue - stepSize);
+    });
+
+    it('should not step past the max value', async function() {
+      const input = elem as BXNumberInput;
+      input.max = '50';
+      input.value = '50';
+      await Promise.resolve();
+      input.stepUp();
+      await Promise.resolve();
+      expect(Number(input.value)).toEqual(50);
+    });
+
+    it('should not step below the min value', async function() {
+      const input = elem as BXNumberInput;
+      input.min = '50';
+      input.value = '50';
+      await Promise.resolve();
+      input.stepDown();
+      await Promise.resolve();
+      expect(Number(input.value)).toEqual(50);
+    });
+  });
+
+  afterEach(async function() {
+    events.reset();
+    await render(undefined!, document.body);
+  });
+});


### PR DESCRIPTION
This adds a number of tests for the number input component. A lot of the base tests are borrowed from `bx-input` with modifications.