### PR TITLE
fix(ui-shell): default label text

### DIFF
--- a/src/components/ui-shell/header-menu-button.ts
+++ b/src/components/ui-shell/header-menu-button.ts
@@ -51,13 +51,13 @@ class BXHeaderMenuButton extends FocusMixin(LitElement) {
    * The `aria-label` attribute for the button in its active state.
    */
   @property({ attribute: 'button-label-active' })
-  buttonLabelActive!: string;
+  buttonLabelActive = 'Close navigation menu';
 
   /**
-   * The `aria-label` attribute for the button in its active state.
+   * The `aria-label` attribute for the button in its inactive state.
    */
   @property({ attribute: 'button-label-inactive' })
-  buttonLabelInactive!: string;
+  buttonLabelInactive = 'Open navigation menu';
 
   /**
    * Collapse mode of the side nav.

--- a/tests/snapshots/ui-shell.md
+++ b/tests/snapshots/ui-shell.md
@@ -7,7 +7,10 @@
 ####     `should render with minimum attributes`
 
 ```
-<button class="bx--header__action bx--header__menu-toggle bx--header__menu-trigger">
+<button
+  aria-label="Open navigation menu"
+  class="bx--header__action bx--header__menu-toggle bx--header__menu-trigger"
+>
 </button>
 
 ```


### PR DESCRIPTION
This change adds default label text for humberger menu button for side nav.

Refs carbon-design-system/ibm-dotcom-library#3161.

(Requires #446 to pass the CI)