### PR TITLE
chore(package): rename package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
         peerDependencies: false,
       },
     ],
-    'import/no-unresolved': [2, { ignore: ['^carbon-custom-elements/es/icons/'] }],
+    'import/no-unresolved': [2, { ignore: ['^carbon-web-components/es/icons/'] }],
   },
   settings: {
     'import/resolver': {
@@ -62,7 +62,7 @@ module.exports = {
       rules: {
         'no-unused-vars': 0,
         '@typescript-eslint/no-unused-vars': 2,
-        'import/no-unresolved': [2, { ignore: ['^carbon-custom-elements/es/(components-react|icons)/'] }],
+        'import/no-unresolved': [2, { ignore: ['^carbon-web-components/es/(components-react|icons)/'] }],
         'react/jsx-uses-react': 2,
         'react/jsx-uses-vars': 2,
       },

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,21 +33,21 @@ If you want to help improve the docs, it's a good idea to let others know what y
 
 ### Setup
 
-1. Fork the project by navigating to the main [repository](https://github.com/carbon-design-system/carbon-custom-elements) and clicking the **Fork** button on the top-right corner.
+1. Fork the project by navigating to the main [repository](https://github.com/carbon-design-system/carbon-web-components) and clicking the **Fork** button on the top-right corner.
 
 2. Navigate to your forked repository and copy the **SSH url**. Clone your fork by running the following in your terminal:
 
    ```
-   $ git clone git@github.com:{ YOUR_USERNAME }/carbon-custom-elements.git
-   $ cd carbon-custom-elements
+   $ git clone git@github.com:{ YOUR_USERNAME }/carbon-web-components.git
+   $ cd carbon-web-components
    ```
 
    See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more details on forking a repository.
 
-3. Once cloned, you will see `origin` as your default remote, pointing to your personal forked repository. Add a remote named `upstream` pointing to the main `carbon-custom-elements`:
+3. Once cloned, you will see `origin` as your default remote, pointing to your personal forked repository. Add a remote named `upstream` pointing to the main `carbon-web-components`:
 
    ```
-   $ git remote add upstream git@github.com:carbon-design-system/carbon-custom-elements.git
+   $ git remote add upstream git@github.com:carbon-design-system/carbon-web-components.git
    $ git remote -v
    ```
 
@@ -91,7 +91,7 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue. H
    $ git push origin { YOUR_BRANCH_NAME }
    ```
 
-8. In Github, navigate to [carbon-design-system/carbon-custom-elements](https://github.com/carbon-design-system/carbon-custom-elements) and click the button that reads "Compare & pull request".
+8. In Github, navigate to [carbon-design-system/carbon-web-components](https://github.com/carbon-design-system/carbon-web-components) and click the button that reads "Compare & pull request".
 
 9. Write a title and description, the click "Create pull request".
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy carbon-custom-elements storybook to IBM Cloud
+name: Deploy carbon-web-components storybook to IBM Cloud
 
 on:
   push:
@@ -18,14 +18,14 @@ jobs:
         run: yarn install
       - name: Build project
         run: yarn build
-      - name: Building carbon-custom-elements storybook
+      - name: Building carbon-web-components storybook
         run: yarn build-storybook
-      - name: Deploying carbon-custom-elements storybook to IBM Cloud
+      - name: Deploying carbon-web-components storybook to IBM Cloud
         uses: carbon-design-system/action-ibmcloud-cf@v1.0.0
         with:
           cloud-api-key: ${{ secrets.CF_TOKEN }}
           cf-org: carbon-design-system
           cf-space: production
           cf-region: us-south
-          cf-app: carbon-custom-elements
+          cf-app: carbon-web-components
           cf-manifest: manifest.yml

--- a/.storybook/angular/manager-head.html
+++ b/.storybook/angular/manager-head.html
@@ -5,7 +5,7 @@
 <meta property="og:title" content="Carbon Custom Elements">
 <meta property="og:site_name" content="Carbon Custom Elements">
 <meta property="og:description" content="This is the Custom Elements implementation of the Carbon Design System. Carbon is a series of individual styles and components, that when combined make beautiful, intuitive designs.">
-<meta property="og:url" content="https://github.com/carbon-design-system/carbon-custom-elements">
+<meta property="og:url" content="https://github.com/carbon-design-system/carbon-web-components">
 
 <!-- Social -->
 <meta name="twitter:card" content="summary_large_image">

--- a/.storybook/angular/theme.js
+++ b/.storybook/angular/theme.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,6 +10,6 @@
 import { create } from '@storybook/theming';
 
 export default create({
-  brandTitle: 'carbon-custom-elements with Angular',
-  brandUrl: 'https://github.com/carbon-design-system/carbon-custom-elements',
+  brandTitle: 'carbon-web-components with Angular',
+  brandUrl: 'https://github.com/carbon-design-system/carbon-web-components',
 });

--- a/.storybook/basic-example-cdn.html
+++ b/.storybook/basic-example-cdn.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <script type="module">
-      import 'https://jspm.dev/carbon-custom-elements/es/components/dropdown/dropdown.js';
-      import 'https://jspm.dev/carbon-custom-elements/es/components/dropdown/dropdown-item.js';
+      import 'https://jspm.dev/carbon-web-components/es/components/dropdown/dropdown.js';
+      import 'https://jspm.dev/carbon-web-components/es/components/dropdown/dropdown-item.js';
     </script>
     <style type="text/css">
       #app {

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -5,7 +5,7 @@
 <meta property="og:title" content="Carbon Custom Elements">
 <meta property="og:site_name" content="Carbon Custom Elements">
 <meta property="og:description" content="This is the Custom Elements implementation of the Carbon Design System. Carbon is a series of individual styles and components, that when combined make beautiful, intuitive designs.">
-<meta property="og:url" content="https://github.com/carbon-design-system/carbon-custom-elements">
+<meta property="og:url" content="https://github.com/carbon-design-system/carbon-web-components">
 
 <!-- Social -->
 <meta name="twitter:card" content="summary_large_image">

--- a/.storybook/react/manager-head.html
+++ b/.storybook/react/manager-head.html
@@ -5,7 +5,7 @@
 <meta property="og:title" content="Carbon Custom Elements">
 <meta property="og:site_name" content="Carbon Custom Elements">
 <meta property="og:description" content="This is the Custom Elements implementation of the Carbon Design System. Carbon is a series of individual styles and components, that when combined make beautiful, intuitive designs.">
-<meta property="og:url" content="https://github.com/carbon-design-system/carbon-custom-elements">
+<meta property="og:url" content="https://github.com/carbon-design-system/carbon-web-components">
 
 <!-- Social -->
 <meta name="twitter:card" content="summary_large_image">

--- a/.storybook/react/theme.js
+++ b/.storybook/react/theme.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,6 +10,6 @@
 import { create } from '@storybook/theming';
 
 export default create({
-  brandTitle: 'carbon-custom-elements with React',
-  brandUrl: 'https://github.com/carbon-design-system/carbon-custom-elements',
+  brandTitle: 'carbon-web-components with React',
+  brandUrl: 'https://github.com/carbon-design-system/carbon-web-components',
 });

--- a/.storybook/react/webpack.config.js
+++ b/.storybook/react/webpack.config.js
@@ -17,7 +17,7 @@ const { transformAsync } = require('@babel/core');
 const babelPluginCreateReactCustomElementType = require('../../tools/babel-plugin-create-react-custom-element-type');
 const configure = require('../webpack.config');
 
-const regexComponentsReactPath = /carbon-custom-elements[\\/]es[\\/]components-react[\\/](.*)$/;
+const regexComponentsReactPath = /carbon-web-components[\\/]es[\\/]components-react[\\/](.*)$/;
 const readFileAsync = promisify(readFile);
 const writeFileAsync = promisify(writeFile);
 const mkdirpAsync = promisify(mkdirp);
@@ -51,7 +51,7 @@ class CreateReactCustomElementTypeProxyPlugin {
   /**
    * A WebPack resolver plugin that proxies module request for:
    *
-   * * `carbon-custom-elements/es/components-react/**` to the corresponsing local path in this project
+   * * `carbon-web-components/es/components-react/**` to the corresponsing local path in this project
    * * `es/components`/`es/globals` to the corresponding source code, given the former may not have been built yet
    */
   constructor() {

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,6 +10,6 @@
 import { create } from '@storybook/theming';
 
 export default create({
-  brandTitle: 'carbon-custom-elements',
-  brandUrl: 'https://github.com/carbon-design-system/carbon-custom-elements',
+  brandTitle: 'carbon-web-components',
+  brandUrl: 'https://github.com/carbon-design-system/carbon-web-components',
 });

--- a/.storybook/vue/manager-head.html
+++ b/.storybook/vue/manager-head.html
@@ -5,7 +5,7 @@
 <meta property="og:title" content="Carbon Custom Elements">
 <meta property="og:site_name" content="Carbon Custom Elements">
 <meta property="og:description" content="This is the Custom Elements implementation of the Carbon Design System. Carbon is a series of individual styles and components, that when combined make beautiful, intuitive designs.">
-<meta property="og:url" content="https://github.com/carbon-design-system/carbon-custom-elements">
+<meta property="og:url" content="https://github.com/carbon-design-system/carbon-web-components">
 
 <!-- Social -->
 <meta name="twitter:card" content="summary_large_image">

--- a/.storybook/vue/theme.js
+++ b/.storybook/vue/theme.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,6 +10,6 @@
 import { create } from '@storybook/theming';
 
 export default create({
-  brandTitle: 'carbon-custom-elements with Vue',
-  brandUrl: 'https://github.com/carbon-design-system/carbon-custom-elements',
+  brandTitle: 'carbon-web-components with Vue',
+  brandUrl: 'https://github.com/carbon-design-system/carbon-web-components',
 });

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = ({ config, mode }) => {
     storyDocsRule.exclude = [path.resolve(__dirname, '../docs')];
   }
 
-  // `carbon-custom-elements` does not use `polymer-webpack-loader` as it does not use full-blown Polymer
+  // `carbon-web-components` does not use `polymer-webpack-loader` as it does not use full-blown Polymer
   const htmlRuleIndex = config.module.rules.findIndex(
     item => item.use && item.use.some && item.use.some(use => /polymer-webpack-loader/i.test(use.loader))
   );
@@ -200,9 +200,9 @@ module.exports = ({ config, mode }) => {
   if (!config.resolve.alias) {
     config.resolve.alias = {};
   }
-  // In our development environment (where `carbon-custom-elements/es/icons` may not have been built yet),
+  // In our development environment (where `carbon-web-components/es/icons` may not have been built yet),
   // we load icons from `@carbon/icons` and use a WebPack loader to convert the icons to `lit-html` version
-  config.resolve.alias['carbon-custom-elements/es/icons'] = '@carbon/icons/lib';
+  config.resolve.alias['carbon-web-components/es/icons'] = '@carbon/icons/lib';
 
   return config;
 };

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Carbon Design System variant that's as easy to use as native HTML elements, wi
 > contributors.
 
 <p align="center">
-  <a href="https://github.com/carbon-design-system/carbon-custom-elements/blob/master/LICENSE">
+  <a href="https://github.com/carbon-design-system/carbon-web-components/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Carbon is released under the Apache-2.0 license" />
   </a>
 </p>
@@ -22,9 +22,9 @@ A Carbon Design System variant that's as easy to use as native HTML elements, wi
   </a>
 </p>
 
-# `carbon-custom-elements`
+# `carbon-web-components`
 
-`carbon-custom-elements` is a variant of Carbon Design System with Custom Elements v1 and Shadow DOM v1 specs.
+`carbon-web-components` is a variant of Carbon Design System with Custom Elements v1 and Shadow DOM v1 specs.
 
 Has been experimenting with enthusiasm, and now has a stable version.
 
@@ -53,33 +53,33 @@ The effort stems from https://github.com/carbon-design-system/issue-tracking/iss
 
 ## Getting started
 
-To install `carbon-custom-elements` in your project, you will need to run the
+To install `carbon-web-components` in your project, you will need to run the
 following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S carbon-custom-elements carbon-components lit-html lit-element
+npm install -S carbon-web-components carbon-components lit-html lit-element
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add carbon-custom-elements carbon-components lit-html lit-element
+yarn add carbon-web-components carbon-components lit-html lit-element
 ```
 
 ### Basic usage
 
 Our example at [CodeSandbox](https://codesandbox.io) shows the most basic usage:
 
-[![Edit carbon-custom-elements](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/basic)
+[![Edit carbon-web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/basic)
 
 The first thing you need is **setting up a module bundler** to resolve ECMAScript `import`s. Above example uses [Parcel](https://parceljs.org). You can use other bundlers like [Rollup](https://rollupjs.org/)/[Webpack](https://webpack.js.org), too.
 
 Once you set up a module bundler, you can start importing our component modules, like:
 
 ```javascript
-import 'carbon-custom-elements/es/components/dropdown/dropdown';
-import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+import 'carbon-web-components/es/components/dropdown/dropdown';
+import 'carbon-web-components/es/components/dropdown/dropdown-item';
 ```
 
 Once you do that, you can use our components in the same manner as native HTML tags, like:
@@ -101,8 +101,8 @@ If you just want to try our components for demnstrations, etc., you can use CDNs
 <html>
   <head>
     <script type="module">
-      import 'https://jspm.dev/carbon-custom-elements/es/components/dropdown/dropdown.js';
-      import 'https://jspm.dev/carbon-custom-elements/es/components/dropdown/dropdown-item.js';
+      import 'https://jspm.dev/carbon-web-components/es/components/dropdown/dropdown.js';
+      import 'https://jspm.dev/carbon-web-components/es/components/dropdown/dropdown-item.js';
     </script>
     <style type="text/css">
       #app {
@@ -133,7 +133,7 @@ If you just want to try our components for demnstrations, etc., you can use CDNs
 
 ### Angular
 
-[![Edit carbon-custom-elements with Angular](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/angular)
+[![Edit carbon-web-components with Angular](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/angular)
 
 Angular users can use our components in the same manner as native HTML tags, too, once you add [`CUSTOM_ELEMENTS_SCHEMA`](https://angular.io/api/core/CUSTOM_ELEMENTS_SCHEMA) schema to your Angular module, like:
 
@@ -152,22 +152,22 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
-The `.d.ts` files in `carbon-custom-elements` package are compiled with TypeScript 3.7. You can use TypeScript 3.7 in your Angular application with upcoming Angular `9.0` release, or with the following instructions, so your application can use those `.d.ts` files:
+The `.d.ts` files in `carbon-web-components` package are compiled with TypeScript 3.7. You can use TypeScript 3.7 in your Angular application with upcoming Angular `9.0` release, or with the following instructions, so your application can use those `.d.ts` files:
 
 - Set `true` to [`angularCompilerOptions.disableTypeScriptVersionCheck`](https://angular.io/guide/angular-compiler-options#disabletypescriptversioncheck) in `tsconfig.json`
 - In `polyfills.ts`, change [`__importDefault` TypeScript helper](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#example-8) as follows: `window.__importDefault = mod => (mod?.__esModule ? mod : { default: mod })`
 
 ### React
 
-[![Edit carbon-custom-elements with React](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/react)
+[![Edit carbon-web-components with React](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/react)
 
-You can use wrapper React components in `carbon-custom-elements/es/components-react` generated [automatically from the custom elements](./src/globals/wrappers/createReactCustomElementType.ts) which allows you to use our components seamlessly in your React code. Here's an example:
+You can use wrapper React components in `carbon-web-components/es/components-react` generated [automatically from the custom elements](./src/globals/wrappers/createReactCustomElementType.ts) which allows you to use our components seamlessly in your React code. Here's an example:
 
 ```javascript
 import React from 'react';
 import { render } from 'react-dom';
-import BXDropdown from 'carbon-custom-elements/es/components-react/dropdown/dropdown';
-import BXDropdownItem from 'carbon-custom-elements/es/components-react/dropdown/dropdown-item';
+import BXDropdown from 'carbon-web-components/es/components-react/dropdown/dropdown';
+import BXDropdownItem from 'carbon-web-components/es/components-react/dropdown/dropdown-item';
 
 const App = () => (
   <BXDropdown triggerContent="Select an item">
@@ -184,7 +184,7 @@ render(<App />, document.getElementById('root'));
 
 ### Vue
 
-[![Edit carbon-custom-elements with Vue](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/vue)
+[![Edit carbon-web-components with Vue](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/vue)
 
 Vue users can use our components in the same manner as native HTML tags, without any additional steps!
 
@@ -192,7 +192,7 @@ Vue users can use our components in the same manner as native HTML tags, without
 
 - [Having components participate in form](./docs/form.md)
 - [Using custom styles in components](./docs/styling.md)
-- [Using `carbon-custom-elements` with old build toolchain](./docs/old-build-toolchain.md)
+- [Using `carbon-web-components` with old build toolchain](./docs/old-build-toolchain.md)
 
 ## Getting started with development
 
@@ -223,11 +223,11 @@ View available web components at: https://custom-elements.carbondesignsystem.com
 To support IE, you need a couple additional setups:
 
 - Toolstack to re-transpile our code to ES5 (e.g. by specifying IE11 in [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env) configuration)
-- Polyfills, listed [here](https://github.com/carbon-design-system/carbon-custom-elements/blob/master/src/polyfills/index.ts)
+- Polyfills, listed [here](https://github.com/carbon-design-system/carbon-web-components/blob/master/src/polyfills/index.ts)
 
 Here's an example code that shows such setup:
 
-[![Edit carbon-custom-elements with IE](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/ie)
+[![Edit carbon-web-components with IE](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/ie)
 
 ## Coding conventions
 
@@ -240,7 +240,7 @@ Can be found at [here](./src/coding-conventions.md).
 > yarn build
 ```
 
-You'll see the build artifacts in `/path/to/carbon-custom-elements/es` directory.
+You'll see the build artifacts in `/path/to/carbon-web-components/es` directory.
 
 ## Running unit test
 

--- a/docs/form-story-angular.mdx
+++ b/docs/form-story-angular.mdx
@@ -10,13 +10,13 @@ Our form components can be used for Angular two-way binding syntax (`[(ngModel)]
 <bx-input [(ngModel)]="model.username" #username="ngModel" type="text" name="username"></bx-input>
 ```
 
-Such Angular directives can be used by importing `BXFormAccessorModule` from `carbon-custom-elements/es/directives-angular/esm2015` or `carbon-custom-elements/es/directives-angular/esm5` into your Angular module:
+Such Angular directives can be used by importing `BXFormAccessorModule` from `carbon-web-components/es/directives-angular/esm2015` or `carbon-web-components/es/directives-angular/esm5` into your Angular module:
 
 ```javascript
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { BXFormAccessorsModule } from 'carbon-custom-elements/es/directives-angular/esm2015';
+import { BXFormAccessorsModule } from 'carbon-web-components/es/directives-angular/esm2015';
 
 import { AppComponent } from './app.component';
 
@@ -33,6 +33,6 @@ export class AppModule {}
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/angular?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>

--- a/docs/form-story-react.mdx
+++ b/docs/form-story-react.mdx
@@ -8,12 +8,12 @@ You can use our form components with Redux Form by creating a React component th
 
 ```javascript
 import { Field } from 'redux-form';
-import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
-import BXInput from 'carbon-custom-elements/es/components-react/input/input';
+import BXFormItem from 'carbon-web-components/es/components-react/form/form-item';
+import BXInput from 'carbon-web-components/es/components-react/input/input';
 
 ...
 
-// A React component that wraps form components from `carbon-custom-elements`
+// A React component that wraps form components from `carbon-web-components`
 const FieldImpl = ({ input, label, type, meta: { touched, error } }) => {
   const validityMessage = !touched ? undefined : error;
   return (
@@ -38,6 +38,6 @@ const FieldImpl = ({ input, label, type, meta: { touched, error } }) => {
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/redux-form?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>

--- a/docs/form-story.mdx
+++ b/docs/form-story.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Having components participate in form
 
-Though form elements in `carbon-custom-elements` (e.g. `<bx-input>`) are not native form elements like `<input>`, form elements in `carbon-custom-elements` have some extra APIs that align well to web/framework standards that allow those form elements to participate in form.
+Though form elements in `carbon-web-components` (e.g. `<bx-input>`) are not native form elements like `<input>`, form elements in `carbon-web-components` have some extra APIs that align well to web/framework standards that allow those form elements to participate in form.
 
 ## `formdata` event
 
@@ -32,7 +32,7 @@ button.addEventListener('click', () => {
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/basic?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 

--- a/docs/form.md
+++ b/docs/form.md
@@ -1,6 +1,6 @@
 # Having components participate in form
 
-Though form elements in `carbon-custom-elements` (e.g. `<bx-input>`) are not native form elements like `<input>`, form elements in `carbon-custom-elements` have some extra APIs that align well to web/framework standards that allow those form elements to participate in form.
+Though form elements in `carbon-web-components` (e.g. `<bx-input>`) are not native form elements like `<input>`, form elements in `carbon-web-components` have some extra APIs that align well to web/framework standards that allow those form elements to participate in form.
 
 ## `formdata` event
 
@@ -25,7 +25,7 @@ button.addEventListener('click', () => {
 });
 ```
 
-[![Edit carbon-custom-elements with formdata event](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/basic)
+[![Edit carbon-web-components with formdata event](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/basic)
 
 ## Angular two-way binding
 
@@ -35,13 +35,13 @@ Our form components can be used for Angular two-way binding syntax (`[(ngModel)]
 <bx-input [(ngModel)]="model.username" #username="ngModel" type="text" name="username"></bx-input>
 ```
 
-Such Angular directives can be used by importing `BXFormAccessorModule` from `carbon-custom-elements/es/directives-angular/esm2015` or `carbon-custom-elements/es/directives-angular/esm5` into your Angular module:
+Such Angular directives can be used by importing `BXFormAccessorModule` from `carbon-web-components/es/directives-angular/esm2015` or `carbon-web-components/es/directives-angular/esm5` into your Angular module:
 
 ```javascript
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { BXFormAccessorsModule } from 'carbon-custom-elements/es/directives-angular/esm2015';
+import { BXFormAccessorsModule } from 'carbon-web-components/es/directives-angular/esm2015';
 
 import { AppComponent } from './app.component';
 
@@ -55,7 +55,7 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
-[![Edit carbon-custom-elements with Angular form directives](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/angular)
+[![Edit carbon-web-components with Angular form directives](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/angular)
 
 ## Redux Form
 
@@ -63,12 +63,12 @@ You can use our form components with Redux Form by creating a React component th
 
 ```javascript
 import { Field } from 'redux-form';
-import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
-import BXInput from 'carbon-custom-elements/es/components-react/input/input';
+import BXFormItem from 'carbon-web-components/es/components-react/form/form-item';
+import BXInput from 'carbon-web-components/es/components-react/input/input';
 
 ...
 
-// A React component that wraps form components from `carbon-custom-elements`
+// A React component that wraps form components from `carbon-web-components`
 const FieldImpl = ({ input, label, type, meta: { touched, error } }) => {
   const validityMessage = !touched ? undefined : error;
   return (
@@ -90,4 +90,4 @@ const FieldImpl = ({ input, label, type, meta: { touched, error } }) => {
 <Field name="username" type="text" component={FieldImpl} label="Username" />
 ```
 
-[![Edit carbon-custom-elements with Redux Form](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/redux-form)
+[![Edit carbon-web-components with Redux Form](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/form/redux-form)

--- a/docs/old-build-toolchain.md
+++ b/docs/old-build-toolchain.md
@@ -1,6 +1,6 @@
-# Using `carbon-custom-elements` with old build toolchain
+# Using `carbon-web-components` with old build toolchain
 
-`carbon-custom-elements` package ships with code that is optimized for modern browsers.
+`carbon-web-components` package ships with code that is optimized for modern browsers.
 
 We have seen that old Webpack, old Babel or UglifyJS2 cannot parse object rest operator in our code unless our code is transpiled with `transform-object-rest-spread` Babel plugin. Here are some details:
 
@@ -16,7 +16,7 @@ module: {
     {
       test: /\.js$/,
       include: [
-        path.dirname(require.resolve('carbon-custom-elements/es')),
+        path.dirname(require.resolve('carbon-web-components/es')),
       ],
       use: [
         {

--- a/docs/styling-story.mdx
+++ b/docs/styling-story.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Using custom styles in components
 
-As Shadow DOM (one of the Web Components specs that `carbon-custom-elements` uses) promises, styles that `carbon-custom-elements` defines does not affect styles in your application, or vice versa.
+As Shadow DOM (one of the Web Components specs that `carbon-web-components` uses) promises, styles that `carbon-web-components` defines does not affect styles in your application, or vice versa.
 
 However, in cases where your application or a Carbon-derived style guide wants to change the styles of our components, there are a few options.
 
@@ -20,12 +20,12 @@ However, in cases where your application or a Carbon-derived style guide wants t
 
 ## Using CSS Custom Properties
 
-Changes to CSS Custom Properties of the Carbon theme are reflected in the color scheme of `carbon-custom-elements` components:
+Changes to CSS Custom Properties of the Carbon theme are reflected in the color scheme of `carbon-web-components` components:
 
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/theme-zoning?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '700px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
@@ -82,7 +82,7 @@ module.exports = {
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/rtl?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
@@ -92,7 +92,7 @@ You can create a derived class of our component and override [static `styles` pr
 
 ```javascript
 import { css, customElement } from 'lit-element';
-import BXDropdown from 'carbon-custom-elements/es/components/dropdown/dropdown';
+import BXDropdown from 'carbon-web-components/es/components/dropdown/dropdown';
 
 @customElement('my-dropdown')
 class MyDropdown extends BXDropdown {
@@ -109,10 +109,10 @@ class MyDropdown extends BXDropdown {
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/custom-style?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
 ## CSS Shadow Parts
 
-In the future, we'd like to support [CSS Shadow Parts](https://www.w3.org/TR/css-shadow-parts-1/) too, so you can use your application's CSS to affect `carbon-custom-elements` styles in a more flexible manner.
+In the future, we'd like to support [CSS Shadow Parts](https://www.w3.org/TR/css-shadow-parts-1/) too, so you can use your application's CSS to affect `carbon-web-components` styles in a more flexible manner.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,6 +1,6 @@
 # Using custom styles in components
 
-As Shadow DOM (one of the Web Components specs that `carbon-custom-elements` uses) promises, styles that `carbon-custom-elements` defines does not affect styles in your application, or vice versa.
+As Shadow DOM (one of the Web Components specs that `carbon-web-components` uses) promises, styles that `carbon-web-components` defines does not affect styles in your application, or vice versa.
 
 However, in cases where your application or a Carbon-derived style guide wants to change the styles of our components, there are a few options.
 
@@ -16,9 +16,9 @@ However, in cases where your application or a Carbon-derived style guide wants t
 
 ## Using CSS Custom Properties
 
-Changes to CSS Custom Properties of the Carbon theme are reflected in the color scheme of `carbon-custom-elements` components:
+Changes to CSS Custom Properties of the Carbon theme are reflected in the color scheme of `carbon-web-components` components:
 
-[![Edit carbon-custom-elements with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/theme-zoning)
+[![Edit carbon-web-components with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/theme-zoning)
 
 For example, if you add CSS like below:
 
@@ -53,7 +53,7 @@ footer {
 
 You can let our custom elements modules load alternate `CSSResult` module. Below example uses [Webpack `NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to let our custom elements modules load RTL version of `CSSResult` module that is shipped alongside with default `CSSResult` modules, instead of loading the default version:
 
-[![Edit carbon-custom-elements with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/rtl)
+[![Edit carbon-web-components with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/rtl)
 
 ```javascript
 const reCssBundle = /\.css\.js$/i;
@@ -76,11 +76,11 @@ module.exports = {
 
 You can create a derived class of our component and override [static `styles` property](https://lit-element.polymer-project.org/guide/styles#static-styles), like:
 
-[![Edit carbon-custom-elements with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/custom-style)
+[![Edit carbon-web-components with custom style](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/styling/custom-style)
 
 ```javascript
 import { css, customElement } from 'lit-element';
-import BXDropdown from 'carbon-custom-elements/es/components/dropdown/dropdown';
+import BXDropdown from 'carbon-web-components/es/components/dropdown/dropdown';
 
 @customElement('my-dropdown')
 class MyDropdown extends BXDropdown {
@@ -96,4 +96,4 @@ class MyDropdown extends BXDropdown {
 
 ## CSS Shadow Parts
 
-In the future, we'd like to support [CSS Shadow Parts](https://www.w3.org/TR/css-shadow-parts-1/) too, so you can use your application's CSS to affect `carbon-custom-elements` styles in a more flexible manner.
+In the future, we'd like to support [CSS Shadow Parts](https://www.w3.org/TR/css-shadow-parts-1/) too, so you can use your application's CSS to affect `carbon-web-components` styles in a more flexible manner.

--- a/docs/welcome-story-angular.mdx
+++ b/docs/welcome-story-angular.mdx
@@ -2,12 +2,12 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Introduction/Welcome" />
 
-# `carbon-custom-elements` with Angular
+# `carbon-web-components` with Angular
 
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/angular?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
@@ -28,7 +28,7 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
-The `.d.ts` files in `carbon-custom-elements` package are compiled with TypeScript 3.7. You can use TypeScript 3.7 in your Angular application with upcoming Angular `9.0` release, or with the following instructions, so your application can use those `.d.ts` files:
+The `.d.ts` files in `carbon-web-components` package are compiled with TypeScript 3.7. You can use TypeScript 3.7 in your Angular application with upcoming Angular `9.0` release, or with the following instructions, so your application can use those `.d.ts` files:
 
 - Set `true` to [`angularCompilerOptions.disableTypeScriptVersionCheck`](https://angular.io/guide/angular-compiler-options#disabletypescriptversioncheck) in `tsconfig.json`
 - In `polyfills.ts`, change [`__importDefault` TypeScript helper](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#example-8) as follows: `window.__importDefault = mod => (mod?.__esModule ? mod : { default: mod })`

--- a/docs/welcome-story-react.mdx
+++ b/docs/welcome-story-react.mdx
@@ -2,22 +2,22 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Introduction/Welcome" />
 
-# `carbon-custom-elements` with React
+# `carbon-web-components` with React
 
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/react?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
-You can use wrapper React components in `carbon-custom-elements/es/components-react` generated [automatically from the custom elements](./src/globals/wrappers/createReactCustomElementType.ts) which allows you to use our components seamlessly in your React code. Here's an example:
+You can use wrapper React components in `carbon-web-components/es/components-react` generated [automatically from the custom elements](./src/globals/wrappers/createReactCustomElementType.ts) which allows you to use our components seamlessly in your React code. Here's an example:
 
 ```javascript
 import React from 'react';
 import { render } from 'react-dom';
-import BXDropdown from 'carbon-custom-elements/es/components-react/dropdown/dropdown';
-import BXDropdownItem from 'carbon-custom-elements/es/components-react/dropdown/dropdown-item';
+import BXDropdown from 'carbon-web-components/es/components-react/dropdown/dropdown';
+import BXDropdownItem from 'carbon-web-components/es/components-react/dropdown/dropdown-item';
 
 const App = () => (
   <BXDropdown triggerContent="Select an item">

--- a/docs/welcome-story.mdx
+++ b/docs/welcome-story.mdx
@@ -17,14 +17,14 @@ A Carbon Design System variant that's as easy to use as native HTML elements, wi
 > contributors.
 
 <p align="center">
-  <a href="https://github.com/carbon-design-system/carbon-custom-elements/blob/master/LICENSE">
+  <a href="https://github.com/carbon-design-system/carbon-web-components/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Carbon is released under the Apache-2.0 license" />
   </a>
 </p>
 
-# `carbon-custom-elements`
+# `carbon-web-components`
 
-`carbon-custom-elements` is a variant of Carbon Design System with Custom Elements v1 and Shadow DOM v1 specs.
+`carbon-web-components` is a variant of Carbon Design System with Custom Elements v1 and Shadow DOM v1 specs.
 
 Experimental at this moment, with enthusiasm.
 
@@ -32,18 +32,18 @@ The effort stems from https://github.com/carbon-design-system/issue-tracking/iss
 
 ## Getting started
 
-To install `carbon-custom-elements` in your project, you will need to run the
+To install `carbon-web-components` in your project, you will need to run the
 following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S carbon-custom-elements carbon-components lit-html lit-element
+npm install -S carbon-web-components carbon-components lit-html lit-element
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
 instead:
 
 ```bash
-yarn add carbon-custom-elements carbon-components lit-html lit-element
+yarn add carbon-web-components carbon-components lit-html lit-element
 ```
 
 ### Basic usage
@@ -53,7 +53,7 @@ Our example at [CodeSandbox](https://codesandbox.io) shows the most basic usage:
 <iframe
   src="https://codesandbox.io/embed/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/basic?fontsize=14&hidenavigation=1&theme=light"
   style={{ width: '100%', height: '500px', border: 'solid rgba(0,0,0,0.1) 1px', boxShadow: 'rgba(0,0,0,0.1) 0 1px 3px 0' }}
-  title="carbon-custom-elements-getting-started"
+  title="carbon-web-components-getting-started"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
@@ -62,8 +62,8 @@ The first thing you need is **setting up a module bundler** to resolve ECMAScrip
 Once you set up a module bundler, you can start importing our component modules, like:
 
 ```javascript
-import 'carbon-custom-elements/es/components/dropdown/dropdown';
-import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+import 'carbon-web-components/es/components/dropdown/dropdown';
+import 'carbon-web-components/es/components/dropdown/dropdown-item';
 ```
 
 Once you do that, you can use our components in the same manner as native HTML tags, like:
@@ -85,8 +85,8 @@ If you just want to try our components for demnstrations, etc., you can use CDNs
 <html>
   <head>
     <script type="module">
-      import 'https://jspm.dev/carbon-custom-elements/es/components/dropdown/dropdown.js';
-      import 'https://jspm.dev/carbon-custom-elements/es/components/dropdown/dropdown-item.js';
+      import 'https://jspm.dev/carbon-web-components/es/components/dropdown/dropdown.js';
+      import 'https://jspm.dev/carbon-web-components/es/components/dropdown/dropdown-item.js';
     </script>
     <style type="text/css">
       #app {
@@ -118,14 +118,14 @@ If you just want to try our components for demnstrations, etc., you can use CDNs
 <iframe
   className="bx-ce-doc--demo-iframe"
   src={console.log('basicExampleCDN:', basicExampleCDN), basicExampleCDN}
-  title="carbon-custom-elements-basic-example-cdn"
+  title="carbon-web-components-basic-example-cdn"
   sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 >
 </iframe>
 
 ### JavaScript framework integration
 
-Given the nature of `carbon-custom-elements` built on top of web standard, `carbon-custom-elements` works well with JavaScript framework of your choice.
+Given the nature of `carbon-web-components` built on top of web standard, `carbon-web-components` works well with JavaScript framework of your choice.
 Please follow below links:
 
 - [Angular](https://carbon-custom-elements-angular.netlify.com)

--- a/examples/codesandbox/angular/package.json
+++ b/examples/codesandbox/angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-getting-started-angular",
+  "name": "carbon-web-components-getting-started-angular",
   "version": "0.1.0",
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with Angular.",
   "scripts": {
@@ -19,8 +19,8 @@
     "@angular/router": "^8.0.0",
     "@babel/runtime": "^7.8.0",
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "rxjs": "^6.0.0",

--- a/examples/codesandbox/angular/src/app/app.component.ts
+++ b/examples/codesandbox/angular/src/app/app.component.ts
@@ -1,15 +1,15 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import { Component } from '@angular/core';
-import 'carbon-custom-elements/es/components/dropdown/dropdown';
-import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+import 'carbon-web-components/es/components/dropdown/dropdown';
+import 'carbon-web-components/es/components/dropdown/dropdown-item';
 
 @Component({
   selector: 'app-root',

--- a/examples/codesandbox/angular/src/index.html
+++ b/examples/codesandbox/angular/src/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>carbon-custom-elements example with Angular</title>
+    <title>carbon-web-components example with Angular</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/examples/codesandbox/basic/index.html
+++ b/examples/codesandbox/basic/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>carbon-custom-elements example</title>
+    <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
     <style type="text/css">
       body {

--- a/examples/codesandbox/basic/package.json
+++ b/examples/codesandbox/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-getting-started",
+  "name": "carbon-web-components-getting-started",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System.",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0"
   },

--- a/examples/codesandbox/basic/src/index.js
+++ b/examples/codesandbox/basic/src/index.js
@@ -1,11 +1,11 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'carbon-custom-elements/es/components/dropdown/dropdown';
-import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+import 'carbon-web-components/es/components/dropdown/dropdown';
+import 'carbon-web-components/es/components/dropdown/dropdown-item';

--- a/examples/codesandbox/form/angular/package.json
+++ b/examples/codesandbox/form/angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-getting-started-angular-forms",
+  "name": "carbon-web-components-getting-started-angular-forms",
   "version": "0.1.0",
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with Angular forms.",
   "scripts": {
@@ -19,8 +19,8 @@
     "@angular/router": "~8.1.0",
     "@babel/runtime": "^7.8.0",
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "rxjs": "^6.0.0",

--- a/examples/codesandbox/form/angular/src/app/app.component.ts
+++ b/examples/codesandbox/form/angular/src/app/app.component.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,10 +9,10 @@
 
 import { Component, ViewChild } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import 'carbon-custom-elements/es/components/button/button';
-import 'carbon-custom-elements/es/components/form/form-item';
-import 'carbon-custom-elements/es/components/input/input';
-import 'carbon-custom-elements/es/components/notification/inline-notification';
+import 'carbon-web-components/es/components/button/button';
+import 'carbon-web-components/es/components/form/form-item';
+import 'carbon-web-components/es/components/input/input';
+import 'carbon-web-components/es/components/notification/inline-notification';
 
 /**
  * The data model.

--- a/examples/codesandbox/form/angular/src/app/app.module.ts
+++ b/examples/codesandbox/form/angular/src/app/app.module.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { BXFormAccessorsModule } from 'carbon-custom-elements/es/directives-angular/esm2015';
+import { BXFormAccessorsModule } from 'carbon-web-components/es/directives-angular/esm2015';
 
 import { AppComponent } from './app.component';
 

--- a/examples/codesandbox/form/angular/src/index.html
+++ b/examples/codesandbox/form/angular/src/index.html
@@ -11,7 +11,7 @@ LICENSE file in the root directory of this source tree.
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>carbon-custom-elements example with Angular</title>
+    <title>carbon-web-components example with Angular</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>

--- a/examples/codesandbox/form/basic/index.html
+++ b/examples/codesandbox/form/basic/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>carbon-custom-elements form example</title>
+    <title>carbon-web-components form example</title>
     <meta charset="UTF-8" />
     <style type="text/css">
       body {

--- a/examples/codesandbox/form/basic/package.json
+++ b/examples/codesandbox/form/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-form-getting-started",
+  "name": "carbon-web-components-form-getting-started",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System.",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0"
   },

--- a/examples/codesandbox/form/basic/src/index.js
+++ b/examples/codesandbox/form/basic/src/index.js
@@ -1,16 +1,16 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'carbon-custom-elements/es/components/button/button';
-import 'carbon-custom-elements/es/components/form/form-item';
-import 'carbon-custom-elements/es/components/input/input';
-import 'carbon-custom-elements/es/components/notification/inline-notification';
+import 'carbon-web-components/es/components/button/button';
+import 'carbon-web-components/es/components/form/form-item';
+import 'carbon-web-components/es/components/input/input';
+import 'carbon-web-components/es/components/notification/inline-notification';
 
 const submit = async formData => {
   // Simulates server latency

--- a/examples/codesandbox/form/redux-form/index.html
+++ b/examples/codesandbox/form/redux-form/index.html
@@ -32,7 +32,7 @@ LICENSE file in the root directory of this source tree.
         align-items: center;
       }
     </style>
-    <title>carbon-custom-elements example with redux-form</title>
+    <title>carbon-web-components example with redux-form</title>
   </head>
   <body>
     <noscript>

--- a/examples/codesandbox/form/redux-form/package.json
+++ b/examples/codesandbox/form/redux-form/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-redux-form-getting-started",
+  "name": "carbon-web-components-redux-form-getting-started",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with redux-form.",
@@ -7,8 +7,8 @@
   "main": "index.html",
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "react": "^16.8.0",

--- a/examples/codesandbox/form/redux-form/src/index.js
+++ b/examples/codesandbox/form/redux-form/src/index.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,10 +12,10 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 import { Field, SubmissionError, reduxForm, reducer as reduxFormReducer } from 'redux-form';
-import BXBtn from 'carbon-custom-elements/es/components-react/button/button';
-import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
-import BXInput from 'carbon-custom-elements/es/components-react/input/input';
-import BXInlineNotification from 'carbon-custom-elements/es/components-react/notification/inline-notification';
+import BXBtn from 'carbon-web-components/es/components-react/button/button';
+import BXFormItem from 'carbon-web-components/es/components-react/form/form-item';
+import BXInput from 'carbon-web-components/es/components-react/input/input';
+import BXInlineNotification from 'carbon-web-components/es/components-react/notification/inline-notification';
 
 const reducer = combineReducers({
   form: reduxFormReducer,

--- a/examples/codesandbox/ie/package.json
+++ b/examples/codesandbox/ie/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-ie-getting-started",
+  "name": "carbon-web-components-ie-getting-started",
   "version": "0.1.0",
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with IE.",
   "scripts": {
@@ -22,11 +22,11 @@
     "@webcomponents/webcomponents-platform": "^1.0.0",
     "babel-loader": "^8.0.0",
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
+    "carbon-web-components": "^1.0.0",
     "core-js": "^3.0.0",
     "es6-promise": "^4.1.0",
     "html-webpack-plugin": "^3.2.0",
-    "lit-element": "^2.3.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "resize-observer-polyfill": "^1.5.0",

--- a/examples/codesandbox/ie/src/index.html
+++ b/examples/codesandbox/ie/src/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>carbon-custom-elements example with IE</title>
+    <title>carbon-web-components example with IE</title>
     <meta charset="UTF-8" />
     <style type="text/css">
       body {

--- a/examples/codesandbox/ie/src/index.js
+++ b/examples/codesandbox/ie/src/index.js
@@ -1,12 +1,12 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'carbon-custom-elements/es/polyfills';
-import 'carbon-custom-elements/es/components/dropdown/dropdown';
-import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+import 'carbon-web-components/es/polyfills';
+import 'carbon-web-components/es/components/dropdown/dropdown';
+import 'carbon-web-components/es/components/dropdown/dropdown-item';

--- a/examples/codesandbox/ie/webpack.config.js
+++ b/examples/codesandbox/ie/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: [
-          path.dirname(require.resolve('carbon-custom-elements/es')),
+          path.dirname(require.resolve('carbon-web-components/es')),
           path.dirname(require.resolve('lit-html')),
           path.dirname(require.resolve('lit-element')),
           path.dirname(require.resolve('@webcomponents/custom-elements')),

--- a/examples/codesandbox/react/index.html
+++ b/examples/codesandbox/react/index.html
@@ -32,7 +32,7 @@ LICENSE file in the root directory of this source tree.
         visibility: inherit;
       }
     </style>
-    <title>carbon-custom-elements example with React</title>
+    <title>carbon-web-components example with React</title>
   </head>
   <body>
     <noscript>

--- a/examples/codesandbox/react/package.json
+++ b/examples/codesandbox/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-react-getting-started",
+  "name": "carbon-web-components-react-getting-started",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with React.",
@@ -7,8 +7,8 @@
   "main": "index.html",
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "react": "^16.0.0",

--- a/examples/codesandbox/react/src/index.js
+++ b/examples/codesandbox/react/src/index.js
@@ -9,8 +9,8 @@
 
 import React from 'react';
 import { render } from 'react-dom';
-import BXDropdown from 'carbon-custom-elements/es/components-react/dropdown/dropdown';
-import BXDropdownItem from 'carbon-custom-elements/es/components-react/dropdown/dropdown-item';
+import BXDropdown from 'carbon-web-components/es/components-react/dropdown/dropdown';
+import BXDropdownItem from 'carbon-web-components/es/components-react/dropdown/dropdown-item';
 
 const App = () => (
   <>

--- a/examples/codesandbox/rtl/package.json
+++ b/examples/codesandbox/rtl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-rtl-getting-started",
+  "name": "carbon-web-components-rtl-getting-started",
   "version": "0.1.0",
   "description": "Sample project for getting started with the Web Components from the Carbon Design System with IE.",
   "scripts": {
@@ -15,11 +15,11 @@
     "@babel/runtime": "^7.8.0",
     "accept-language-parser": "^1.5.0",
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
+    "carbon-web-components": "^1.0.0",
     "classnames": "^2.2.0",
     "es6-promise": "^4.1.0",
     "html-webpack-plugin": "^3.2.0",
-    "lit-element": "^2.3.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "rtl-detect": "^1.0.0",

--- a/examples/codesandbox/rtl/src/index.ejs
+++ b/examples/codesandbox/rtl/src/index.ejs
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html dir="<%= dir %>">
   <head>
-    <title>carbon-custom-elements example</title>
+    <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
     <style type="text/css">
       body {

--- a/examples/codesandbox/rtl/src/index.js
+++ b/examples/codesandbox/rtl/src/index.js
@@ -1,11 +1,11 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'carbon-custom-elements/es/components/slider/slider';
-import 'carbon-custom-elements/es/components/slider/slider-input';
+import 'carbon-web-components/es/components/slider/slider';
+import 'carbon-web-components/es/components/slider/slider-input';

--- a/examples/codesandbox/styling/custom-style/index.html
+++ b/examples/codesandbox/styling/custom-style/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>carbon-custom-elements example</title>
+    <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
     <style type="text/css">
       body {

--- a/examples/codesandbox/styling/custom-style/package.json
+++ b/examples/codesandbox/styling/custom-style/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-getting-started-with-custom-styles",
+  "name": "carbon-web-components-getting-started-with-custom-styles",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System, with custom styles.",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0"
   },

--- a/examples/codesandbox/styling/custom-style/src/index.js
+++ b/examples/codesandbox/styling/custom-style/src/index.js
@@ -8,7 +8,7 @@
  */
 
 import { css } from 'lit-element';
-import BXDropdown from 'carbon-custom-elements/es/components/dropdown/dropdown';
+import BXDropdown from 'carbon-web-components/es/components/dropdown/dropdown';
 
 class MyDropdown extends BXDropdown {}
 

--- a/examples/codesandbox/styling/theme-zoning/index.html
+++ b/examples/codesandbox/styling/theme-zoning/index.html
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 <html>
   <head>
-    <title>carbon-custom-elements example</title>
+    <title>carbon-web-components example</title>
     <meta charset="UTF-8" />
     <!-- Production application should limit the CSS import here to @carbon/grid CSS and `carbon-components/scss/components/ui-shell/_content.scss` -->
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/carbon-components@10.7.0/css/carbon-components.min.css">
@@ -37,9 +37,9 @@ LICENSE file in the root directory of this source tree.
               Theming and CSS scoping
             </h2>
             <p>
-              The color scheme of <code>carbon-custom-elements</code> components can be changed either by CSS custom properties (this
+              The color scheme of <code>carbon-web-components</code> components can be changed either by CSS custom properties (this
               example) or by
-              <a target="_blank" href="https://codesandbox.io/s/github/carbon-design-system/carbon-custom-elements/tree/master/examples/codesandbox/custom-style">
+              <a target="_blank" href="https://codesandbox.io/s/github/carbon-design-system/carbon-web-components/tree/master/examples/codesandbox/custom-style">
               creating inherited components with the static <code>styles</code> property changed</a>.
               <br />
               <br />
@@ -48,8 +48,8 @@ LICENSE file in the root directory of this source tree.
               of <code>&lt;bx-btn&gt;</code> reflect such change.
               <br />
               <br />
-              As Shadow DOM (one of the Web Components specs that <code>carbon-custom-elements</code> uses) promises, styles that
-              <code>carbon-custom-elements</code> defines do not affect styles in your application.
+              As Shadow DOM (one of the Web Components specs that <code>carbon-web-components</code> uses) promises, styles that
+              <code>carbon-web-components</code> defines do not affect styles in your application.
             </p>
           </div>
         </div>
@@ -59,7 +59,7 @@ LICENSE file in the root directory of this source tree.
       <p>
         <span>Have questions?</span>
         <bx-btn kind="secondary">Nope!</bx-btn>
-        <bx-btn href="https://github.com/carbon-design-system/carbon-custom-elements/issues/new" target="_blank">Enter an issue</bx-btn>
+        <bx-btn href="https://github.com/carbon-design-system/carbon-web-components/issues/new" target="_blank">Enter an issue</bx-btn>
       </p>
     </footer>
   </body>

--- a/examples/codesandbox/styling/theme-zoning/package.json
+++ b/examples/codesandbox/styling/theme-zoning/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-theme-zoning-getting-started",
+  "name": "carbon-web-components-theme-zoning-getting-started",
   "version": "0.1.0",
   "private": true,
   "description": "Sample project for getting started with the Web Components from the Carbon Design System.",
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0"
   },

--- a/examples/codesandbox/styling/theme-zoning/src/index.js
+++ b/examples/codesandbox/styling/theme-zoning/src/index.js
@@ -7,12 +7,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import 'carbon-custom-elements/es/components/button/button';
-import 'carbon-custom-elements/es/components/ui-shell/header';
-import 'carbon-custom-elements/es/components/ui-shell/header-nav';
-import 'carbon-custom-elements/es/components/ui-shell/header-nav-item';
-import 'carbon-custom-elements/es/components/ui-shell/header-menu';
-import 'carbon-custom-elements/es/components/ui-shell/header-menu-item';
-import 'carbon-custom-elements/es/components/ui-shell/header-menu-button';
-import 'carbon-custom-elements/es/components/ui-shell/header-name';
+import 'carbon-web-components/es/components/button/button';
+import 'carbon-web-components/es/components/ui-shell/header';
+import 'carbon-web-components/es/components/ui-shell/header-nav';
+import 'carbon-web-components/es/components/ui-shell/header-nav-item';
+import 'carbon-web-components/es/components/ui-shell/header-menu';
+import 'carbon-web-components/es/components/ui-shell/header-menu-item';
+import 'carbon-web-components/es/components/ui-shell/header-menu-button';
+import 'carbon-web-components/es/components/ui-shell/header-name';
 import './index.scss';

--- a/examples/codesandbox/vue/package.json
+++ b/examples/codesandbox/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements-vue-getting-started",
+  "name": "carbon-web-components-vue-getting-started",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "carbon-components": "~10.16.0",
-    "carbon-custom-elements": "^1.0.0",
-    "lit-element": "^2.3.0",
+    "carbon-web-components": "^1.0.0",
+    "lit-element": "~2.2.0",
     "lit-html": "^1.2.0",
     "lodash-es": "^4.17.0",
     "vue": "^2.5.0"

--- a/examples/codesandbox/vue/public/index.html
+++ b/examples/codesandbox/vue/public/index.html
@@ -13,7 +13,7 @@ LICENSE file in the root directory of this source tree.
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>carbon-custom-elements example with Vue</title>
+    <title>carbon-web-components example with Vue</title>
   </head>
   <body>
     <noscript>

--- a/examples/codesandbox/vue/src/components/HelloWorld.vue
+++ b/examples/codesandbox/vue/src/components/HelloWorld.vue
@@ -18,8 +18,8 @@ LICENSE file in the root directory of this source tree.
 </template>
 
 <script>
-import 'carbon-custom-elements/es/components/dropdown/dropdown';
-import 'carbon-custom-elements/es/components/dropdown/dropdown-item';
+import 'carbon-web-components/es/components/dropdown/dropdown';
+import 'carbon-web-components/es/components/dropdown/dropdown-item';
 
 export default {
   name: 'HelloWorld',

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
-- name: carbon-custom-elements
+- name: carbon-web-components
   memory: 64M
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
 routes:
-  - route: custom-elements.carbondesignsystem.com
+  - route: web-components.carbondesignsystem.com

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carbon-custom-elements",
+  "name": "carbon-web-components",
   "version": "1.2.1",
   "license": "Apache-2.0",
   "main": "es/index.js",
@@ -11,8 +11,8 @@
     "./package.json": "./package.json"
   },
   "typings": "es/index.d.ts",
-  "repository": "https://github.com/carbon-design-system/carbon-custom-elements",
-  "bugs": "https://github.com/carbon-design-system/carbon-custom-elements/issues",
+  "repository": "https://github.com/carbon-design-system/carbon-web-components",
+  "bugs": "https://github.com/carbon-design-system/carbon-web-components/issues",
   "files": [
     "es/**/*",
     "scss/**/*",

--- a/src/coding-conventions.md
+++ b/src/coding-conventions.md
@@ -32,7 +32,7 @@
 
 ## Linters/formatters
 
-`carbon-custom-elements` uses ESLint with `typescript-eslint` for linting, and Prettier for code formatting.
+`carbon-web-components` uses ESLint with `typescript-eslint` for linting, and Prettier for code formatting.
 Most of ESLint configurations are same as ones in `carbon-components`.
 
 ## TSDoc comments
@@ -65,7 +65,7 @@ const Mixin = <T extends Constructor<SomeClass>>(Base: T) => class extends Base 
 
 To avoid memory leaks and zombie event listeners, we ensure the event listeners on custom elements themselves (hosts) and ones on `document`, etc. are released when they get out of render tree.
 
-For that purpose, `carbon-custom-elements` uses `@HostListener(type, options)` decorator. `@HostListener(type, options)` decorator works with a custom element class inheriting `HostListenerMixin()` and attaches an event listener using the target method as the listener. The `type` argument can be something like `document:click` so the `click` event listener is attached to `document`.
+For that purpose, `carbon-web-components` uses `@HostListener(type, options)` decorator. `@HostListener(type, options)` decorator works with a custom element class inheriting `HostListenerMixin()` and attaches an event listener using the target method as the listener. The `type` argument can be something like `document:click` so the `click` event listener is attached to `document`.
 
 Here's an example seen in `<bx-modal>` code:
 
@@ -93,7 +93,7 @@ class BXModal extends HostListenerMixin(LitElement) {
 
 Carbon core CSS uses BEM modifier like `bx--btn--danger` to style different states/variants of a component.
 
-OTOH `carbon-custom-elements` uses attributes to represent different states/variants (e.g. `<bx-btn type="danger">`), in a similar manner as how attributes influence states/variants of native elements (e.g. `<input type="hidden">`).
+OTOH `carbon-web-components` uses attributes to represent different states/variants (e.g. `<bx-btn type="danger">`), in a similar manner as how attributes influence states/variants of native elements (e.g. `<input type="hidden">`).
 
 If such states/variants should affect the style of custom element (shadow host), we define attribute styles from the following reasons:
 
@@ -102,7 +102,7 @@ If such states/variants should affect the style of custom element (shadow host),
 
 ## Customizing components
 
-Like `carbon-components` library does, `carbon-custom-elements` ensures components are written in a flexible manner enough to support use cases different applications have.
+Like `carbon-components` library does, `carbon-web-components` ensures components are written in a flexible manner enough to support use cases different applications have.
 
 ### Defining (default) component options
 
@@ -155,7 +155,7 @@ CustomElementClass.staticPropName;
 
 ## Custom events
 
-Wherever it makes sense, `carbon-custom-elements` translates user-initiated events to something that gives event listeners more context of what they mean. For example, `<bx-modal>` translates `click` event on `<bx-modal-close-button>` to `bx-modal-beingclosed` and `bx-modal-closed` custom events.
+Wherever it makes sense, `carbon-web-components` translates user-initiated events to something that gives event listeners more context of what they mean. For example, `<bx-modal>` translates `click` event on `<bx-modal-close-button>` to `bx-modal-beingclosed` and `bx-modal-closed` custom events.
 
 `bx-modal-beingclosed` is cancelable in a similar manner as how `click` event on `<a href="...">` is cancelable; If `bx-modal-beingclosed` is canceled, `<bx-modal>` stops closing itself.
 
@@ -195,7 +195,7 @@ If you get TypeScript "may be null" errors, think twice to see if there is such 
 
 ## Updating view upon change in `private`/`protected` properties
 
-`lit-element` observes for changes in declared properties for updating the view. `carbon-custom-elements` codebase doesn't use this feature simply to get properties observed. Specifically, `carbon-custom-elements` doesn't set `private`/`protected` properties as declared. Whenever change in `private`/`protected` should cause update in the view, we take manual approach (`.requestUpdate()`).
+`lit-element` observes for changes in declared properties for updating the view. `carbon-web-components` codebase doesn't use this feature simply to get properties observed. Specifically, `carbon-web-components` doesn't set `private`/`protected` properties as declared. Whenever change in `private`/`protected` should cause update in the view, we take manual approach (`.requestUpdate()`).
 
 ## CSS considerations with IE11
 

--- a/src/components/accordion/accordion-story-react.tsx
+++ b/src/components/accordion/accordion-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXAccordion from 'carbon-custom-elements/es/components-react/accordion/accordion';
+import BXAccordion from 'carbon-web-components/es/components-react/accordion/accordion';
 // @ts-ignore
-import BXAccordionItem from 'carbon-custom-elements/es/components-react/accordion/accordion-item';
+import BXAccordionItem from 'carbon-web-components/es/components-react/accordion/accordion-item';
 import { defaultStory as baseDefaultStory } from './accordion-story';
 
 export { default } from './accordion-story';

--- a/src/components/breadcrumb/breadcrumb-story-react.tsx
+++ b/src/components/breadcrumb/breadcrumb-story-react.tsx
@@ -1,21 +1,21 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXBreadcrumb from 'carbon-custom-elements/es/components-react/breadcrumb/breadcrumb';
+import BXBreadcrumb from 'carbon-web-components/es/components-react/breadcrumb/breadcrumb';
 // @ts-ignore
-import BXBreadcrumbItem from 'carbon-custom-elements/es/components-react/breadcrumb/breadcrumb-item';
+import BXBreadcrumbItem from 'carbon-web-components/es/components-react/breadcrumb/breadcrumb-item';
 // @ts-ignore
-import BXBreadcrumbLink from 'carbon-custom-elements/es/components-react/breadcrumb/breadcrumb-link';
+import BXBreadcrumbLink from 'carbon-web-components/es/components-react/breadcrumb/breadcrumb-link';
 import { defaultStory as baseDefaultStory } from './breadcrumb-story';
 
 export { default } from './breadcrumb-story';

--- a/src/components/button/button-story-react.tsx
+++ b/src/components/button/button-story-react.tsx
@@ -9,12 +9,12 @@
 
 import React from 'react';
 import Add16 from '@carbon/icons-react/es/add/16';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXBtn from 'carbon-custom-elements/es/components-react/button/button';
+import BXBtn from 'carbon-web-components/es/components-react/button/button';
 // @ts-ignore
-import BXBtnSkeleton from 'carbon-custom-elements/es/components-react/button/button-skeleton';
+import BXBtnSkeleton from 'carbon-web-components/es/components-react/button/button-skeleton';
 import { defaultStory as baseDefaultStory, textAndIcon as baseTextAndIcon, skeleton as baseSkeleton } from './button-story';
 
 export { default } from './button-story';

--- a/src/components/button/button-story.ts
+++ b/src/components/button/button-story.ts
@@ -10,10 +10,10 @@
 import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import Add16 from 'carbon-custom-elements/es/icons/add/16';
+import Add16 from 'carbon-web-components/es/icons/add/16';
 import ifNonNull from '../../globals/directives/if-non-null';
 import { BUTTON_KIND, BUTTON_SIZE } from './button';
 import './button-skeleton';

--- a/src/components/checkbox/checkbox-story-react.tsx
+++ b/src/components/checkbox/checkbox-story-react.tsx
@@ -8,10 +8,10 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXCheckbox from 'carbon-custom-elements/es/components-react/checkbox/checkbox';
+import BXCheckbox from 'carbon-web-components/es/components-react/checkbox/checkbox';
 import { defaultStory as baseDefaultStory } from './checkbox-story';
 
 export { default } from './checkbox-story';

--- a/src/components/checkbox/checkbox-story.mdx
+++ b/src/components/checkbox/checkbox-story.mdx
@@ -2,7 +2,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Check box
 
-Check box in `carbon-custom-elements` represents a combination of a check box and its label.
+Check box in `carbon-web-components` represents a combination of a check box and its label.
 
 <Preview withToolbar>
   <Story id="components-checkbox--default-story" height="160px" />

--- a/src/components/code-snippet/code-snippet-story-react.tsx
+++ b/src/components/code-snippet/code-snippet-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXCodeSnippet from 'carbon-custom-elements/es/components-react/code-snippet/code-snippet';
+import BXCodeSnippet from 'carbon-web-components/es/components-react/code-snippet/code-snippet';
 // @ts-ignore
-import BXCodeSnippetSkeleton from 'carbon-custom-elements/es/components-react/code-snippet/code-snippet-skeleton';
+import BXCodeSnippetSkeleton from 'carbon-web-components/es/components-react/code-snippet/code-snippet-skeleton';
 import {
   singleLine as baseSingleLine,
   multiLine as baseMultiLine,

--- a/src/components/combo-box/combo-box-story-react.tsx
+++ b/src/components/combo-box/combo-box-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXComboBox from 'carbon-custom-elements/es/components-react/combo-box/combo-box';
+import BXComboBox from 'carbon-web-components/es/components-react/combo-box/combo-box';
 // @ts-ignore
-import BXComboBoxItem from 'carbon-custom-elements/es/components-react/combo-box/combo-box-item';
+import BXComboBoxItem from 'carbon-web-components/es/components-react/combo-box/combo-box-item';
 import { defaultStory as baseDefaultStory } from './combo-box-story';
 
 export { default } from './combo-box-story';

--- a/src/components/content-switcher/content-switcher-story-react.tsx
+++ b/src/components/content-switcher/content-switcher-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXContentSwitcher from 'carbon-custom-elements/es/components-react/content-switcher/content-switcher';
+import BXContentSwitcher from 'carbon-web-components/es/components-react/content-switcher/content-switcher';
 // @ts-ignore
-import BXContentSwitcherItem from 'carbon-custom-elements/es/components-react/content-switcher/content-switcher-item';
+import BXContentSwitcherItem from 'carbon-web-components/es/components-react/content-switcher/content-switcher-item';
 import { defaultStory as baseDefaultStory } from './content-switcher-story';
 
 export { default } from './content-switcher-story';

--- a/src/components/copy-button/copy-button-story-react.tsx
+++ b/src/components/copy-button/copy-button-story-react.tsx
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXCopyButton from 'carbon-custom-elements/es/components-react/copy-button/copy-button';
+import BXCopyButton from 'carbon-web-components/es/components-react/copy-button/copy-button';
 import { defaultStory as baseDefaultStory } from './copy-button-story';
 
 export { default } from './copy-button-story';

--- a/src/components/data-table/_table-sort.scss
+++ b/src/components/data-table/_table-sort.scss
@@ -59,7 +59,7 @@
   opacity: 1;
 }
 
-// `carbon-custom-elements` uses conditional rendering for choosing Arrows16 vs. ArrowDown16,
+// `carbon-web-components` uses conditional rendering for choosing Arrows16 vs. ArrowDown16,
 // and thus `display:none` here is not needed
 :host(#{$prefix}-table-header-cell[sort-direction]) .bx--table-sort .bx--table-sort__icon {
   display: block;

--- a/src/components/data-table/data-table-story-react.tsx
+++ b/src/components/data-table/data-table-story-react.tsx
@@ -13,52 +13,52 @@ import { useDebounce } from 'use-debounce';
 import Delete16 from '@carbon/icons-react/es/delete/16';
 import Download16 from '@carbon/icons-react/es/download/16';
 import Settings16 from '@carbon/icons-react/es/settings/16';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXBtn from 'carbon-custom-elements/es/components-react/button/button';
+import BXBtn from 'carbon-web-components/es/components-react/button/button';
 // @ts-ignore
-import BXOverflowMenu from 'carbon-custom-elements/es/components-react/overflow-menu/overflow-menu';
+import BXOverflowMenu from 'carbon-web-components/es/components-react/overflow-menu/overflow-menu';
 // @ts-ignore
-import BXOverflowMenuBody from 'carbon-custom-elements/es/components-react/overflow-menu/overflow-menu-body';
+import BXOverflowMenuBody from 'carbon-web-components/es/components-react/overflow-menu/overflow-menu-body';
 // @ts-ignore
-import BXOverflowMenuItem from 'carbon-custom-elements/es/components-react/overflow-menu/overflow-menu-item';
+import BXOverflowMenuItem from 'carbon-web-components/es/components-react/overflow-menu/overflow-menu-item';
 // @ts-ignore
-import BXPagination from 'carbon-custom-elements/es/components-react/pagination/pagination';
+import BXPagination from 'carbon-web-components/es/components-react/pagination/pagination';
 // @ts-ignore
-import BXPageSizesSelect from 'carbon-custom-elements/es/components-react/pagination/page-sizes-select';
+import BXPageSizesSelect from 'carbon-web-components/es/components-react/pagination/page-sizes-select';
 // @ts-ignore
-import BXPagesSelect from 'carbon-custom-elements/es/components-react/pagination/pages-select';
+import BXPagesSelect from 'carbon-web-components/es/components-react/pagination/pages-select';
 // @ts-ignore
-import BXTable, { TABLE_COLOR_SCHEME, TABLE_SIZE } from 'carbon-custom-elements/es/components-react/data-table/table';
+import BXTable, { TABLE_COLOR_SCHEME, TABLE_SIZE } from 'carbon-web-components/es/components-react/data-table/table';
 // @ts-ignore
-import BXTableHead from 'carbon-custom-elements/es/components-react/data-table/table-head';
+import BXTableHead from 'carbon-web-components/es/components-react/data-table/table-head';
 // @ts-ignore
-import BXTableHeaderRow from 'carbon-custom-elements/es/components-react/data-table/table-header-row';
+import BXTableHeaderRow from 'carbon-web-components/es/components-react/data-table/table-header-row';
 import BXTableHeaderCell, {
   TABLE_SORT_DIRECTION,
   // @ts-ignore
-} from 'carbon-custom-elements/es/components-react/data-table/table-header-cell';
+} from 'carbon-web-components/es/components-react/data-table/table-header-cell';
 // @ts-ignore
-import BXTableBody from 'carbon-custom-elements/es/components-react/data-table/table-body';
+import BXTableBody from 'carbon-web-components/es/components-react/data-table/table-body';
 // @ts-ignore
-import BXTableRow from 'carbon-custom-elements/es/components-react/data-table/table-row';
+import BXTableRow from 'carbon-web-components/es/components-react/data-table/table-row';
 // @ts-ignore
-import BXTableCell from 'carbon-custom-elements/es/components-react/data-table/table-cell';
+import BXTableCell from 'carbon-web-components/es/components-react/data-table/table-cell';
 // @ts-ignore
-import BXTableHeaderExpandRow from 'carbon-custom-elements/es/components-react/data-table/table-header-expand-row';
+import BXTableHeaderExpandRow from 'carbon-web-components/es/components-react/data-table/table-header-expand-row';
 // @ts-ignore
-import BXTableExpandRow from 'carbon-custom-elements/es/components-react/data-table/table-expand-row';
+import BXTableExpandRow from 'carbon-web-components/es/components-react/data-table/table-expand-row';
 // @ts-ignore
-import BXTableExpandedRow from 'carbon-custom-elements/es/components-react/data-table/table-expanded-row';
+import BXTableExpandedRow from 'carbon-web-components/es/components-react/data-table/table-expanded-row';
 // @ts-ignore
-import BXTableToolbar from 'carbon-custom-elements/es/components-react/data-table/table-toolbar';
+import BXTableToolbar from 'carbon-web-components/es/components-react/data-table/table-toolbar';
 // @ts-ignore
-import BXTableToolbarContent from 'carbon-custom-elements/es/components-react/data-table/table-toolbar-content';
+import BXTableToolbarContent from 'carbon-web-components/es/components-react/data-table/table-toolbar-content';
 // @ts-ignore
-import BXTableToolbarSearch from 'carbon-custom-elements/es/components-react/data-table/table-toolbar-search';
+import BXTableToolbarSearch from 'carbon-web-components/es/components-react/data-table/table-toolbar-search';
 // @ts-ignore
-import BXTableBatchActions from 'carbon-custom-elements/es/components-react/data-table/table-batch-actions';
+import BXTableBatchActions from 'carbon-web-components/es/components-react/data-table/table-batch-actions';
 import BXBtnElement from '../button/button';
 import { rows as demoRows, rowsMany as demoRowsMany, columns as demoColumns, sortInfo as demoSortInfo } from './stories/data';
 import { TDemoTableColumn, TDemoTableRow, TDemoSortInfo } from './stories/types';

--- a/src/components/data-table/data-table-story.mdx
+++ b/src/components/data-table/data-table-story.mdx
@@ -2,7 +2,7 @@ import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
 
 # Data table
 
-Data table in `carbon-custom-elements` focuses on primitives that constructs table UI, consisting of the following:
+Data table in `carbon-web-components` focuses on primitives that constructs table UI, consisting of the following:
 
 | Tag                      | Description     | HTML tag counterpart |
 | ------------------------ | --------------- | -------------------- |

--- a/src/components/data-table/data-table-story.ts
+++ b/src/components/data-table/data-table-story.ts
@@ -12,14 +12,14 @@ import { html, property, LitElement } from 'lit-element';
 import { repeat } from 'lit-html/directives/repeat';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import Delete16 from 'carbon-custom-elements/es/icons/delete/16';
+import Delete16 from 'carbon-web-components/es/icons/delete/16';
 // @ts-ignore
-import Download16 from 'carbon-custom-elements/es/icons/download/16';
+import Download16 from 'carbon-web-components/es/icons/download/16';
 // @ts-ignore
-import Settings16 from 'carbon-custom-elements/es/icons/settings/16';
+import Settings16 from 'carbon-web-components/es/icons/settings/16';
 import BXBtn from '../button/button';
 import ifNonNull from '../../globals/directives/if-non-null';
 import '../overflow-menu/overflow-menu';

--- a/src/components/date-picker/date-picker-story-react.tsx
+++ b/src/components/date-picker/date-picker-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXDatePicker from 'carbon-custom-elements/es/components-react/date-picker/date-picker';
+import BXDatePicker from 'carbon-web-components/es/components-react/date-picker/date-picker';
 // @ts-ignore
-import BXDatePickerInput from 'carbon-custom-elements/es/components-react/date-picker/date-picker-input';
+import BXDatePickerInput from 'carbon-web-components/es/components-react/date-picker/date-picker-input';
 // @ts-ignore
-import BXDatePickerInputSkeleton from 'carbon-custom-elements/es/components-react/date-picker/date-picker-input-skeleton';
+import BXDatePickerInputSkeleton from 'carbon-web-components/es/components-react/date-picker/date-picker-input-skeleton';
 import {
   defaultStory as baseDefaultStory,
   singleWithCalendar as baseSingleWithCalendar,

--- a/src/components/dropdown/dropdown-story-react.tsx
+++ b/src/components/dropdown/dropdown-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXDropdown from 'carbon-custom-elements/es/components-react/dropdown/dropdown';
+import BXDropdown from 'carbon-web-components/es/components-react/dropdown/dropdown';
 // @ts-ignore
-import BXDropdownItem from 'carbon-custom-elements/es/components-react/dropdown/dropdown-item';
+import BXDropdownItem from 'carbon-web-components/es/components-react/dropdown/dropdown-item';
 // @ts-ignore
-import BXDropdownSkeleton from 'carbon-custom-elements/es/components-react/dropdown/dropdown-skeleton';
+import BXDropdownSkeleton from 'carbon-web-components/es/components-react/dropdown/dropdown-skeleton';
 import { defaultStory as baseDefaultStory } from './dropdown-story';
 
 export { default } from './dropdown-story';

--- a/src/components/form/form-data.md
+++ b/src/components/form/form-data.md
@@ -1,6 +1,6 @@
 # Event-based form participation
 
-This document is for assessing if `carbon-custom-elements` library can support event-based form participation spec, as a stop-gap solution until full-blown [form-associated custom element API](https://github.com/whatwg/html/pull/4383) in order for our components to support use cases seen e.g. with `<input>` in `<form>`.
+This document is for assessing if `carbon-web-components` library can support event-based form participation spec, as a stop-gap solution until full-blown [form-associated custom element API](https://github.com/whatwg/html/pull/4383) in order for our components to support use cases seen e.g. with `<input>` in `<form>`.
 
 ## Specifications and tests
 

--- a/src/components/icon/icon-story.ts
+++ b/src/components/icon/icon-story.ts
@@ -9,16 +9,16 @@
 
 import { html, svg } from 'lit-html';
 
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import Add16 from 'carbon-custom-elements/es/icons/add/16';
+import Add16 from 'carbon-web-components/es/icons/add/16';
 // @ts-ignore
-import Add20 from 'carbon-custom-elements/es/icons/add/20';
+import Add20 from 'carbon-web-components/es/icons/add/20';
 // @ts-ignore
-import Add24 from 'carbon-custom-elements/es/icons/add/24';
+import Add24 from 'carbon-web-components/es/icons/add/24';
 // @ts-ignore
-import Add32 from 'carbon-custom-elements/es/icons/add/32';
+import Add32 from 'carbon-web-components/es/icons/add/32';
 
 export const defaultStory = () => html`
   ${Add16()} ${Add20()} ${Add24()} ${Add32()}

--- a/src/components/input/input-story-react.tsx
+++ b/src/components/input/input-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXInput from 'carbon-custom-elements/es/components-react/input/input';
+import BXInput from 'carbon-web-components/es/components-react/input/input';
 // @ts-ignore
-import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
+import BXFormItem from 'carbon-web-components/es/components-react/form/form-item';
 import {
   defaultStory as baseDefaultStory,
   formItem as baseFormItem,

--- a/src/components/link/link-story-react.tsx
+++ b/src/components/link/link-story-react.tsx
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXLink from 'carbon-custom-elements/es/components-react/link/link';
+import BXLink from 'carbon-web-components/es/components-react/link/link';
 import { defaultStory as baseDefaultStory } from './link-story';
 
 export { default } from './link-story';

--- a/src/components/link/link-story.ts
+++ b/src/components/link/link-story.ts
@@ -37,7 +37,7 @@ export default {
     knobs: {
       'bx-link': () => ({
         disabled: boolean('Disabled (disabled)', false),
-        href: textNullable('Link href (href)', 'https://github.com/carbon-design-system/carbon-custom-elements'),
+        href: textNullable('Link href (href)', 'https://github.com/carbon-design-system/carbon-web-components'),
         onClick: action('click'),
       }),
     },

--- a/src/components/list/list-story-react.tsx
+++ b/src/components/list/list-story-react.tsx
@@ -1,21 +1,21 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXOrderedList from 'carbon-custom-elements/es/components-react/list/ordered-list';
+import BXOrderedList from 'carbon-web-components/es/components-react/list/ordered-list';
 // @ts-ignore
-import BXUnorderedList from 'carbon-custom-elements/es/components-react/list/unordered-list';
+import BXUnorderedList from 'carbon-web-components/es/components-react/list/unordered-list';
 // @ts-ignore
-import BXListItem from 'carbon-custom-elements/es/components-react/list/list-item';
+import BXListItem from 'carbon-web-components/es/components-react/list/list-item';
 
 export { default } from './list-story';
 

--- a/src/components/loading/loading-story-react.tsx
+++ b/src/components/loading/loading-story-react.tsx
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXLoading from 'carbon-custom-elements/es/components-react/loading/loading';
+import BXLoading from 'carbon-web-components/es/components-react/loading/loading';
 import { defaultStory as baseDefaultStory } from './loading-story';
 
 export { default } from './loading-story';

--- a/src/components/modal/modal-story-react.tsx
+++ b/src/components/modal/modal-story-react.tsx
@@ -9,24 +9,24 @@
 
 import React from 'react';
 import '../button/button';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXBtn from 'carbon-custom-elements/es/components-react/button/button';
+import BXBtn from 'carbon-web-components/es/components-react/button/button';
 // @ts-ignore
-import BXModal from 'carbon-custom-elements/es/components-react/modal/modal';
+import BXModal from 'carbon-web-components/es/components-react/modal/modal';
 // @ts-ignore
-import BXModalHeader from 'carbon-custom-elements/es/components-react/modal/modal-header';
+import BXModalHeader from 'carbon-web-components/es/components-react/modal/modal-header';
 // @ts-ignore
-import BXModalCloseButton from 'carbon-custom-elements/es/components-react/modal/modal-close-button';
+import BXModalCloseButton from 'carbon-web-components/es/components-react/modal/modal-close-button';
 // @ts-ignore
-import BXModalHeading from 'carbon-custom-elements/es/components-react/modal/modal-heading';
+import BXModalHeading from 'carbon-web-components/es/components-react/modal/modal-heading';
 // @ts-ignore
-import BXModalLabel from 'carbon-custom-elements/es/components-react/modal/modal-label';
+import BXModalLabel from 'carbon-web-components/es/components-react/modal/modal-label';
 // @ts-ignore
-import BXModalBody from 'carbon-custom-elements/es/components-react/modal/modal-body';
+import BXModalBody from 'carbon-web-components/es/components-react/modal/modal-body';
 // @ts-ignore
-import BXModalFooter from 'carbon-custom-elements/es/components-react/modal/modal-footer';
+import BXModalFooter from 'carbon-web-components/es/components-react/modal/modal-footer';
 import { defaultStory as baseDefaultStory } from './modal-story';
 
 export { default } from './modal-story';

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -221,7 +221,7 @@ class BXModal extends HostListenerMixin(LitElement) {
         this._launcher = this.ownerDocument!.activeElement;
         const primaryFocusNode = this.querySelector((this.constructor as typeof BXModal).selectorPrimaryFocus);
         if (primaryFocusNode) {
-          // For cases where a `carbon-custom-elements` component (e.g. `<bx-btn>`) being `primaryFocusNode`,
+          // For cases where a `carbon-web-components` component (e.g. `<bx-btn>`) being `primaryFocusNode`,
           // where its first update/render cycle that makes it focusable happens after `<bx-modal>`'s first update/render cycle
           await 0;
           (primaryFocusNode as HTMLElement).focus();
@@ -230,7 +230,7 @@ class BXModal extends HostListenerMixin(LitElement) {
             Boolean((elem as HTMLElement).offsetParent)
           );
           if (tabbable) {
-            // For cases where a `carbon-custom-elements` component (e.g. `<bx-btn>`) being `tabbable`,
+            // For cases where a `carbon-web-components` component (e.g. `<bx-btn>`) being `tabbable`,
             // where its first update/render cycle that makes it focusable happens after `<bx-modal>`'s first update/render cycle
             await 0;
             (tabbable as HTMLElement).focus();

--- a/src/components/multi-select/multi-select-story-react.tsx
+++ b/src/components/multi-select/multi-select-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXMultiSelect from 'carbon-custom-elements/es/components-react/multi-select/multi-select';
+import BXMultiSelect from 'carbon-web-components/es/components-react/multi-select/multi-select';
 // @ts-ignore
-import BXMultiSelectItem from 'carbon-custom-elements/es/components-react/multi-select/multi-select-item';
+import BXMultiSelectItem from 'carbon-web-components/es/components-react/multi-select/multi-select-item';
 import { defaultStory as baseDefaultStory } from './multi-select-story';
 
 export { default } from './multi-select-story';

--- a/src/components/notification/notification-story-react.tsx
+++ b/src/components/notification/notification-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
 // prettier-ignore
 // eslint-disable-next-line max-len
-import BXInlineNotification from 'carbon-custom-elements/es/components-react/notification/inline-notification';
+import BXInlineNotification from 'carbon-web-components/es/components-react/notification/inline-notification';
 // @ts-ignore
-import BXToastNotification from 'carbon-custom-elements/es/components-react/notification/toast-notification';
+import BXToastNotification from 'carbon-web-components/es/components-react/notification/toast-notification';
 import { inline as baseInline, toast as baseToast } from './notification-story';
 
 export { default } from './notification-story';

--- a/src/components/number-input/number-input-story-react.tsx
+++ b/src/components/number-input/number-input-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXNumberInput from 'carbon-custom-elements/es/components-react/number-input/number-input';
+import BXNumberInput from 'carbon-web-components/es/components-react/number-input/number-input';
 // @ts-ignore
-import BXNumberInputSkeleton from 'carbon-custom-elements/es/components-react/number-input/number-input-skeleton';
+import BXNumberInputSkeleton from 'carbon-web-components/es/components-react/number-input/number-input-skeleton';
 // @ts-ignore
-import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
+import BXFormItem from 'carbon-web-components/es/components-react/form/form-item';
 import {
   defaultStory as baseDefaultStory,
   formItem as baseFormItem,

--- a/src/components/overflow-menu/overflow-menu-story-react.tsx
+++ b/src/components/overflow-menu/overflow-menu-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXOverflowMenu from 'carbon-custom-elements/es/components-react/overflow-menu/overflow-menu';
+import BXOverflowMenu from 'carbon-web-components/es/components-react/overflow-menu/overflow-menu';
 // @ts-ignore
-import BXOverflowMenuBody from 'carbon-custom-elements/es/components-react/overflow-menu/overflow-menu-body';
+import BXOverflowMenuBody from 'carbon-web-components/es/components-react/overflow-menu/overflow-menu-body';
 // @ts-ignore
-import BXOverflowMenuItem from 'carbon-custom-elements/es/components-react/overflow-menu/overflow-menu-item';
+import BXOverflowMenuItem from 'carbon-web-components/es/components-react/overflow-menu/overflow-menu-item';
 import { defaultStory as baseDefaultStory } from './overflow-menu-story';
 
 export { default } from './overflow-menu-story';

--- a/src/components/progress-indicator/progress-indicator-story-react.tsx
+++ b/src/components/progress-indicator/progress-indicator-story-react.tsx
@@ -1,24 +1,24 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXProgressIndicator from 'carbon-custom-elements/es/components-react/progress-indicator/progress-indicator';
+import BXProgressIndicator from 'carbon-web-components/es/components-react/progress-indicator/progress-indicator';
 // @ts-ignore
-import BXProgressStep from 'carbon-custom-elements/es/components-react/progress-indicator/progress-step';
+import BXProgressStep from 'carbon-web-components/es/components-react/progress-indicator/progress-step';
 // @ts-ignore
 // eslint-disable-next-line max-len
-import BXProgressIndicatorSkeleton from 'carbon-custom-elements/es/components-react/progress-indicator/progress-indicator-skeleton';
+import BXProgressIndicatorSkeleton from 'carbon-web-components/es/components-react/progress-indicator/progress-indicator-skeleton';
 // @ts-ignore
-import BXProgressStepSkeleton from 'carbon-custom-elements/es/components-react/progress-indicator/progress-step-skeleton';
+import BXProgressStepSkeleton from 'carbon-web-components/es/components-react/progress-indicator/progress-step-skeleton';
 import { defaultStory as baseDefaultStory } from './progress-indicator-story';
 
 export { default } from './progress-indicator-story';

--- a/src/components/progress-indicator/progress-indicator.scss
+++ b/src/components/progress-indicator/progress-indicator.scss
@@ -28,7 +28,7 @@ $css--plex: true !default;
 
   // Carbon core style has hard-coded width whose value is the same as `.bx--progress-step`.
   // We override it so changing width of `<bx-progress-step>` automatically changes the width here.
-  // https://github.com/carbon-design-system/carbon-custom-elements/issues/325
+  // https://github.com/carbon-design-system/carbon-web-components/issues/325
   .#{$prefix}--progress-line {
     width: 100%;
   }

--- a/src/components/radio-button/radio-button-story-react.tsx
+++ b/src/components/radio-button/radio-button-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXRadioButtonGroup from 'carbon-custom-elements/es/components-react/radio-button/radio-button-group';
+import BXRadioButtonGroup from 'carbon-web-components/es/components-react/radio-button/radio-button-group';
 // @ts-ignore
-import BXRadioButton from 'carbon-custom-elements/es/components-react/radio-button/radio-button';
+import BXRadioButton from 'carbon-web-components/es/components-react/radio-button/radio-button';
 // @ts-ignore
-import BXRadioButtonSkeleton from 'carbon-custom-elements/es/components-react/radio-button/radio-button-skeleton';
+import BXRadioButtonSkeleton from 'carbon-web-components/es/components-react/radio-button/radio-button-skeleton';
 import { defaultStory as baseDefaultStory } from './radio-button-story';
 
 export { default } from './radio-button-story';

--- a/src/components/search/search-story-react.tsx
+++ b/src/components/search/search-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXSearch from 'carbon-custom-elements/es/components-react/search/search';
+import BXSearch from 'carbon-web-components/es/components-react/search/search';
 // @ts-ignore
-import BXSearchSkeleton from 'carbon-custom-elements/es/components-react/search/search-skeleton';
+import BXSearchSkeleton from 'carbon-web-components/es/components-react/search/search-skeleton';
 import { defaultStory as baseDefaultStory } from './search-story';
 
 export { default } from './search-story';

--- a/src/components/skeleton-placeholder/skeleton-placeholder-story-react.tsx
+++ b/src/components/skeleton-placeholder/skeleton-placeholder-story-react.tsx
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXSkeletonPlaceholder from 'carbon-custom-elements/es/components-react/skeleton-placeholder/skeleton-placeholder';
+import BXSkeletonPlaceholder from 'carbon-web-components/es/components-react/skeleton-placeholder/skeleton-placeholder';
 import { defaultStory as baseDefaultStory } from './skeleton-placeholder-story';
 
 export { default } from './skeleton-placeholder-story';

--- a/src/components/skeleton-text/skeleton-text-story-react.tsx
+++ b/src/components/skeleton-text/skeleton-text-story-react.tsx
@@ -1,17 +1,17 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXSkeletonText from 'carbon-custom-elements/es/components-react/skeleton-text/skeleton-text';
+import BXSkeletonText from 'carbon-web-components/es/components-react/skeleton-text/skeleton-text';
 import { defaultStory as baseDefaultStory } from './skeleton-text-story';
 
 export { default } from './skeleton-text-story';

--- a/src/components/slider/slider-story-react.tsx
+++ b/src/components/slider/slider-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXSlider from 'carbon-custom-elements/es/components-react/slider/slider';
+import BXSlider from 'carbon-web-components/es/components-react/slider/slider';
 // @ts-ignore
-import BXSliderInput from 'carbon-custom-elements/es/components-react/slider/slider-input';
+import BXSliderInput from 'carbon-web-components/es/components-react/slider/slider-input';
 // @ts-ignore
-import BXSliderSkeleton from 'carbon-custom-elements/es/components-react/slider/slider-skeleton';
+import BXSliderSkeleton from 'carbon-web-components/es/components-react/slider/slider-skeleton';
 import { defaultStory as baseDefaultStory, withInputBox as baseWithInputBox } from './slider-story';
 
 export { default } from './slider-story';

--- a/src/components/structured-list/structured-list-story-react.tsx
+++ b/src/components/structured-list/structured-list-story-react.tsx
@@ -8,21 +8,21 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXStructuredList from 'carbon-custom-elements/es/components-react/structured-list/structured-list';
+import BXStructuredList from 'carbon-web-components/es/components-react/structured-list/structured-list';
 // @ts-ignore
-import BXStructuredListHead from 'carbon-custom-elements/es/components-react/structured-list/structured-list-head';
+import BXStructuredListHead from 'carbon-web-components/es/components-react/structured-list/structured-list-head';
 // @ts-ignore
-import BXStructuredListHeaderRow from 'carbon-custom-elements/es/components-react/structured-list/structured-list-header-row';
+import BXStructuredListHeaderRow from 'carbon-web-components/es/components-react/structured-list/structured-list-header-row';
 // @ts-ignore
-import BXStructuredListBody from 'carbon-custom-elements/es/components-react/structured-list/structured-list-body';
+import BXStructuredListBody from 'carbon-web-components/es/components-react/structured-list/structured-list-body';
 // @ts-ignore
-import BXStructuredListRow from 'carbon-custom-elements/es/components-react/structured-list/structured-list-row';
+import BXStructuredListRow from 'carbon-web-components/es/components-react/structured-list/structured-list-row';
 // @ts-ignore
 // eslint-disable-next-line max-len
-import BXStructuredListHeaderCellSkeleton from 'carbon-custom-elements/es/components-react/structured-list/structured-list-header-cell-skeleton';
+import BXStructuredListHeaderCellSkeleton from 'carbon-web-components/es/components-react/structured-list/structured-list-header-cell-skeleton';
 import { defaultStory as baseDefaultStory } from './structured-list-story';
 import styles from './structured-list-story.scss';
 

--- a/src/components/tabs/tabs-story-react.tsx
+++ b/src/components/tabs/tabs-story-react.tsx
@@ -8,16 +8,16 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXTabs from 'carbon-custom-elements/es/components-react/tabs/tabs';
+import BXTabs from 'carbon-web-components/es/components-react/tabs/tabs';
 // @ts-ignore
-import BXTab from 'carbon-custom-elements/es/components-react/tabs/tab';
+import BXTab from 'carbon-web-components/es/components-react/tabs/tab';
 // @ts-ignore
-import BXTabsSkeleton from 'carbon-custom-elements/es/components-react/tabs/tabs-skeleton';
+import BXTabsSkeleton from 'carbon-web-components/es/components-react/tabs/tabs-skeleton';
 // @ts-ignore
-import BXTabSkeleton from 'carbon-custom-elements/es/components-react/tabs/tab-skeleton';
+import BXTabSkeleton from 'carbon-web-components/es/components-react/tabs/tab-skeleton';
 import { defaultStory as baseDefaultStory } from './tabs-story';
 import styles from './tabs-story.scss';
 

--- a/src/components/tag/tag-story-react.tsx
+++ b/src/components/tag/tag-story-react.tsx
@@ -8,12 +8,12 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXTag from 'carbon-custom-elements/es/components-react/tag/tag';
+import BXTag from 'carbon-web-components/es/components-react/tag/tag';
 // @ts-ignore
-import BXFilterTag from 'carbon-custom-elements/es/components-react/tag/filter-tag';
+import BXFilterTag from 'carbon-web-components/es/components-react/tag/filter-tag';
 import { defaultStory as baseDefaultStory, filter as baseFilter } from './tag-story';
 
 export { default } from './tag-story';

--- a/src/components/textarea/textarea-story-react.tsx
+++ b/src/components/textarea/textarea-story-react.tsx
@@ -8,14 +8,14 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXTextarea from 'carbon-custom-elements/es/components-react/textarea/textarea';
+import BXTextarea from 'carbon-web-components/es/components-react/textarea/textarea';
 // @ts-ignore
-import BXTextareaSkeleton from 'carbon-custom-elements/es/components-react/textarea/textarea-skeleton';
+import BXTextareaSkeleton from 'carbon-web-components/es/components-react/textarea/textarea-skeleton';
 // @ts-ignore
-import BXFormItem from 'carbon-custom-elements/es/components-react/form/form-item';
+import BXFormItem from 'carbon-web-components/es/components-react/form/form-item';
 import {
   defaultStory as baseDefaultStory,
   formItem as baseFormItem,

--- a/src/components/tile/tile-story-react.tsx
+++ b/src/components/tile/tile-story-react.tsx
@@ -8,18 +8,18 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXTile from 'carbon-custom-elements/es/components-react/tile/tile';
+import BXTile from 'carbon-web-components/es/components-react/tile/tile';
 // @ts-ignore
-import BXClickableTile from 'carbon-custom-elements/es/components-react/tile/clickable-tile';
+import BXClickableTile from 'carbon-web-components/es/components-react/tile/clickable-tile';
 // @ts-ignore
-import BXRadioTile from 'carbon-custom-elements/es/components-react/tile/radio-tile';
+import BXRadioTile from 'carbon-web-components/es/components-react/tile/radio-tile';
 // @ts-ignore
-import BXSelectableTile from 'carbon-custom-elements/es/components-react/tile/selectable-tile';
+import BXSelectableTile from 'carbon-web-components/es/components-react/tile/selectable-tile';
 // @ts-ignore
-import BXExpandableTile from 'carbon-custom-elements/es/components-react/tile/expandable-tile';
+import BXExpandableTile from 'carbon-web-components/es/components-react/tile/expandable-tile';
 import createReactCustomElementType from '../../globals/wrappers/createReactCustomElementType';
 import baseStory, {
   defaultStory as baseDefaultStory,

--- a/src/components/toggle/toggle-story-react.tsx
+++ b/src/components/toggle/toggle-story-react.tsx
@@ -8,10 +8,10 @@
  */
 
 import React from 'react';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXToggle from 'carbon-custom-elements/es/components-react/toggle/toggle';
+import BXToggle from 'carbon-web-components/es/components-react/toggle/toggle';
 import { defaultStory as baseDefaultStory } from './toggle-story';
 
 export { default } from './toggle-story';

--- a/src/components/tooltip/tooltip-story-react.tsx
+++ b/src/components/tooltip/tooltip-story-react.tsx
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2019
+ * Copyright IBM Corp. 2019, 2020
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,20 +9,20 @@
 
 import React from 'react';
 import Filter16 from '@carbon/icons-react/es/filter/16';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import BXBtn from 'carbon-custom-elements/es/components-react/button/button';
+import BXBtn from 'carbon-web-components/es/components-react/button/button';
 // @ts-ignore
-import BXTooltip from 'carbon-custom-elements/es/components-react/tooltip/tooltip';
+import BXTooltip from 'carbon-web-components/es/components-react/tooltip/tooltip';
 // @ts-ignore
-import BXTooltipBody from 'carbon-custom-elements/es/components-react/tooltip/tooltip-body';
+import BXTooltipBody from 'carbon-web-components/es/components-react/tooltip/tooltip-body';
 // @ts-ignore
-import BXTooltipFooter from 'carbon-custom-elements/es/components-react/tooltip/tooltip-footer';
+import BXTooltipFooter from 'carbon-web-components/es/components-react/tooltip/tooltip-footer';
 // @ts-ignore
-import BXTooltipDefinition from 'carbon-custom-elements/es/components-react/tooltip/tooltip-definition';
+import BXTooltipDefinition from 'carbon-web-components/es/components-react/tooltip/tooltip-definition';
 // @ts-ignore
-import BXTooltipIcon from 'carbon-custom-elements/es/components-react/tooltip/tooltip-icon';
+import BXTooltipIcon from 'carbon-web-components/es/components-react/tooltip/tooltip-icon';
 import { defaultStory as baseDefaultStory, definition as baseDefinition, icon as baseIcon } from './tooltip-story';
 import styles from './tooltip-story.scss';
 

--- a/src/components/tooltip/tooltip-story.ts
+++ b/src/components/tooltip/tooltip-story.ts
@@ -9,10 +9,10 @@
 
 import { html } from 'lit-element';
 import { boolean, select } from '@storybook/addon-knobs';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import Filter16 from 'carbon-custom-elements/es/icons/filter/16';
+import Filter16 from 'carbon-web-components/es/icons/filter/16';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
 import '../button/button';

--- a/src/components/ui-shell/ui-shell-story-react.tsx
+++ b/src/components/ui-shell/ui-shell-story-react.tsx
@@ -10,35 +10,35 @@
 import React from 'react';
 import Fade16 from '@carbon/icons-react/es/fade/16';
 import contentStyles from 'carbon-components/scss/components/ui-shell/_content.scss';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 import BXSideNav, {
   SIDE_NAV_COLLAPSE_MODE,
   SIDE_NAV_USAGE_MODE,
   // @ts-ignore
-} from 'carbon-custom-elements/es/components-react/ui-shell/side-nav';
+} from 'carbon-web-components/es/components-react/ui-shell/side-nav';
 // @ts-ignore
-import BXSideNavItems from 'carbon-custom-elements/es/components-react/ui-shell/side-nav-items';
+import BXSideNavItems from 'carbon-web-components/es/components-react/ui-shell/side-nav-items';
 // @ts-ignore
-import BXSideNavLink from 'carbon-custom-elements/es/components-react/ui-shell/side-nav-link';
+import BXSideNavLink from 'carbon-web-components/es/components-react/ui-shell/side-nav-link';
 // @ts-ignore
-import BXSideNavMenu from 'carbon-custom-elements/es/components-react/ui-shell/side-nav-menu';
+import BXSideNavMenu from 'carbon-web-components/es/components-react/ui-shell/side-nav-menu';
 // @ts-ignore
-import BXSideNavMenuItem from 'carbon-custom-elements/es/components-react/ui-shell/side-nav-menu-item';
+import BXSideNavMenuItem from 'carbon-web-components/es/components-react/ui-shell/side-nav-menu-item';
 // @ts-ignore
-import BXHeader from 'carbon-custom-elements/es/components-react/ui-shell/header';
+import BXHeader from 'carbon-web-components/es/components-react/ui-shell/header';
 // @ts-ignore
-import BXHeaderNav from 'carbon-custom-elements/es/components-react/ui-shell/header-nav';
+import BXHeaderNav from 'carbon-web-components/es/components-react/ui-shell/header-nav';
 // @ts-ignore
-import BXHeaderNavItem from 'carbon-custom-elements/es/components-react/ui-shell/header-nav-item';
+import BXHeaderNavItem from 'carbon-web-components/es/components-react/ui-shell/header-nav-item';
 // @ts-ignore
-import BXHeaderMenu from 'carbon-custom-elements/es/components-react/ui-shell/header-menu';
+import BXHeaderMenu from 'carbon-web-components/es/components-react/ui-shell/header-menu';
 // @ts-ignore
-import BXHeaderMenuItem from 'carbon-custom-elements/es/components-react/ui-shell/header-menu-item';
+import BXHeaderMenuItem from 'carbon-web-components/es/components-react/ui-shell/header-menu-item';
 // @ts-ignore
-import BXHeaderMenuButton from 'carbon-custom-elements/es/components-react/ui-shell/header-menu-button';
+import BXHeaderMenuButton from 'carbon-web-components/es/components-react/ui-shell/header-menu-button';
 // @ts-ignore
-import BXHeaderName from 'carbon-custom-elements/es/components-react/ui-shell/header-name';
+import BXHeaderName from 'carbon-web-components/es/components-react/ui-shell/header-name';
 import { sideNav as baseSideNav, sideNavWithIcons as baseSideNavWithIcons, header as baseHeader } from './ui-shell-story';
 import styles from './ui-shell-story.scss';
 

--- a/src/components/ui-shell/ui-shell-story.ts
+++ b/src/components/ui-shell/ui-shell-story.ts
@@ -9,10 +9,10 @@
 
 import { html } from 'lit-element';
 import { boolean, select } from '@storybook/addon-knobs';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import Fade16 from 'carbon-custom-elements/es/icons/fade/16';
+import Fade16 from 'carbon-web-components/es/icons/fade/16';
 import contentStyles from 'carbon-components/scss/components/ui-shell/_content.scss';
 import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';

--- a/src/polyfills/index.ts
+++ b/src/polyfills/index.ts
@@ -9,7 +9,7 @@
 
 // NOTE: `Array.from()` and `Object.assign()` and event constructor are covered by `@webcomponents/webcomponents-platform`
 // NOTE: The need of iterator (`for` ... `of` loop) support is not revealed by Storybook,
-// but by testing `carbon-custom-elements-with-polyfills.js` stand-alone
+// but by testing `carbon-web-components-with-polyfills.js` stand-alone
 import 'core-js/modules/es.array.find.js';
 import 'core-js/modules/es.math.sign.js';
 import 'core-js/modules/es.symbol.js';

--- a/tests/integration/build/setup.js
+++ b/tests/integration/build/setup.js
@@ -16,7 +16,7 @@ const { setup } = require('jest-environment-puppeteer');
 const { mkdir, track } = require('temp');
 
 const packs = {
-  'carbon-custom-elements': path.resolve(__dirname, '../../..'),
+  'carbon-web-components': path.resolve(__dirname, '../../..'),
 };
 
 /**
@@ -27,11 +27,7 @@ const packs = {
  */
 async function setupPackages(tmpDir) {
   const commands = Object.keys(packs).reduce((acc, pack) => {
-    acc.push(
-      `cd ${packs[pack]} && yarn pack --filename ${tmpDir}/${pack}.tar.gz`,
-      `tar xzf ${tmpDir}/${pack}.tar.gz --directory ${tmpDir}`,
-      `mv ${tmpDir}/package ${tmpDir}/${pack}`
-    );
+    acc.push(`cd ${packs[pack]} && yarn pack --filename ${tmpDir}/${pack}.tar.gz`);
     return acc;
   }, []);
   // eslint-disable-next-line no-restricted-syntax

--- a/tests/integration/replace-dependencies.js
+++ b/tests/integration/replace-dependencies.js
@@ -17,7 +17,7 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
 const deps = ['dependencies', 'peerDependencies', 'devDependencies'];
-const packs = ['carbon-custom-elements'];
+const packs = ['carbon-web-components'];
 
 /**
  * Replaces `@carbon/ibmdotcom-*` dependencies in the given `package.json` files with the local directory references.
@@ -35,7 +35,7 @@ const replace = async files => {
           // eslint-disable-next-line no-restricted-syntax
           for (const pack of packs) {
             if (item[pack]) {
-              item[pack] = `file:../${pack}`;
+              item[pack] = `file:../${pack}.tar.gz`;
             }
           }
         }

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -66,9 +66,9 @@ module.exports = function setupKarma(config) {
       devtool: 'inline-source-maps',
       resolve: {
         alias: {
-          // In our development environment (where `carbon-custom-elements/es/icons` may not have been built yet),
+          // In our development environment (where `carbon-web-components/es/icons` may not have been built yet),
           // we load icons from `@carbon/icons` and use a WebPack loader to convert the icons to `lit-html` version
-          'carbon-custom-elements/es/icons': '@carbon/icons/lib',
+          'carbon-web-components/es/icons': '@carbon/icons/lib',
         },
         extensions: ['.js', '.ts'],
       },

--- a/tests/spec/ui-shell_spec.ts
+++ b/tests/spec/ui-shell_spec.ts
@@ -8,10 +8,10 @@
  */
 
 import { html, render } from 'lit-html';
-// Below path will be there when an application installs `carbon-custom-elements` package.
+// Below path will be there when an application installs `carbon-web-components` package.
 // In our dev env, we auto-generate the file and re-map below path to to point to the generated file.
 // @ts-ignore
-import Fade16 from 'carbon-custom-elements/es/icons/fade/16';
+import Fade16 from 'carbon-web-components/es/icons/fade/16';
 import EventManager from '../utils/event-manager';
 import ifNonNull from '../../src/globals/directives/if-non-null';
 /* eslint-disable import/no-duplicates */


### PR DESCRIPTION
Upon the community's consemsus, changes `carbon-custom-elements` package name to `carbon-web-components`, to resonate to the umbrella term and to the communities around Web Components technologies.