### PR TITLE
Expose package subpaths with the "exports" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "license": "Apache-2.0",
   "main": "es/index.js",
   "module": "es/index.js",
+  "exports": {
+    "./es/": "./es/",
+    "./custom-elements.json": "./custom-elements.json",
+    "./package.json": "./package.json"
+  },
   "typings": "es/index.d.ts",
   "repository": "https://github.com/carbon-design-system/carbon-custom-elements",
   "bugs": "https://github.com/carbon-design-system/carbon-custom-elements/issues",


### PR DESCRIPTION
This adds the `"exports"` field as defined in Node.js 12 and 14 to enable subpath imports.

The current form is backwards compatible because the base-level files have been explicitly listed.

Ideally with the exports field, exact entry points would be listed, but the list here would be well over 100 which could be some work, but would have some benefits in hiding internal non public modules.

For now though, this will provide support to CDNs such as jspm and Skypack which use the "exports" field to determine how to resolve package subpaths. Specifically for jspm.dev this would ensure all subpaths are iterated and served, since usually subpaths are ignored as they might be tests etc.

Happy to answer any further questions around this, and the full docs on the field are available here - https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_package_entry_points.