### PR TITLE
test(integration): use full package

### DIFF
--- a/examples/codesandbox/ie/webpack.config.js
+++ b/examples/codesandbox/ie/webpack.config.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "es/index.js",
   "module": "es/index.js",
   "exports": {
+    "./es": "./es/index.js",
     "./es/": "./es/",
     "./custom-elements.json": "./custom-elements.json",
     "./package.json": "./package.json"
@@ -131,6 +132,7 @@
     "babel-preset-vue": "^2.0.0",
     "bluebird": "^3.5.0",
     "carbon-components": "^10.14.0",
+    "child-process-promise": "^2.2.0",
     "commander": "^2.13.0",
     "core-js": "^3.0.0",
     "css-loader": "^2.0.0",

--- a/tests/integration/build/angular_steps.js
+++ b/tests/integration/build/angular_steps.js
@@ -16,16 +16,15 @@ const PORT = 8080;
 
 describe('Angular example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/angular');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/angular');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/angular/package.json`,
         `cd ${tmpDir}/angular`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn ng serve --port ${PORT}`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/basic_steps.js
+++ b/tests/integration/build/basic_steps.js
@@ -16,16 +16,15 @@ const PORT = 1234;
 
 describe('Basic example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/basic');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/basic');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/basic/package.json`,
         `cd ${tmpDir}/basic`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn parcel --port ${PORT} index.html`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/custom-style_steps.js
+++ b/tests/integration/build/custom-style_steps.js
@@ -16,16 +16,15 @@ const PORT = 1236;
 
 describe('Custom style example with inherited component class', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/styling/custom-style');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/styling/custom-style');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/custom-style/package.json`,
         `cd ${tmpDir}/custom-style`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn parcel --port ${PORT} index.html`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/form-angular_steps.js
+++ b/tests/integration/build/form-angular_steps.js
@@ -16,16 +16,15 @@ const PORT = 8084;
 
 describe('Angular form example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/form/angular');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/form/angular');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}/form-angular`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/form-angular/package.json`,
         `cd ${tmpDir}/form-angular`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn ng serve --port ${PORT}`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/form-basic_steps.js
+++ b/tests/integration/build/form-basic_steps.js
@@ -16,16 +16,15 @@ const PORT = 1235;
 
 describe('Basic form example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/form/basic');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/form/basic');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}/form-basic`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/form-basic/package.json`,
         `cd ${tmpDir}/form-basic`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn parcel --port ${PORT} index.html`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/ie_steps.js
+++ b/tests/integration/build/ie_steps.js
@@ -16,16 +16,15 @@ const PORT = 8081;
 
 describe('IE example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/ie');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/ie');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/ie/package.json`,
         `cd ${tmpDir}/ie`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn webpack-dev-server --mode=development --open=false --port=${PORT}`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/react_steps.js
+++ b/tests/integration/build/react_steps.js
@@ -16,16 +16,15 @@ const PORT = 3000;
 
 describe('React example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/react');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/react');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/react/package.json`,
         `cd ${tmpDir}/react`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `BROWSER=none PORT=${PORT} yarn start`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/redux-form_steps.js
+++ b/tests/integration/build/redux-form_steps.js
@@ -16,16 +16,15 @@ const PORT = 3001;
 
 describe('Redux-form example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/form/redux-form');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/form/redux-form');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}/redux-form`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/redux-form/package.json`,
         `cd ${tmpDir}/redux-form`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `BROWSER=none PORT=${PORT} yarn start`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/rtl_steps.js
+++ b/tests/integration/build/rtl_steps.js
@@ -16,16 +16,15 @@ const PORT = 8083;
 
 describe('RTL example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/rtl');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/rtl');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/rtl/package.json`,
         `cd ${tmpDir}/rtl`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn webpack-dev-server --mode=development --open=false --port=${PORT}`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/theme-zoning_steps.js
+++ b/tests/integration/build/theme-zoning_steps.js
@@ -16,16 +16,15 @@ const PORT = 1237;
 
 describe('Custom style example with inherited component class', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/styling/theme-zoning');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/styling/theme-zoning');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/theme-zoning/package.json`,
         `cd ${tmpDir}/theme-zoning`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn parcel --port ${PORT} index.html`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/build/vue_steps.js
+++ b/tests/integration/build/vue_steps.js
@@ -16,16 +16,15 @@ const PORT = 8082;
 
 describe('Basic example', () => {
   beforeAll(async () => {
-    const dist = path.resolve(__dirname, '../../../es');
-    const src = path.resolve(__dirname, '../../../examples/codesandbox/vue');
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const src = path.resolve(projectRoot, 'examples/codesandbox/vue');
     const tmpDir = process.env.CCE_EXAMPLE_TMPDIR;
     await setupDevServer({
       command: [
         `cp -r ${src} ${tmpDir}`,
+        `node ${projectRoot}/tests/integration/replace-dependencies.js ${tmpDir}/vue/package.json`,
         `cd ${tmpDir}/vue`,
         'yarn install',
-        'rm -Rf node_modules/carbon-custom-elements/es',
-        `cp -r ${dist} node_modules/carbon-custom-elements`,
         `yarn serve --port ${PORT}`,
       ].join(' && '),
       launchTimeout: Number(process.env.LAUNCH_TIMEOUT),

--- a/tests/integration/replace-dependencies.js
+++ b/tests/integration/replace-dependencies.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright IBM Corp. 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const { promisify } = require('util');
+const commander = require('commander');
+
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+const deps = ['dependencies', 'peerDependencies', 'devDependencies'];
+const packs = ['carbon-custom-elements'];
+
+/**
+ * Replaces `@carbon/ibmdotcom-*` dependencies in the given `package.json` files with the local directory references.
+ *
+ * @param {string[]} files The files.
+ */
+const replace = async files => {
+  await Promise.all(
+    files.map(async file => {
+      const contents = JSON.parse(await readFile(file));
+      // eslint-disable-next-line no-restricted-syntax
+      for (const dep of deps) {
+        const item = contents[dep];
+        if (item) {
+          // eslint-disable-next-line no-restricted-syntax
+          for (const pack of packs) {
+            if (item[pack]) {
+              item[pack] = `file:../${pack}`;
+            }
+          }
+        }
+      }
+      await writeFile(file, JSON.stringify(contents, null, 2));
+    })
+  );
+};
+
+const { args } = commander.parse(process.argv);
+
+replace(args).then(
+  () => {
+    process.exit(0);
+  },
+  error => {
+    console.error(error); // eslint-disable-line no-console
+    process.exit(1);
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6041,6 +6041,15 @@ chardet@^0.7.0:
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+child-process-promise@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
+  integrity sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=
+  dependencies:
+    cross-spawn "^4.0.2"
+    node-version "^1.0.0"
+    promise-polyfill "^6.0.1"
+
 "chokidar@>=2.0.0 <4.0.0", chokidar@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
@@ -6908,6 +6917,14 @@ cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
   integrity sha1-ElYDfsufDF9549bvE14wdwGEuYI=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
@@ -13736,6 +13753,11 @@ node-sass@^4.8.3:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
+node-version@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
+  integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
+
 "nopt@2 || 3":
   version "3.0.6"
   resolved "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -15307,6 +15329,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
+  integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
 
 promise.allsettled@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Changes test scripts for build integration tests so that the whole built package contents of `carbon-custom-elements` is used for build integration tests.

Before this change, only `es` directory used fresh package contents and the rest was from NPM, which means that changes in `package.json`, etc. were not tested.

This change also fixes broken build integration test of IE example, which was caused by a missing item in `exports` field.