### PR TITLE
fix(modal): wrap close in native button

### DIFF
--- a/src/components/modal/modal-close-button.ts
+++ b/src/components/modal/modal-close-button.ts
@@ -20,11 +20,17 @@ const { prefix } = settings;
  */
 @customElement(`${prefix}-modal-close-button`)
 class BXModalCloseButton extends LitElement {
+  createRenderRoot() {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+
   render() {
     return html`
-      ${Close20({
-        class: `${prefix}--modal-close__icon`,
-      })}
+      <button class="${prefix}--modal-close">
+        ${Close20({
+          class: `${prefix}--modal-close__icon`,
+        })}
+      </button>
     `;
   }
 

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -80,7 +80,7 @@
 }
 
 :host(#{$prefix}-modal-close-button) {
-  @extend .#{$prefix}--modal-close;
+  outline: none;
 }
 
 :host(#{$prefix}-modal-heading),

--- a/tests/integration/ui/modal_steps.js
+++ b/tests/integration/ui/modal_steps.js
@@ -15,7 +15,7 @@ describe('bx-modal', () => {
   });
 
   it('should have modal closable', async () => {
-    await page.click('bx-modal-close-button');
+    await page.click('bx-modal-close-button button');
     await expect(page).toHaveSelector('bx-modal .bx--modal-container', { state: 'hidden' });
   });
 });


### PR DESCRIPTION
This change support keyboard action in `<bx-modal-close-button>` by wrapping it in a native `<button>`.