### PR TITLE
fix(host-listener): support dash in event name

### DIFF
--- a/src/globals/mixins/host-listener.ts
+++ b/src/globals/mixins/host-listener.ts
@@ -13,7 +13,7 @@ import Handle from '../internal/handle';
 /**
  * The format for the event name used by `@HostListener` decorator.
  */
-const EVENT_NAME_FORMAT = /^((document|window|shadowRoot):)?(\w+)$/;
+const EVENT_NAME_FORMAT = /^((document|window|shadowRoot):)?([\w-]+)$/;
 
 /**
  * @param Base The base class.


### PR DESCRIPTION
This change fixes an issue in `@HostListener()` decorator handling code where it gets broken if an event name with `-` is given.