### PR TITLE
feat(ui-shell): support title attribute

### DIFF
--- a/src/components/ui-shell/header-nav-item.ts
+++ b/src/components/ui-shell/header-nav-item.ts
@@ -27,15 +27,21 @@ class BXHeaderNavItem extends FocusMixin(LitElement) {
   @property()
   href!: string;
 
+  /**
+   * The title.
+   */
+  @property()
+  title!: string;
+
   createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
   }
 
   render() {
-    const { href } = this;
+    const { href, title } = this;
     return html`
       <a role="menuitem" class="${prefix}--header__menu-item" tabindex="0" href="${ifDefined(href)}">
-        <span class="${prefix}--text-truncate--end"><slot></slot></span>
+        <span class="${prefix}--text-truncate--end"><slot>${title}</slot></span>
       </a>
     `;
   }

--- a/src/components/ui-shell/side-nav-link.ts
+++ b/src/components/ui-shell/side-nav-link.ts
@@ -47,6 +47,12 @@ class BXSideNavLink extends FocusMixin(LitElement) {
   @property()
   href = '';
 
+  /**
+   * The title.
+   */
+  @property()
+  title!: string;
+
   createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
   }
@@ -59,7 +65,7 @@ class BXSideNavLink extends FocusMixin(LitElement) {
   }
 
   render() {
-    const { active, href, _handleSlotChangeTitleIcon: handleSlotChangeTitleIcon } = this;
+    const { active, href, title, _handleSlotChangeTitleIcon: handleSlotChangeTitleIcon } = this;
     const classes = classMap({
       [`${prefix}--side-nav__link`]: true,
       [`${prefix}--side-nav__link--current`]: active,
@@ -70,7 +76,7 @@ class BXSideNavLink extends FocusMixin(LitElement) {
           <slot name="title-icon" @slotchange=${handleSlotChangeTitleIcon}></slot>
         </div>
         <span class="${prefix}--side-nav__link-text">
-          <slot></slot>
+          <slot>${title}</slot>
         </span>
       </a>
     `;

--- a/src/components/ui-shell/side-nav-menu-item.ts
+++ b/src/components/ui-shell/side-nav-menu-item.ts
@@ -34,6 +34,12 @@ class BXSideNavMenuItem extends FocusMixin(LitElement) {
   @property()
   href = '';
 
+  /**
+   * The title.
+   */
+  @property()
+  title!: string;
+
   createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
   }
@@ -50,7 +56,7 @@ class BXSideNavMenuItem extends FocusMixin(LitElement) {
   }
 
   render() {
-    const { active, href } = this;
+    const { active, href, title } = this;
     const classes = classMap({
       [`${prefix}--side-nav__link`]: true,
       [`${prefix}--side-nav__link--current`]: active,
@@ -58,7 +64,7 @@ class BXSideNavMenuItem extends FocusMixin(LitElement) {
     return html`
       <a role="menuitem" class="${classes}" href="${href}">
         <span class="${prefix}--side-nav__link-text">
-          <slot></slot>
+          <slot>${title}</slot>
         </span>
       </a>
     `;


### PR DESCRIPTION
This change adds `title` attribute support to several nav items in UI shell. `title` attribute works as text-only content of such nav items and it can be used instead of a child node.